### PR TITLE
docs: update onboarding docs for invite-only model [ENG-58]

### DIFF
--- a/packages/docs/getting-started/introduction.mdx
+++ b/packages/docs/getting-started/introduction.mdx
@@ -238,7 +238,7 @@ If you purchased a product through Creem's payment platform:
 
 <AccordionGroup>
   <Accordion title="How fast can I start accepting payments?">
-    Once you have access, most developers go from zero to first payment in under 10 minutes. Set up a product, generate a checkout link. That's it. Creem is currently invite-only - get an invite code from an existing merchant or [join the waitlist](https://creem.io).
+    Once you have access, most developers go from zero to first payment in under 10 minutes. Set up a product, generate a checkout link. That's it.
   </Accordion>
   <Accordion title="What payment methods do you support?">
     Cards (Visa, Mastercard, Amex), PayPal, Apple Pay, Google Pay, and local payment methods based on customer location. WeChat Pay and Alipay support coming soon.

--- a/packages/docs/getting-started/introduction.mdx
+++ b/packages/docs/getting-started/introduction.mdx
@@ -113,8 +113,12 @@ Give this prompt to any AI coding assistant (Claude, Cursor, Copilot, Windsurf) 
 ## Quick Start
 
 <Steps>
-  <Step title="Create Your Account">
-    [Sign up at creem.io](https://creem.io) and create your store. No credit card required.
+  <Step title="Get Access">
+    Creem is currently **invite-only**. You can get access by:
+    - Getting an **invite code** from an existing Creem merchant
+    - Joining the [waitlist](https://creem.io) and optionally sharing details about your business to move up in the queue
+
+    Once you have an invite code, redeem it to create your store. No credit card required.
   </Step>
   <Step title="Get Your API Keys">
     Grab your test API key from the dashboard. Keys prefixed with `creem_test_` use the sandbox environment.
@@ -234,7 +238,7 @@ If you purchased a product through Creem's payment platform:
 
 <AccordionGroup>
   <Accordion title="How fast can I start accepting payments?">
-    Most developers go from zero to first payment in under 10 minutes. Create an account, set up a product, generate a checkout link. That's it.
+    Once you have access, most developers go from zero to first payment in under 10 minutes. Set up a product, generate a checkout link. That's it. Creem is currently invite-only - get an invite code from an existing merchant or [join the waitlist](https://creem.io).
   </Accordion>
   <Accordion title="What payment methods do you support?">
     Cards (Visa, Mastercard, Amex), PayPal, Apple Pay, Google Pay, and local payment methods based on customer location. WeChat Pay and Alipay support coming soon.

--- a/packages/docs/getting-started/quickstart.mdx
+++ b/packages/docs/getting-started/quickstart.mdx
@@ -20,9 +20,9 @@ Choose the path that works best for you:
 
 Integrate Creem directly into your application. It's as easy as the following:
 
-### 1. Get your API key
+### 1. Get access & your API key
 
-Navigate to the [Developers section](https://creem.io/dashboard/developers) in your dashboard and copy your API key.
+Creem is currently invite-only. Get an invite code from an existing merchant or [join the waitlist](https://creem.io). Once you're in, navigate to the [Developers section](https://creem.io/dashboard/developers) in your dashboard and copy your API key.
 
 <Tip>
   Use [Test Mode](/getting-started/test-mode) to develop without processing real

--- a/packages/docs/guides/faq.mdx
+++ b/packages/docs/guides/faq.mdx
@@ -21,10 +21,6 @@ description: 'Answers to the most common questions about using Creem.'
   </Accordion>
   <Accordion title="How long will the waitlist take?">
     We're rolling out access in batches and don't have a fixed timeline. The fastest way to get access is through an invite code from an existing merchant.
-  </Accordion>
-  <Accordion title="Is Creem permanently invite-only?">
-    No. The invite-only model is temporary while we ensure the highest quality for our merchant base. We plan to open up access more broadly in the future.
-  </Accordion>
   <Accordion title="How long does the account review take?">
     Account reviews are typically completed within **24-48 hours**. During peak periods, it may take up to 72 hours. You'll receive an email once the review is complete. If changes are requested, address them and reply — your account will be re-reviewed promptly.
   </Accordion>

--- a/packages/docs/guides/faq.mdx
+++ b/packages/docs/guides/faq.mdx
@@ -6,6 +6,25 @@ description: 'Answers to the most common questions about using Creem.'
 ## Account & Onboarding
 
 <AccordionGroup>
+  <Accordion title="How do I sign up for Creem?">
+    Creem is currently **invite-only**. There are two ways to get access:
+    1. **Invite code** - Get one from an existing Creem merchant. Merchants who qualify receive invite codes they can share.
+    2. **Waitlist** - [Join the waitlist](https://creem.io) and you'll be notified when access opens up. You can provide details about your business to move up in the queue.
+
+    Once you redeem an invite code, you can create your store and go through the standard account review process.
+  </Accordion>
+  <Accordion title="How do I get an invite code?">
+    Invite codes are distributed to existing Creem merchants. If you know someone already using Creem, ask them to share one of their invite codes. Each code is single-use. Merchants can find their available invite codes in the sidebar of their dashboard.
+  </Accordion>
+  <Accordion title="How does the waitlist work?">
+    When you join the waitlist, you're placed in a queue. You can move up by clicking **"Tell us about your business"** and sharing details about your product - this puts you ahead of others who haven't provided details. We'll email you when your spot opens up, or you can redeem an invite code at any time to skip the waitlist entirely.
+  </Accordion>
+  <Accordion title="How long will the waitlist take?">
+    We're rolling out access in batches and don't have a fixed timeline. The fastest way to get access is through an invite code from an existing merchant.
+  </Accordion>
+  <Accordion title="Is Creem permanently invite-only?">
+    No. The invite-only model is temporary while we ensure the highest quality for our merchant base. We plan to open up access more broadly in the future.
+  </Accordion>
   <Accordion title="How long does the account review take?">
     Account reviews are typically completed within **24-48 hours**. During peak periods, it may take up to 72 hours. You'll receive an email once the review is complete. If changes are requested, address them and reply — your account will be re-reviewed promptly.
   </Accordion>

--- a/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
+++ b/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
@@ -3,7 +3,7 @@ title: 'Account Reviews'
 description: 'Learn how account reviews work on Creem.'
 ---
 
-Before you can accept payments through Creem, your store needs to pass our account review. Here's everything you need to know to get approved on the first try.
+Creem is currently **invite-only**. To create a store, you need an invite code from an existing merchant or you can [join the waitlist](https://creem.io). Once you have access and create your store, it needs to pass our account review before you can accept payments. Here's everything you need to know to get approved on the first try.
 
 <Tip>
   Run through this checklist before submitting for review — it covers the most common reasons applications are sent back.

--- a/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
+++ b/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
@@ -3,7 +3,7 @@ title: 'Account Reviews'
 description: 'Learn how account reviews work on Creem.'
 ---
 
-Creem is currently **invite-only**. To create a store, you need an invite code from an existing merchant or you can [join the waitlist](https://creem.io). Once you have access and create your store, it needs to pass our account review before you can accept payments. Here's everything you need to know to get approved on the first try.
+Before you can accept payments through Creem, your store needs to pass our account review. Here's everything you need to know to get approved on the first try.
 
 <Tip>
   Run through this checklist before submitting for review — it covers the most common reasons applications are sent back.


### PR DESCRIPTION
Updates public docs for invite-only onboarding (ENG-58).

**Changes:**
- Introduction: Quick Start → 'Get Access' with invite code + waitlist info
- Quickstart: invite-only note before API key step
- Account Reviews: invite-only context in opening paragraph
- FAQ: 5 new entries (signup, invite codes, waitlist mechanics, timeline, permanence)

Framed as temporary. Two paths: invite codes from merchants, or waitlist with 'skip the line' option.