### PR TITLE
chore: add in-game items to prohibited products list

### DIFF
--- a/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
+++ b/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
@@ -130,6 +130,7 @@ Every application is reviewed for deceptive content. The following will get your
   - Homework/Essay mills
   - Multi-level marketing, pyramid, or IBO schemes
   - NFT & Crypto assets products
+  - In-game items, currencies, and virtual goods tied to third-party games
   - Any other products that our providers and partners deem too risky
 </Accordion>
 


### PR DESCRIPTION
Adds "In-game items, currencies, and virtual goods tied to third-party games" to the prohibited products list in account reviews docs.