### PR TITLE
fix: correct pricing from 30¢ to 40¢ on introduction page

### DIFF
--- a/packages/docs/getting-started/introduction.mdx
+++ b/packages/docs/getting-started/introduction.mdx
@@ -4,7 +4,7 @@ description: 'The most competitive Merchant of Record for SaaS, digital products
 keywords: 'creem, merchant of record, saas payments, getting started, stripe alternative, paddle alternative, gumroad alternative'
 ---
 
-> 3,000+ teams sell globally with Creem. 3.9% + 30¢ flat. No monthly fees. No tax headaches.
+> 3,000+ teams sell globally with Creem. 3.9% + 40¢ flat. No monthly fees. No tax headaches.
 
 ## What is Creem?
 
@@ -14,7 +14,7 @@ We are the legal seller of record. We collect and remit VAT, GST, and sales tax 
 
 <CardGroup cols={2}>
   <Card title="Most Competitive MoR" icon="money-bill">
-    3.9% + 30¢ flat. No monthly fees, no setup costs, no hidden charges. You only pay when you earn.
+    3.9% + 40¢ flat. No monthly fees, no setup costs, no hidden charges. You only pay when you earn.
   </Card>
   <Card title="Global Tax Compliance" icon="globe">
     VAT, GST, and sales tax across 190+ countries. 28+ US states, EU (Estonia OSS), UK, South Korea, and growing.
@@ -39,7 +39,7 @@ We are the legal seller of record. We collect and remit VAT, GST, and sales tax 
   <Accordion title="You're Paying Too Much in Fees" icon="credit-card">
     **The Problem**: Most MoR solutions charge 5-8% per transaction plus monthly platform fees. On a \$49/mo SaaS, that's \$2-4 per transaction gone.
 
-    **Creem's Solution**: 3.9% + 30¢ flat. No monthly fees. No minimums. No tiered pricing that punishes small volume. The most competitive MoR on the market.
+    **Creem's Solution**: 3.9% + 40¢ flat. No monthly fees. No minimums. No tiered pricing that punishes small volume. The most competitive MoR on the market.
   </Accordion>
 
   <Accordion title="Your Payment Provider Wasn't Built for Developers" icon="terminal">
@@ -240,7 +240,7 @@ If you purchased a product through Creem's payment platform:
     Cards (Visa, Mastercard, Amex), PayPal, Apple Pay, Google Pay, and local payment methods based on customer location. WeChat Pay and Alipay support coming soon.
   </Accordion>
   <Accordion title="How does pricing work?">
-    3.9% + 30¢ per successful transaction. No monthly fees, no setup costs, no hidden charges. You only pay when you earn.
+    3.9% + 40¢ per successful transaction. No monthly fees, no setup costs, no hidden charges. You only pay when you earn.
   </Accordion>
   <Accordion title="What makes Creem different from Stripe?">
     Stripe is a payment processor. You're still responsible for tax compliance, filing, and remittance. Creem is a Merchant of Record. We are the legal seller, handling all of that for you. Plus affiliates, revenue splits, and license keys out of the box.


### PR DESCRIPTION
The introduction docs page showed **3.9% + 30¢** in 4 places, but the correct pricing is **3.9% + 40¢** (consistent with the payouts page which already had the correct amount).

**Changes:**
- Updated all 4 occurrences of 30¢ → 40¢ in packages/docs/getting-started/introduction.mdx

No other docs pages had the incorrect pricing.