### PR TITLE
fix: escape dollar signs in docs to prevent LaTeX rendering

### DIFF
--- a/packages/docs/getting-started/introduction.mdx
+++ b/packages/docs/getting-started/introduction.mdx
@@ -37,7 +37,7 @@ We are the legal seller of record. We collect and remit VAT, GST, and sales tax 
   </Accordion>
 
   <Accordion title="You're Paying Too Much in Fees" icon="credit-card">
-    **The Problem**: Most MoR solutions charge 5-8% per transaction plus monthly platform fees. On a $49/mo SaaS, that's $2-4 per transaction gone.
+    **The Problem**: Most MoR solutions charge 5-8% per transaction plus monthly platform fees. On a \$49/mo SaaS, that's \$2-4 per transaction gone.
 
     **Creem's Solution**: 3.9% + 30¢ flat. No monthly fees. No minimums. No tiered pricing that punishes small volume. The most competitive MoR on the market.
   </Accordion>

--- a/packages/docs/integrations/evendeals.mdx
+++ b/packages/docs/integrations/evendeals.mdx
@@ -7,7 +7,7 @@ description: 'Add purchase parity pricing to your Creem products and boost inter
 
 [Evendeals](https://www.evendeals.com) is a purchase parity pricing platform that helps you adjust prices based on your customers' location. Combined with Creem's payment processing and tax compliance, you get a complete global sales stack.
 
-A single price doesn't work for a global audience. $49/mo might be reasonable in the US, but it could represent days of work in other countries. Parity pricing consistently drives **20-30% more international sales** by showing location-based discounts to visitors from lower-income regions.
+A single price doesn't work for a global audience. \$49/mo might be reasonable in the US, but it could represent days of work in other countries. Parity pricing consistently drives **20-30% more international sales** by showing location-based discounts to visitors from lower-income regions.
 
 <Accordion title="What you'll learn">
 


### PR DESCRIPTION
Escapes `$` signs in `getting-started/introduction.mdx` and `integrations/evendeals.mdx` to prevent LaTeX rendering on the docs site.