### PR TITLE
docs: add Customer Credits documentation

### DIFF
--- a/packages/docs/api-reference/endpoint/close-credits-account.mdx
+++ b/packages/docs/api-reference/endpoint/close-credits-account.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Close an account'
+description: 'Permanently close an account. This action cannot be undone. Balance and history remain readable.'
+openapi: post /v1/customer-credits/accounts/{id}/close
+---

--- a/packages/docs/api-reference/endpoint/create-credits-account.mdx
+++ b/packages/docs/api-reference/endpoint/create-credits-account.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Create a customer credits account'
+description: 'Create a new credits account for a customer. Optionally seed it with an initial balance.'
+openapi: post /v1/customer-credits/accounts
+---

--- a/packages/docs/api-reference/endpoint/credit-account.mdx
+++ b/packages/docs/api-reference/endpoint/credit-account.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Credit an account'
+description: 'Add credits to a customer account. Returns the resulting transaction record.'
+openapi: post /v1/customer-credits/accounts/{id}/credit
+---

--- a/packages/docs/api-reference/endpoint/debit-account.mdx
+++ b/packages/docs/api-reference/endpoint/debit-account.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Debit an account'
+description: 'Deduct credits from a customer account. Returns the resulting transaction record.'
+openapi: post /v1/customer-credits/accounts/{id}/debit
+---

--- a/packages/docs/api-reference/endpoint/freeze-credits-account.mdx
+++ b/packages/docs/api-reference/endpoint/freeze-credits-account.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Freeze an account'
+description: 'Freeze an account to prevent new transactions. The account remains readable.'
+openapi: post /v1/customer-credits/accounts/{id}/freeze
+---

--- a/packages/docs/api-reference/endpoint/get-credits-account-balance.mdx
+++ b/packages/docs/api-reference/endpoint/get-credits-account-balance.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Get account balance'
+description: 'Get the current balance of an account. Optionally pass ?at= for historical balance.'
+openapi: get /v1/customer-credits/accounts/{id}/balance
+---

--- a/packages/docs/api-reference/endpoint/get-credits-account.mdx
+++ b/packages/docs/api-reference/endpoint/get-credits-account.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Retrieve a customer credits account'
+description: 'Get details of a customer credits account by ID.'
+openapi: get /v1/customer-credits/accounts/{id}
+---

--- a/packages/docs/api-reference/endpoint/list-credits-accounts.mdx
+++ b/packages/docs/api-reference/endpoint/list-credits-accounts.mdx
@@ -1,0 +1,5 @@
+---
+title: 'List customer credits accounts'
+description: 'List accounts for the authenticated store with cursor pagination. System accounts are excluded.'
+openapi: get /v1/customer-credits/accounts
+---

--- a/packages/docs/api-reference/endpoint/list-credits-entries.mdx
+++ b/packages/docs/api-reference/endpoint/list-credits-entries.mdx
@@ -1,0 +1,5 @@
+---
+title: 'List account entries'
+description: 'List the credit and debit history for an account with cursor pagination.'
+openapi: get /v1/customer-credits/accounts/{id}/entries
+---

--- a/packages/docs/api-reference/endpoint/reverse-credits-transaction.mdx
+++ b/packages/docs/api-reference/endpoint/reverse-credits-transaction.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Reverse a transaction'
+description: 'Reverse a previous credit or debit on this account. Creates a new transaction that undoes the original, preserving the full history.'
+openapi: post /v1/customer-credits/accounts/{id}/reverse
+---

--- a/packages/docs/api-reference/endpoint/unfreeze-credits-account.mdx
+++ b/packages/docs/api-reference/endpoint/unfreeze-credits-account.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Unfreeze an account'
+description: 'Unfreeze a frozen account to allow transactions again.'
+openapi: post /v1/customer-credits/accounts/{id}/unfreeze
+---

--- a/packages/docs/api-reference/openapi.json
+++ b/packages/docs/api-reference/openapi.json
@@ -3342,11 +3342,6 @@
             "description": "Account name",
             "example": "default"
           },
-          "type": {
-            "type": "string",
-            "description": "Account type",
-            "enum": ["asset", "liability", "revenue", "expense", "equity"]
-          },
           "unit_label": {
             "type": "string",
             "description": "Unit label",
@@ -3371,7 +3366,6 @@
           "store_id",
           "customer_id",
           "name",
-          "type",
           "unit_label",
           "status",
           "created_at",

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -98,6 +98,14 @@
               "features/product-bundles",
               "features/moderation",
               {
+                "group": "Customer Credits",
+                "pages": [
+                  "features/customer-credits/introduction",
+                  "features/customer-credits/accounts",
+                  "features/customer-credits/transactions"
+                ]
+              },
+              {
                 "group": "Addons",
                 "pages": [
                   "features/addons/licenses",
@@ -187,6 +195,7 @@
               "guides/introduction",
               "guides/create-your-first-product",
               "guides/create-checkout-session",
+              "guides/customer-credits-recipes",
               "guides/faq"
             ]
           }

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -283,6 +283,23 @@
             ]
           },
           {
+            "group": "Customer Credits",
+            "icon": "coins",
+            "pages": [
+              "api-reference/endpoint/create-credits-account",
+              "api-reference/endpoint/list-credits-accounts",
+              "api-reference/endpoint/get-credits-account",
+              "api-reference/endpoint/get-credits-account-balance",
+              "api-reference/endpoint/list-credits-entries",
+              "api-reference/endpoint/credit-account",
+              "api-reference/endpoint/debit-account",
+              "api-reference/endpoint/reverse-credits-transaction",
+              "api-reference/endpoint/freeze-credits-account",
+              "api-reference/endpoint/unfreeze-credits-account",
+              "api-reference/endpoint/close-credits-account"
+            ]
+          },
+          {
             "group": "Moderation",
             "icon": "shield-check",
             "pages": [

--- a/packages/docs/features/customer-credits/accounts.mdx
+++ b/packages/docs/features/customer-credits/accounts.mdx
@@ -36,6 +36,7 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts \
   "created_at": "2026-04-14T12:00:00.000Z",
   "updated_at": "2026-04-14T12:00:00.000Z"
 }
+```
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |

--- a/packages/docs/features/customer-credits/accounts.mdx
+++ b/packages/docs/features/customer-credits/accounts.mdx
@@ -31,17 +31,11 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts \
   "store_id": "store_xxx",
   "customer_id": "cust_abc123",
   "name": "loyalty_points",
-  "type": "liability",
   "unit_label": "points",
   "status": "active",
   "created_at": "2026-04-14T12:00:00.000Z",
   "updated_at": "2026-04-14T12:00:00.000Z"
 }
-```
-
-<Info>
-  The `type` field is managed by Creem — you don't need to set or think about it.
-</Info>
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
@@ -75,7 +69,6 @@ curl "https://api.creem.io/v1/customer-credits/accounts?customer_id=cust_abc123"
       "store_id": "store_xxx",
       "customer_id": "cust_abc123",
       "name": "loyalty_points",
-      "type": "liability",
       "unit_label": "points",
       "status": "active",
       "created_at": "2026-04-14T12:00:00.000Z",

--- a/packages/docs/features/customer-credits/accounts.mdx
+++ b/packages/docs/features/customer-credits/accounts.mdx
@@ -3,9 +3,7 @@ title: 'Accounts'
 description: 'Create and manage credit accounts for your customers.'
 ---
 
-<Note>
-  Customer Credits is in **Experimental** preview.
-</Note>
+<Note>Customer Credits is in **Experimental** preview.</Note>
 
 ## What is an account?
 
@@ -56,15 +54,16 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts \
 
 ### Options
 
-| Parameter | Type | Required | Description |
-| --- | --- | --- | --- |
-| `customer_id` | string | ✅ | The customer this account belongs to |
-| `name` | string | | A label for this account. Default: `"default"`. Unique per customer |
-| `unit_label` | string | | What to call the units — "points", "gems", "credits". Default: `"credits"` |
-| `initial_balance` | string | | Seed the account with credits on creation |
+| Parameter         | Type   | Required | Description                                                                |
+| ----------------- | ------ | -------- | -------------------------------------------------------------------------- |
+| `customer_id`     | string | ✅       | The customer this account belongs to                                       |
+| `name`            | string |          | A label for this account. Default: `"default"`. Unique per customer        |
+| `unit_label`      | string |          | What to call the units — "points", "gems", "credits". Default: `"credits"` |
+| `initial_balance` | string |          | Seed the account with credits on creation                                  |
 
 <Info>
-  If you set `initial_balance` and the initial credit fails, the account isn't created either. No orphaned accounts.
+  If you set `initial_balance` and the initial credit fails, the account isn't
+  created either. No orphaned accounts.
 </Info>
 
 ---
@@ -170,27 +169,43 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/clos
   Closing is permanent. If you might need the account later, freeze it instead.
 </Warning>
 
-| Status | Can credit/debit? | Can read? | Use case |
-| --- | --- | --- | --- |
-| `active` | ✅ | ✅ | Normal operation |
-| `frozen` | ❌ | ✅ | Fraud review, disputes |
-| `closed` | ❌ | ✅ | Customer churned, account retired |
+| Status   | Can credit/debit? | Can read? | Use case                          |
+| -------- | ----------------- | --------- | --------------------------------- |
+| `active` | ✅                | ✅        | Normal operation                  |
+| `frozen` | ❌                | ✅        | Fraud review, disputes            |
+| `closed` | ❌                | ✅        | Customer churned, account retired |
 
 ---
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Transactions" icon="arrow-right-arrow-left" href="/features/customer-credits/transactions">
+  <Card
+    title="Transactions"
+    icon="arrow-right-arrow-left"
+    href="/features/customer-credits/transactions"
+  >
     Credit, debit, reverse, and view history.
   </Card>
-  <Card title="Recipes" icon="book-open" href="/guides/customer-credits-recipes">
+  <Card
+    title="Recipes"
+    icon="book-open"
+    href="/guides/customer-credits-recipes"
+  >
     Step-by-step guides for common patterns.
   </Card>
-  <Card title="API Reference" icon="code" href="/api-reference/endpoint/create-credits-account">
+  <Card
+    title="API Reference"
+    icon="code"
+    href="/api-reference/endpoint/create-credits-account"
+  >
     Full endpoint schemas.
   </Card>
-  <Card title="Introduction" icon="house" href="/features/customer-credits/introduction">
+  <Card
+    title="Introduction"
+    icon="house"
+    href="/features/customer-credits/introduction"
+  >
     Back to overview.
   </Card>
 </CardGroup>

--- a/packages/docs/features/customer-credits/accounts.mdx
+++ b/packages/docs/features/customer-credits/accounts.mdx
@@ -41,6 +41,10 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts \
 }
 ```
 
+<Info>
+  The `type` field defaults to `"liability"` and is managed by Creem — you don't need to set or worry about it. It's included in the response for completeness.
+</Info>
+
 ### Parameters
 
 | Parameter | Type | Required | Description |
@@ -88,6 +92,16 @@ curl "https://api.creem.io/v1/customer-credits/accounts?customer_id=cust_abc123"
   ],
   "has_more": false
 }
+```
+
+## Get an Account
+
+Retrieve a single account by ID.
+
+```bash
+curl https://api.creem.io/v1/customer-credits/accounts/{account_id} \
+  -H "x-api-key: YOUR_API_KEY"
+```
 ```
 
 ### Query Parameters

--- a/packages/docs/features/customer-credits/accounts.mdx
+++ b/packages/docs/features/customer-credits/accounts.mdx
@@ -1,0 +1,210 @@
+---
+title: 'Accounts'
+description: 'Create and manage credit accounts for your customers. Each account tracks a named balance with full history.'
+---
+
+<Note>
+  Customer Credits is currently in **Experimental** preview. All responses include the `X-API-Stability: experimental` header.
+</Note>
+
+## Overview
+
+A credit account holds a balance for one of your customers. Most customers will have a single `"default"` account, but you can create multiple accounts per customer for different balance types (e.g., `"loyalty_points"`, `"referral_credits"`, `"promo_balance"`).
+
+## Create an Account
+
+<Tabs>
+  <Tab title="TypeScript SDK">
+
+```typescript
+const account = await creem.customerCredits.accounts.create({
+  owner_id: 'cust_abc123',
+  name: 'loyalty_points',
+  unit_label: 'points',
+  initial_credit_amount: 100,    // optional: seed the account
+  initial_credit_reference: 'signup_bonus',
+});
+```
+
+  </Tab>
+
+  <Tab title="REST API">
+
+```bash
+curl -X POST https://api.creem.io/v1/customer-credits/accounts \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Idempotency-Key: create_acct_cust_abc123_loyalty" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "owner_id": "cust_abc123",
+    "name": "loyalty_points",
+    "unit_label": "points",
+    "initial_credit_amount": 100,
+    "initial_credit_reference": "signup_bonus"
+  }'
+```
+
+  </Tab>
+</Tabs>
+
+### Response
+
+```json
+{
+  "id": "cca_7kXmR2pQ9vN",
+  "owner_id": "cust_abc123",
+  "name": "loyalty_points",
+  "unit_label": "points",
+  "status": "active",
+  "balance": 100,
+  "created_at": "2026-04-14T12:00:00Z",
+  "updated_at": "2026-04-14T12:00:00Z"
+}
+```
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `owner_id` | string | ✅ | Creem `customer_id` or your `external_customer_id` |
+| `name` | string | | Account name. Default: `"default"`. Must be unique per customer within your store. |
+| `unit_label` | string | | Display label for the unit. Default: `"credits"`. Purely cosmetic. |
+| `initial_credit_amount` | integer | | Seed the account with this many units on creation. |
+| `initial_credit_reference` | string | Conditional | Required if `initial_credit_amount` is set. Reference for the seed transaction. |
+| `metadata` | object | | Arbitrary key-value pairs for your own tracking. |
+
+<Info>
+  Account creation is atomic: if `initial_credit_amount` is provided and the initial credit fails, the account is not created. You won't end up with orphaned zero-balance accounts.
+</Info>
+
+## List Accounts
+
+Retrieve all credit accounts in your store, with optional filtering by owner.
+
+<Tabs>
+  <Tab title="TypeScript SDK">
+
+```typescript
+// All accounts
+const accounts = await creem.customerCredits.accounts.list();
+
+// Filter by customer
+const customerAccounts = await creem.customerCredits.accounts.list({
+  owner_id: 'cust_abc123',
+});
+
+// Paginate
+const page2 = await creem.customerCredits.accounts.list({
+  starting_after: 'cca_7kXmR2pQ9vN',
+  limit: 25,
+});
+```
+
+  </Tab>
+
+  <Tab title="REST API">
+
+```bash
+# All accounts
+curl https://api.creem.io/v1/customer-credits/accounts \
+  -H "x-api-key: YOUR_API_KEY"
+
+# Filter by owner
+curl "https://api.creem.io/v1/customer-credits/accounts?owner_id=cust_abc123" \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+  </Tab>
+</Tabs>
+
+### Response
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "cca_7kXmR2pQ9vN",
+      "owner_id": "cust_abc123",
+      "name": "loyalty_points",
+      "unit_label": "points",
+      "status": "active",
+      "balance": 300,
+      "created_at": "2026-04-14T12:00:00Z",
+      "updated_at": "2026-04-14T14:30:00Z"
+    }
+  ],
+  "has_more": false
+}
+```
+
+### Query Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `owner_id` | string | Filter to accounts owned by this customer |
+| `limit` | integer | Number of results (1–100, default 20) |
+| `starting_after` | string | Cursor: return results after this account ID |
+| `ending_before` | string | Cursor: return results before this account ID |
+
+## Get Account Balance
+
+Returns the current balance for an account. This is an instant lookup — no scanning required.
+
+```bash
+curl https://api.creem.io/v1/customer-credits/accounts/{account_id}/balance \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+```json
+{
+  "account_id": "cca_7kXmR2pQ9vN",
+  "total_debits": 200,
+  "total_credits": 500,
+  "balance": 300
+}
+```
+
+## Freeze an Account
+
+Freezing prevents any new transactions from being posted to the account. The account remains readable — balances and history are still accessible. Useful for fraud investigations or dispute holds.
+
+```bash
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/freeze \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+## Unfreeze an Account
+
+Restores a frozen account to `active` status.
+
+```bash
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/unfreeze \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+## Close an Account
+
+Closing an account is permanent. The account cannot be reopened, but all data (balance, entries, transactions) remains readable for audit purposes.
+
+```bash
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/close \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+<Warning>
+  Closing an account is irreversible. Consider freezing first if you may need to reactivate it.
+</Warning>
+
+## Delete an Account
+
+Empty accounts (zero entries) can be deleted to clean up test data or abandoned accounts.
+
+```bash
+curl -X DELETE https://api.creem.io/v1/customer-credits/accounts/{account_id} \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+<Warning>
+  Deletion only succeeds if the account has zero entries. Accounts with any transaction history cannot be deleted — use **close** instead.
+</Warning>

--- a/packages/docs/features/customer-credits/accounts.mdx
+++ b/packages/docs/features/customer-credits/accounts.mdx
@@ -142,7 +142,7 @@ stateDiagram-v2
 
 ### Freeze — pause an account
 
-Temporarily block all credits and debits. Useful for fraud review or disputes. The account stays readable.
+Temporarily block all credits and debits. The account stays readable.
 
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/freeze \
@@ -169,11 +169,11 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/clos
   Closing is permanent. If you might need the account later, freeze it instead.
 </Warning>
 
-| Status   | Can credit/debit? | Can read? | Use case                          |
-| -------- | ----------------- | --------- | --------------------------------- |
-| `active` | ✅                | ✅        | Normal operation                  |
-| `frozen` | ❌                | ✅        | Fraud review, disputes            |
-| `closed` | ❌                | ✅        | Customer churned, account retired |
+| Status | Can credit/debit? | Can read? | Use case |
+| --- | --- | --- | --- |
+| `active` | ✅ | ✅ | Default |
+| `frozen` | ❌ | ✅ | Temporarily paused |
+| `closed` | ❌ | ✅ | Permanent |
 
 ---
 

--- a/packages/docs/features/customer-credits/accounts.mdx
+++ b/packages/docs/features/customer-credits/accounts.mdx
@@ -7,11 +7,27 @@ description: 'Create and manage credit accounts for your customers.'
   Customer Credits is in **Experimental** preview.
 </Note>
 
-## Overview
+## What is an account?
 
-An account holds a credit balance for one customer. Most customers need just one account, but you can create multiple per customer for different purposes (e.g., `"loyalty_points"` and `"referral_credits"`).
+An account holds a credit balance for one customer. Think of it as a digital wallet — you create it, add credits to it, and debit from it when the customer uses them.
 
-## Create an account
+Most customers need just one account. But you can create multiple per customer for different purposes:
+
+<CardGroup cols={3}>
+  <Card title="loyalty_points" icon="star">
+    Earned from purchases
+  </Card>
+  <Card title="referral_credits" icon="user-plus">
+    Earned from inviting friends
+  </Card>
+  <Card title="promo_credits" icon="gift">
+    Given during campaigns
+  </Card>
+</CardGroup>
+
+## Creating accounts
+
+Pass a `customer_id` and you're done. Everything else is optional.
 
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts \
@@ -38,65 +54,24 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts \
 }
 ```
 
+### Options
+
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `customer_id` | string | ✅ | The customer this account belongs to |
-| `name` | string | | Account name. Default: `"default"`. Unique per customer in your store |
-| `unit_label` | string | | What to call the units. Default: `"credits"` |
-| `initial_balance` | string | | Start the account with this many credits |
+| `name` | string | | A label for this account. Default: `"default"`. Unique per customer |
+| `unit_label` | string | | What to call the units — "points", "gems", "credits". Default: `"credits"` |
+| `initial_balance` | string | | Seed the account with credits on creation |
 
 <Info>
   If you set `initial_balance` and the initial credit fails, the account isn't created either. No orphaned accounts.
 </Info>
 
-## List accounts
+---
 
-```bash
-# All accounts
-curl https://api.creem.io/v1/customer-credits/accounts \
-  -H "x-api-key: YOUR_API_KEY"
+## Checking balance
 
-# For a specific customer
-curl "https://api.creem.io/v1/customer-credits/accounts?customer_id=cust_abc123" \
-  -H "x-api-key: YOUR_API_KEY"
-```
-
-```json
-{
-  "object": "list",
-  "data": [
-    {
-      "id": "cca_7kXmR2pQ9vN",
-      "store_id": "store_xxx",
-      "customer_id": "cust_abc123",
-      "name": "loyalty_points",
-      "unit_label": "points",
-      "status": "active",
-      "created_at": "2026-04-14T12:00:00.000Z",
-      "updated_at": "2026-04-14T14:30:00.000Z"
-    }
-  ],
-  "has_more": false
-}
-```
-
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `customer_id` | string | Filter by customer |
-| `limit` | integer | Results per page (1–100, default 10) |
-| `starting_after` | string | Cursor for forward pagination |
-| `ending_before` | string | Cursor for backward pagination |
-
-## Get an account
-
-```bash
-curl https://api.creem.io/v1/customer-credits/accounts/{account_id} \
-  -H "x-api-key: YOUR_API_KEY"
-```
-
-## Check balance
-
-Returns the current balance instantly.
+One call to see what's available.
 
 ```bash
 curl https://api.creem.io/v1/customer-credits/accounts/{account_id}/balance \
@@ -110,7 +85,9 @@ curl https://api.creem.io/v1/customer-credits/accounts/{account_id}/balance \
 }
 ```
 
-You can also check what the balance was at a specific point in time:
+### Point-in-time balance
+
+Need to know what the balance was last Tuesday? Pass an `at` parameter.
 
 ```bash
 curl "https://api.creem.io/v1/customer-credits/accounts/{account_id}/balance?at=2026-04-01T00:00:00.000Z" \
@@ -124,25 +101,65 @@ curl "https://api.creem.io/v1/customer-credits/accounts/{account_id}/balance?at=
 }
 ```
 
-## Freeze an account
+---
 
-Temporarily block new transactions. The account stays readable.
+## Listing accounts
+
+```bash
+# All accounts in your store
+curl https://api.creem.io/v1/customer-credits/accounts \
+  -H "x-api-key: YOUR_API_KEY"
+
+# For a specific customer
+curl "https://api.creem.io/v1/customer-credits/accounts?customer_id=cust_abc123" \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+Supports cursor-based pagination with `limit`, `starting_after`, and `ending_before`.
+
+---
+
+## Getting a single account
+
+```bash
+curl https://api.creem.io/v1/customer-credits/accounts/{account_id} \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+---
+
+## Account lifecycle
+
+Accounts have three states. You can move between them as needed.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Active
+    Active --> Frozen: Freeze
+    Frozen --> Active: Unfreeze
+    Active --> Closed: Close
+    Frozen --> Closed: Close
+```
+
+### Freeze — pause an account
+
+Temporarily block all credits and debits. Useful for fraud review or disputes. The account stays readable.
 
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/freeze \
   -H "x-api-key: YOUR_API_KEY"
 ```
 
-## Unfreeze an account
+### Unfreeze — resume an account
 
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/unfreeze \
   -H "x-api-key: YOUR_API_KEY"
 ```
 
-## Close an account
+### Close — permanently retire an account
 
-Permanently close an account. Balance and history stay readable, but no new transactions are allowed.
+Balance and history stay readable forever, but no new transactions are allowed.
 
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/close \
@@ -150,5 +167,30 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/clos
 ```
 
 <Warning>
-  This can't be undone. If you might need the account later, freeze it instead.
+  Closing is permanent. If you might need the account later, freeze it instead.
 </Warning>
+
+| Status | Can credit/debit? | Can read? | Use case |
+| --- | --- | --- | --- |
+| `active` | ✅ | ✅ | Normal operation |
+| `frozen` | ❌ | ✅ | Fraud review, disputes |
+| `closed` | ❌ | ✅ | Customer churned, account retired |
+
+---
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Transactions" icon="arrow-right-arrow-left" href="/features/customer-credits/transactions">
+    Credit, debit, reverse, and view history.
+  </Card>
+  <Card title="Recipes" icon="book-open" href="/guides/customer-credits-recipes">
+    Step-by-step guides for common patterns.
+  </Card>
+  <Card title="API Reference" icon="code" href="/api-reference/endpoint/create-credits-account">
+    Full endpoint schemas.
+  </Card>
+  <Card title="Introduction" icon="house" href="/features/customer-credits/introduction">
+    Back to overview.
+  </Card>
+</CardGroup>

--- a/packages/docs/features/customer-credits/accounts.mdx
+++ b/packages/docs/features/customer-credits/accounts.mdx
@@ -1,17 +1,17 @@
 ---
 title: 'Accounts'
-description: 'Create and manage credit accounts for your customers. Each account tracks a named balance with full history.'
+description: 'Create and manage credit accounts for your customers.'
 ---
 
 <Note>
-  Customer Credits is currently in **Experimental** preview. All responses include the `X-API-Stability: experimental` header.
+  Customer Credits is in **Experimental** preview.
 </Note>
 
 ## Overview
 
-A credit account holds a balance for one of your customers. Most customers will have a single `"default"` account, but you can create multiple accounts per customer for different balance types (e.g., `"loyalty_points"`, `"referral_credits"`, `"promo_balance"`).
+An account holds a credit balance for one customer. Most customers need just one account, but you can create multiple per customer for different purposes (e.g., `"loyalty_points"` and `"referral_credits"`).
 
-## Create an Account
+## Create an account
 
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts \
@@ -24,8 +24,6 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts \
     "initial_balance": "100"
   }'
 ```
-
-### Response
 
 ```json
 {
@@ -42,37 +40,31 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts \
 ```
 
 <Info>
-  The `type` field defaults to `"liability"` and is managed by Creem — you don't need to set or worry about it. It's included in the response for completeness.
+  The `type` field is managed by Creem — you don't need to set or think about it.
 </Info>
-
-### Parameters
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `customer_id` | string | ✅ | The customer this account belongs to |
-| `name` | string | | Account name. Default: `"default"`. Must be unique per customer within your store. |
-| `unit_label` | string | | Display label for the unit. Default: `"credits"`. Purely cosmetic. |
-| `initial_balance` | string | | Seed the account with this many credits on creation (as a string for large number support). |
+| `name` | string | | Account name. Default: `"default"`. Unique per customer in your store |
+| `unit_label` | string | | What to call the units. Default: `"credits"` |
+| `initial_balance` | string | | Start the account with this many credits |
 
 <Info>
-  Account creation is atomic: if `initial_balance` is provided and the initial credit fails, the account is not created. You won't end up with orphaned zero-balance accounts.
+  If you set `initial_balance` and the initial credit fails, the account isn't created either. No orphaned accounts.
 </Info>
 
-## List Accounts
-
-Retrieve all credit accounts in your store, with optional filtering by customer.
+## List accounts
 
 ```bash
 # All accounts
 curl https://api.creem.io/v1/customer-credits/accounts \
   -H "x-api-key: YOUR_API_KEY"
 
-# Filter by customer
+# For a specific customer
 curl "https://api.creem.io/v1/customer-credits/accounts?customer_id=cust_abc123" \
   -H "x-api-key: YOUR_API_KEY"
 ```
-
-### Response
 
 ```json
 {
@@ -94,28 +86,23 @@ curl "https://api.creem.io/v1/customer-credits/accounts?customer_id=cust_abc123"
 }
 ```
 
-## Get an Account
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `customer_id` | string | Filter by customer |
+| `limit` | integer | Results per page (1–100, default 10) |
+| `starting_after` | string | Cursor for forward pagination |
+| `ending_before` | string | Cursor for backward pagination |
 
-Retrieve a single account by ID.
+## Get an account
 
 ```bash
 curl https://api.creem.io/v1/customer-credits/accounts/{account_id} \
   -H "x-api-key: YOUR_API_KEY"
 ```
-```
 
-### Query Parameters
+## Check balance
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `customer_id` | string | Filter to accounts owned by this customer |
-| `limit` | integer | Number of results (1–100, default 10) |
-| `starting_after` | string | Cursor: return results after this account ID |
-| `ending_before` | string | Cursor: return results before this account ID |
-
-## Get Account Balance
-
-Returns the current balance for an account. Optionally pass `?at=` for a historical balance at a specific point in time.
+Returns the current balance instantly.
 
 ```bash
 curl https://api.creem.io/v1/customer-credits/accounts/{account_id}/balance \
@@ -129,7 +116,7 @@ curl https://api.creem.io/v1/customer-credits/accounts/{account_id}/balance \
 }
 ```
 
-### Historical Balance
+You can also check what the balance was at a specific point in time:
 
 ```bash
 curl "https://api.creem.io/v1/customer-credits/accounts/{account_id}/balance?at=2026-04-01T00:00:00.000Z" \
@@ -143,27 +130,25 @@ curl "https://api.creem.io/v1/customer-credits/accounts/{account_id}/balance?at=
 }
 ```
 
-## Freeze an Account
+## Freeze an account
 
-Freezing prevents any new transactions from being posted to the account. The account remains readable — balances and history are still accessible. Useful for fraud investigations or dispute holds.
+Temporarily block new transactions. The account stays readable.
 
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/freeze \
   -H "x-api-key: YOUR_API_KEY"
 ```
 
-## Unfreeze an Account
-
-Restores a frozen account to `active` status.
+## Unfreeze an account
 
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/unfreeze \
   -H "x-api-key: YOUR_API_KEY"
 ```
 
-## Close an Account
+## Close an account
 
-Closing an account is permanent. The account cannot be reopened, but all data (balance, entries, transactions) remains readable for audit purposes.
+Permanently close an account. Balance and history stay readable, but no new transactions are allowed.
 
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/close \
@@ -171,5 +156,5 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/clos
 ```
 
 <Warning>
-  Closing an account is irreversible. Consider freezing first if you may need to reactivate it.
+  This can't be undone. If you might need the account later, freeze it instead.
 </Warning>

--- a/packages/docs/features/customer-credits/accounts.mdx
+++ b/packages/docs/features/customer-credits/accounts.mdx
@@ -13,52 +13,31 @@ A credit account holds a balance for one of your customers. Most customers will 
 
 ## Create an Account
 
-<Tabs>
-  <Tab title="TypeScript SDK">
-
-```typescript
-const account = await creem.customerCredits.accounts.create({
-  owner_id: 'cust_abc123',
-  name: 'loyalty_points',
-  unit_label: 'points',
-  initial_credit_amount: 100,    // optional: seed the account
-  initial_credit_reference: 'signup_bonus',
-});
-```
-
-  </Tab>
-
-  <Tab title="REST API">
-
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts \
   -H "x-api-key: YOUR_API_KEY" \
-  -H "Idempotency-Key: create_acct_cust_abc123_loyalty" \
   -H "Content-Type: application/json" \
   -d '{
-    "owner_id": "cust_abc123",
+    "customer_id": "cust_abc123",
     "name": "loyalty_points",
     "unit_label": "points",
-    "initial_credit_amount": 100,
-    "initial_credit_reference": "signup_bonus"
+    "initial_balance": "100"
   }'
 ```
-
-  </Tab>
-</Tabs>
 
 ### Response
 
 ```json
 {
   "id": "cca_7kXmR2pQ9vN",
-  "owner_id": "cust_abc123",
+  "store_id": "store_xxx",
+  "customer_id": "cust_abc123",
   "name": "loyalty_points",
+  "type": "liability",
   "unit_label": "points",
   "status": "active",
-  "balance": 100,
-  "created_at": "2026-04-14T12:00:00Z",
-  "updated_at": "2026-04-14T12:00:00Z"
+  "created_at": "2026-04-14T12:00:00.000Z",
+  "updated_at": "2026-04-14T12:00:00.000Z"
 }
 ```
 
@@ -66,56 +45,28 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts \
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `owner_id` | string | ✅ | Creem `customer_id` or your `external_customer_id` |
+| `customer_id` | string | ✅ | The customer this account belongs to |
 | `name` | string | | Account name. Default: `"default"`. Must be unique per customer within your store. |
 | `unit_label` | string | | Display label for the unit. Default: `"credits"`. Purely cosmetic. |
-| `initial_credit_amount` | integer | | Seed the account with this many units on creation. |
-| `initial_credit_reference` | string | Conditional | Required if `initial_credit_amount` is set. Reference for the seed transaction. |
-| `metadata` | object | | Arbitrary key-value pairs for your own tracking. |
+| `initial_balance` | string | | Seed the account with this many credits on creation (as a string for large number support). |
 
 <Info>
-  Account creation is atomic: if `initial_credit_amount` is provided and the initial credit fails, the account is not created. You won't end up with orphaned zero-balance accounts.
+  Account creation is atomic: if `initial_balance` is provided and the initial credit fails, the account is not created. You won't end up with orphaned zero-balance accounts.
 </Info>
 
 ## List Accounts
 
-Retrieve all credit accounts in your store, with optional filtering by owner.
-
-<Tabs>
-  <Tab title="TypeScript SDK">
-
-```typescript
-// All accounts
-const accounts = await creem.customerCredits.accounts.list();
-
-// Filter by customer
-const customerAccounts = await creem.customerCredits.accounts.list({
-  owner_id: 'cust_abc123',
-});
-
-// Paginate
-const page2 = await creem.customerCredits.accounts.list({
-  starting_after: 'cca_7kXmR2pQ9vN',
-  limit: 25,
-});
-```
-
-  </Tab>
-
-  <Tab title="REST API">
+Retrieve all credit accounts in your store, with optional filtering by customer.
 
 ```bash
 # All accounts
 curl https://api.creem.io/v1/customer-credits/accounts \
   -H "x-api-key: YOUR_API_KEY"
 
-# Filter by owner
-curl "https://api.creem.io/v1/customer-credits/accounts?owner_id=cust_abc123" \
+# Filter by customer
+curl "https://api.creem.io/v1/customer-credits/accounts?customer_id=cust_abc123" \
   -H "x-api-key: YOUR_API_KEY"
 ```
-
-  </Tab>
-</Tabs>
 
 ### Response
 
@@ -125,13 +76,14 @@ curl "https://api.creem.io/v1/customer-credits/accounts?owner_id=cust_abc123" \
   "data": [
     {
       "id": "cca_7kXmR2pQ9vN",
-      "owner_id": "cust_abc123",
+      "store_id": "store_xxx",
+      "customer_id": "cust_abc123",
       "name": "loyalty_points",
+      "type": "liability",
       "unit_label": "points",
       "status": "active",
-      "balance": 300,
-      "created_at": "2026-04-14T12:00:00Z",
-      "updated_at": "2026-04-14T14:30:00Z"
+      "created_at": "2026-04-14T12:00:00.000Z",
+      "updated_at": "2026-04-14T14:30:00.000Z"
     }
   ],
   "has_more": false
@@ -142,14 +94,14 @@ curl "https://api.creem.io/v1/customer-credits/accounts?owner_id=cust_abc123" \
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `owner_id` | string | Filter to accounts owned by this customer |
-| `limit` | integer | Number of results (1–100, default 20) |
+| `customer_id` | string | Filter to accounts owned by this customer |
+| `limit` | integer | Number of results (1–100, default 10) |
 | `starting_after` | string | Cursor: return results after this account ID |
 | `ending_before` | string | Cursor: return results before this account ID |
 
 ## Get Account Balance
 
-Returns the current balance for an account. This is an instant lookup — no scanning required.
+Returns the current balance for an account. Optionally pass `?at=` for a historical balance at a specific point in time.
 
 ```bash
 curl https://api.creem.io/v1/customer-credits/accounts/{account_id}/balance \
@@ -158,10 +110,22 @@ curl https://api.creem.io/v1/customer-credits/accounts/{account_id}/balance \
 
 ```json
 {
-  "account_id": "cca_7kXmR2pQ9vN",
-  "total_debits": 200,
-  "total_credits": 500,
-  "balance": 300
+  "balance": "5000",
+  "updated_at": "2026-04-14T14:30:00.000Z"
+}
+```
+
+### Historical Balance
+
+```bash
+curl "https://api.creem.io/v1/customer-credits/accounts/{account_id}/balance?at=2026-04-01T00:00:00.000Z" \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+```json
+{
+  "balance": "3000",
+  "as_of": "2026-04-01T00:00:00.000Z"
 }
 ```
 
@@ -194,17 +158,4 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/clos
 
 <Warning>
   Closing an account is irreversible. Consider freezing first if you may need to reactivate it.
-</Warning>
-
-## Delete an Account
-
-Empty accounts (zero entries) can be deleted to clean up test data or abandoned accounts.
-
-```bash
-curl -X DELETE https://api.creem.io/v1/customer-credits/accounts/{account_id} \
-  -H "x-api-key: YOUR_API_KEY"
-```
-
-<Warning>
-  Deletion only succeeds if the account has zero entries. Accounts with any transaction history cannot be deleted — use **close** instead.
 </Warning>

--- a/packages/docs/features/customer-credits/introduction.mdx
+++ b/packages/docs/features/customer-credits/introduction.mdx
@@ -213,4 +213,7 @@ Accounts have three states:
   <Card title="Recipes" icon="book-open" href="/guides/customer-credits-recipes">
     Step-by-step guides for loyalty programs, prepaid wallets, referral credits, and more.
   </Card>
+  <Card title="API Reference" icon="code" href="/api-reference/endpoint/create-credits-account">
+    Full endpoint documentation with request/response schemas.
+  </Card>
 </CardGroup>

--- a/packages/docs/features/customer-credits/introduction.mdx
+++ b/packages/docs/features/customer-credits/introduction.mdx
@@ -1,30 +1,48 @@
 ---
 title: 'Customer Credits'
 sidebarTitle: 'Introduction'
-description: 'Manage customer credit balances — points, gems, stars, or any unit you want. Ship loyalty programs, in-app currencies, and prepaid balances without building balance infrastructure from scratch.'
+description: 'Give your customers a credit balance — points, gems, stars, or any unit. Build loyalty programs, prepaid wallets, and usage-based billing without building the infrastructure yourself.'
 ---
 
 <Note>
-  Customer Credits is currently in **Experimental** preview. The API is stable but may receive additive changes. All responses include the `X-API-Stability: experimental` header.
+  Customer Credits is in **Experimental** preview. The API is stable but may receive additive changes.
 </Note>
 
 ## What is Customer Credits?
 
-Customer Credits lets you create and manage credit balances for your customers — points, gems, stars, or any unit you want. You credit and debit through a simple API, and Creem takes care of tracking every change with a complete history.
+Customer Credits lets you give your customers a balance they can earn and spend — points, gems, stars, or whatever fits your product.
 
-Think of it as a hosted balance system: you define what your units are called, Creem stores and tracks them reliably. Every change is recorded, so you always have a full audit trail if you need it.
+You add credits when something good happens (a purchase, a referral, a top-up). You remove credits when they're used (a redemption, an API call, a feature unlock). Creem tracks everything and gives you a complete history.
 
-### Key Properties
+**No database tables to design. No race conditions to debug. Just API calls.**
 
-| Property | Detail |
-| --- | --- |
-| **Unit-agnostic** | Credits, gems, stars, points, tokens — you name them, we track them |
-| **Full history** | Every balance change is recorded permanently. Corrections are new entries, never edits to old ones |
-| **BigInt amounts** | Handles any scale — amounts are strings to support arbitrarily large numbers |
-| **Idempotent writes** | Every mutation requires an `idempotency_key` — safe to retry without double-counting |
-| **Reference tracking** | Every transaction carries a mandatory `reference` field for linking back to your own events (orders, signups, campaigns) |
+## Why use it?
 
-## How It Works
+<CardGroup cols={2}>
+  <Card title="AI & LLM Products" icon="microchip">
+    Sell credit packs for your AI product. Customers buy credits, each API call deducts from their balance. Different models can cost different amounts.
+  </Card>
+  <Card title="Loyalty & Rewards" icon="star">
+    Award points on purchases, let customers redeem them for discounts. Track earning and spending with full history.
+  </Card>
+  <Card title="Prepaid Balances" icon="wallet">
+    Let customers top up a balance and draw down against it for future purchases or service usage.
+  </Card>
+  <Card title="Referral Programs" icon="user-plus">
+    Credit both sides automatically when a referred user converts. Track the full lifecycle.
+  </Card>
+  <Card title="Usage Metering" icon="gauge">
+    Allocate credit pools for API calls, compute hours, storage, or any metered resource. Debit on consumption.
+  </Card>
+  <Card title="Promotional Credits" icon="gift">
+    Issue credits for marketing campaigns, seasonal offers, or beta incentives.
+  </Card>
+  <Card title="Goodwill & Compensation" icon="hand-holding-heart">
+    Issue credits for service disruptions or support escalations — tracked and auditable.
+  </Card>
+</CardGroup>
+
+## How it works
 
 ```mermaid
 sequenceDiagram
@@ -32,112 +50,60 @@ sequenceDiagram
     participant Creem as Creem API
 
     App->>Creem: Create account for customer
-    Creem-->>App: Account created (cca_xxx)
+    Creem-->>App: Account created ✓
 
-    App->>Creem: Credit 100 units (purchase reward)
-    Creem-->>App: Transaction posted (cct_xxx)
+    App->>Creem: Credit 100 units
+    Creem-->>App: Done ✓
 
-    App->>Creem: Debit 30 units (redemption)
-    Creem-->>App: Transaction posted (cct_xxx)
+    App->>Creem: Debit 30 units
+    Creem-->>App: Done ✓
 
-    App->>Creem: GET /accounts/:id/balance
-    Creem-->>App: Balance: 70 units
+    App->>Creem: What's the balance?
+    Creem-->>App: 70 units
 ```
 
-1. **Create an account** for a customer — just pass their `customer_id`.
-2. **Credit or debit** — add or remove units with a single API call.
-3. **Check balance & history** — show customers their balance or export for reconciliation.
+Three steps:
 
-## Core Concepts
+1. **Create an account** — pass a `customer_id` and you're done.
+2. **Credit or debit** — one API call to add or remove units.
+3. **Check balance** — instant lookup, always up to date.
 
-### Accounts
-
-An account holds a credit balance for one customer. Each account has:
-
-- A **name** (default: `"default"`) — useful when a customer has multiple balances (e.g., `"loyalty_points"` and `"referral_credits"`)
-- A **unit label** (default: `"credits"`) — purely cosmetic, for display purposes
-- A **status**: `active`, `frozen`, or `closed`
-
-### Transactions
-
-A transaction represents a single balance change — a credit (adding units) or a debit (removing units). Every transaction requires:
-
-- An **`idempotency_key`** — prevents duplicate processing on retries
-- A **`reference`** — your own correlation ID (e.g., `"order_12345"`, `"referral_signup_abc"`)
-
-### Balance History
-
-Every credit and debit is stored as an immutable entry. You can list the full history of an account at any time — useful for building transaction logs, customer-facing dashboards, or running reconciliation.
-
-## Use Cases
-
-<CardGroup cols={2}>
-  <Card title="Loyalty & Rewards" icon="star">
-    Award points on purchases, redeem for discounts or perks. Track earning and spending with a full history.
-  </Card>
-  <Card title="In-App Currency" icon="coins">
-    Power virtual currencies — gems, stars, credits — for games, marketplaces, or creator platforms.
-  </Card>
-  <Card title="Prepaid Balances" icon="wallet">
-    Let customers top up a balance and draw down against it for future purchases or service usage.
-  </Card>
-  <Card title="Referral Credits" icon="user-plus">
-    Credit referrers automatically when their invitees convert. Track the full referral-to-redemption lifecycle.
-  </Card>
-  <Card title="Service Usage Metering" icon="gauge">
-    Allocate credit pools for API calls, compute hours, storage, or any metered resource. Debit on consumption.
-  </Card>
-  <Card title="Promotional Campaigns" icon="gift">
-    Issue time-limited promotional credits for marketing campaigns, seasonal offers, or beta incentives.
-  </Card>
-  <Card title="Compensation & Goodwill" icon="hand-holding-heart">
-    Issue credits for service disruptions or support escalations — tracked and auditable.
-  </Card>
-  <Card title="AI Wrapper Credits" icon="microchip">
-    Sell credit packs for your AI product — customers buy credits, each API call deducts from their balance. No need to build billing infrastructure.
-  </Card>
-
-</CardGroup>
-
-## Quick Example
-
-<Tabs>
-  <Tab title="REST API">
+## Quick start
 
 <Warning>
   If you're in test mode, use `https://test-api.creem.io` instead of `https://api.creem.io`. Learn more about [Test Mode](/getting-started/test-mode).
 </Warning>
 
+### 1. Create an account
+
 ```bash
-# 1. Create an account
 curl -X POST https://api.creem.io/v1/customer-credits/accounts \
   -H "x-api-key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "customer_id": "cust_abc123",
-    "name": "loyalty_points",
-    "unit_label": "points"
+    "name": "credits",
+    "unit_label": "credits"
   }'
 ```
-
-### Create Account Response
 
 ```json
 {
   "id": "cca_7kXmR2pQ9vN",
   "store_id": "store_xxx",
   "customer_id": "cust_abc123",
-  "name": "loyalty_points",
+  "name": "credits",
   "type": "liability",
-  "unit_label": "points",
+  "unit_label": "credits",
   "status": "active",
   "created_at": "2026-04-14T12:00:00.000Z",
   "updated_at": "2026-04-14T12:00:00.000Z"
 }
 ```
 
+### 2. Add credits
+
 ```bash
-# 2. Credit 500 points
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/cca_7kXmR2pQ9vN/credit \
   -H "x-api-key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
@@ -148,70 +114,64 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/cca_7kXmR2pQ9vN/c
   }'
 ```
 
-### Credit Response
-
-```json
-{
-  "id": "cct_3mNpK8rW2xY",
-  "store_id": "store_xxx",
-  "reference": "order_789",
-  "idempotency_key": "reward_order_789",
-  "reversal_of": null,
-  "entries": [
-    {
-      "id": "cce_2hJnR6wP5bC",
-      "transaction_id": "cct_3mNpK8rW2xY",
-      "account_id": "cca_7kXmR2pQ9vN",
-      "side": "credit",
-      "amount": "500",
-      "created_at": "2026-04-14T14:30:00.000Z"
-    }
-  ],
-  "created_at": "2026-04-14T14:30:00.000Z"
-}
-```
+### 3. Use credits
 
 ```bash
-# 3. Check balance
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/cca_7kXmR2pQ9vN/debit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "200",
+    "reference": "redemption_456",
+    "idempotency_key": "redeem_456"
+  }'
+```
+
+### 4. Check balance
+
+```bash
 curl https://api.creem.io/v1/customer-credits/accounts/cca_7kXmR2pQ9vN/balance \
   -H "x-api-key: YOUR_API_KEY"
 ```
 
-### Balance Response
-
 ```json
 {
-  "balance": "500",
+  "balance": "300",
   "updated_at": "2026-04-14T14:30:00.000Z"
 }
 ```
 
-  </Tab>
-</Tabs>
+## Key features
 
-## Account Lifecycle
+| Feature | Detail |
+| --- | --- |
+| **Any unit** | Credits, gems, stars, points — you name them, we track them |
+| **Full history** | Every change is recorded. You can always see what happened and why |
+| **Safe retries** | Every write requires an `idempotency_key` — retry without fear of double-counting |
+| **Reference tracking** | Link every transaction to your own events with a `reference` field |
+| **Large numbers** | Amounts are strings — no overflow, no matter the scale |
 
-Accounts have three states:
+## Account states
 
-| Status | Can transact? | Can read? | Notes |
+| Status | Can add/remove credits? | Can read? | Notes |
 | --- | --- | --- | --- |
-| `active` | ✅ | ✅ | Default state |
-| `frozen` | ❌ | ✅ | Temporarily paused — useful for fraud review or disputes |
-| `closed` | ❌ | ✅ | Permanently closed. Cannot be reopened. Balance and history remain readable. |
+| `active` | ✅ | ✅ | Default |
+| `frozen` | ❌ | ✅ | Temporarily paused — useful for fraud review |
+| `closed` | ❌ | ✅ | Permanent. Balance and history stay readable |
 
-## What's Next?
+## Next steps
 
 <CardGroup cols={2}>
   <Card title="Accounts" icon="user" href="/features/customer-credits/accounts">
-    Create, list, freeze, and close credit accounts.
+    Create, list, freeze, and close accounts.
   </Card>
   <Card title="Transactions" icon="arrow-right-arrow-left" href="/features/customer-credits/transactions">
-    Credit, debit, reverse, and query transactions.
+    Credit, debit, reverse, and view history.
   </Card>
   <Card title="Recipes" icon="book-open" href="/guides/customer-credits-recipes">
-    Step-by-step guides for loyalty programs, prepaid wallets, referral credits, and more.
+    Step-by-step guides for common use cases.
   </Card>
   <Card title="API Reference" icon="code" href="/api-reference/endpoint/create-credits-account">
-    Full endpoint documentation with request/response schemas.
+    Full endpoint docs with schemas.
   </Card>
 </CardGroup>

--- a/packages/docs/features/customer-credits/introduction.mdx
+++ b/packages/docs/features/customer-credits/introduction.mdx
@@ -1,0 +1,231 @@
+---
+title: 'Customer Credits'
+sidebarTitle: 'Introduction'
+description: 'Manage customer credit balances — points, gems, tokens, coins, or any unit you want. Ship loyalty programs, in-app currencies, and prepaid balances without building balance infrastructure from scratch.'
+---
+
+<Note>
+  Customer Credits is currently in **Experimental** preview. The API is stable but may receive additive changes. All responses include the `X-API-Stability: experimental` header.
+</Note>
+
+## What is Customer Credits?
+
+Customer Credits lets you create and manage credit balances for your customers — points, gems, tokens, coins, or any unit you want. You credit and debit through a simple API, and Creem takes care of tracking every change with a complete history.
+
+Think of it as a hosted balance system: you define what your units are called, Creem stores and tracks them reliably. Every change is recorded, so you always have a full audit trail if you need it.
+
+### Key Properties
+
+| Property | Detail |
+| --- | --- |
+| **Unit-agnostic** | Credits, gems, stars, points, tokens — you name them, we track them |
+| **Immutable history** | Every balance change is recorded permanently. Corrections are new entries, never edits to old ones |
+| **BigInt amounts** | Handles any scale — no overflow limits |
+| **Idempotent writes** | Every mutation requires an `Idempotency-Key` header — safe to retry without double-counting |
+| **Reference tracking** | Every transaction carries a mandatory `reference` field for linking back to your own events (orders, signups, campaigns) |
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant App as Your App
+    participant Creem as Creem API
+
+    App->>Creem: Create account for customer
+    Creem-->>App: Account created (cca_xxx)
+
+    App->>Creem: Credit 100 units (purchase reward)
+    Creem-->>App: Transaction posted (cct_xxx)
+
+    App->>Creem: Debit 30 units (redemption)
+    Creem-->>App: Transaction posted (cct_xxx)
+
+    App->>Creem: GET /accounts/:id/balance
+    Creem-->>App: Balance: 70 units
+```
+
+1. **Create an account** for each customer (or use your own `external_customer_id` to let Creem auto-resolve).
+2. **Credit or debit** units via the API. Each operation is tracked as a transaction with a reference back to your system.
+3. **Query balances and history** for dashboards, receipts, or reconciliation.
+
+## Core Concepts
+
+### Accounts
+
+An account holds a credit balance for one customer. Each account has:
+
+- A **name** (default: `"default"`) — useful when a customer has multiple balances (e.g., `"loyalty_points"` and `"referral_credits"`)
+- A **unit label** (default: `"credits"`) — purely cosmetic, for display purposes
+- A **status**: `active`, `frozen`, or `closed`
+
+### Transactions
+
+A transaction represents a single balance change — a credit (adding units) or a debit (removing units). Every transaction requires:
+
+- An **`Idempotency-Key` header** — prevents duplicate processing on retries
+- A **`reference`** — your own correlation ID (e.g., `"order_12345"`, `"referral_signup_abc"`)
+
+### Balance History
+
+Every credit and debit is stored as an immutable entry. You can list the full history of an account at any time — useful for building transaction logs, customer-facing dashboards, or running reconciliation.
+
+## Use Cases
+
+<CardGroup cols={2}>
+  <Card title="Loyalty & Rewards" icon="star">
+    Award points on purchases, redeem for discounts or perks. Track earning and spending with a full history.
+  </Card>
+  <Card title="In-App Currency" icon="coins">
+    Power virtual currencies — gems, tokens, coins — for games, marketplaces, or creator platforms.
+  </Card>
+  <Card title="Prepaid Balances" icon="wallet">
+    Let customers top up a balance and draw down against it for future purchases or service usage.
+  </Card>
+  <Card title="Referral Credits" icon="user-plus">
+    Credit referrers automatically when their invitees convert. Track the full referral-to-redemption lifecycle.
+  </Card>
+  <Card title="Service Usage Metering" icon="gauge">
+    Allocate credit pools for API calls, compute hours, storage, or any metered resource. Debit on consumption.
+  </Card>
+  <Card title="Promotional Campaigns" icon="gift">
+    Issue time-limited promotional credits for marketing campaigns, seasonal offers, or beta incentives.
+  </Card>
+  <Card title="Compensation & Goodwill" icon="hand-holding-heart">
+    Issue credits for service disruptions or support escalations — tracked and auditable.
+  </Card>
+  <Card title="Marketplace Escrow" icon="handshake">
+    Hold credits between buyer payment and seller delivery, releasing on confirmation.
+  </Card>
+</CardGroup>
+
+## Quick Example
+
+<Tabs>
+  <Tab title="TypeScript SDK">
+
+```typescript
+import { createCreem } from 'creem_io';
+
+const creem = createCreem({
+  apiKey: process.env.CREEM_API_KEY!,
+});
+
+// 1. Create an account for a customer
+const account = await creem.customerCredits.accounts.create({
+  owner_id: 'cust_abc123',        // Creem customer ID or your external ID
+  name: 'loyalty_points',          // optional, defaults to "default"
+  unit_label: 'points',            // optional, defaults to "credits"
+});
+
+// 2. Credit 500 points for a purchase reward
+const creditTx = await creem.customerCredits.credit({
+  account_id: account.id,
+  amount: 500,
+  reference: 'order_789',
+  description: 'Purchase reward — Order #789',
+}, {
+  idempotencyKey: 'reward_order_789',
+});
+
+// 3. Debit 200 points for a redemption
+const debitTx = await creem.customerCredits.debit({
+  account_id: account.id,
+  amount: 200,
+  reference: 'redemption_456',
+  description: 'Points redemption at checkout',
+}, {
+  idempotencyKey: 'redeem_456',
+});
+
+// 4. Check balance
+const balance = await creem.customerCredits.accounts.getBalance(account.id);
+console.log(balance.balance); // 300
+```
+
+  </Tab>
+
+  <Tab title="REST API">
+
+<Warning>
+  If you're in test mode, use `https://test-api.creem.io` instead of `https://api.creem.io`. Learn more about [Test Mode](/getting-started/test-mode).
+</Warning>
+
+```bash
+# 1. Create an account
+curl -X POST https://api.creem.io/v1/customer-credits/accounts \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Idempotency-Key: create_acct_cust_abc123" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "owner_id": "cust_abc123",
+    "name": "loyalty_points",
+    "unit_label": "points"
+  }'
+
+# 2. Credit 500 points
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Idempotency-Key: reward_order_789" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": 500,
+    "reference": "order_789",
+    "description": "Purchase reward — Order #789"
+  }'
+
+# 3. Debit 200 points
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Idempotency-Key: redeem_456" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": 200,
+    "reference": "redemption_456",
+    "description": "Points redemption at checkout"
+  }'
+
+# 4. Check balance
+curl https://api.creem.io/v1/customer-credits/accounts/{account_id}/balance \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+### Response
+
+```json
+{
+  "account_id": "cca_7kXmR2pQ9vN",
+  "total_debits": 200,
+  "total_credits": 500,
+  "balance": 300
+}
+```
+
+  </Tab>
+</Tabs>
+
+## Account Lifecycle
+
+Accounts have three states:
+
+| Status | Can transact? | Can read? | Notes |
+| --- | --- | --- | --- |
+| `active` | ✅ | ✅ | Default state |
+| `frozen` | ❌ | ✅ | Temporarily paused — useful for fraud review or disputes |
+| `closed` | ❌ | ✅ | Permanently closed. Cannot be reopened. Balance and history remain readable. |
+
+## What's Next?
+
+<CardGroup cols={2}>
+  <Card title="Accounts" icon="user" href="/features/customer-credits/accounts">
+    Create, list, freeze, and close credit accounts.
+  </Card>
+  <Card title="Transactions" icon="arrow-right-arrow-left" href="/features/customer-credits/transactions">
+    Credit, debit, reverse, and query transactions.
+  </Card>
+  <Card title="Recipes" icon="book-open" href="/guides/customer-credits-recipes">
+    Step-by-step guides for loyalty programs, prepaid wallets, referral credits, and more.
+  </Card>
+  <Card title="API Reference" icon="code" href="/api-reference/endpoint/create-credits-account">
+    Full endpoint documentation.
+  </Card>
+</CardGroup>

--- a/packages/docs/features/customer-credits/introduction.mdx
+++ b/packages/docs/features/customer-credits/introduction.mdx
@@ -20,8 +20,8 @@ Think of it as a hosted balance system: you define what your units are called, C
 | --- | --- |
 | **Unit-agnostic** | Credits, gems, stars, points, tokens — you name them, we track them |
 | **Immutable history** | Every balance change is recorded permanently. Corrections are new entries, never edits to old ones |
-| **BigInt amounts** | Handles any scale — no overflow limits |
-| **Idempotent writes** | Every mutation requires an `Idempotency-Key` header — safe to retry without double-counting |
+| **BigInt amounts** | Handles any scale — amounts are strings to support arbitrarily large numbers |
+| **Idempotent writes** | Every mutation requires an `idempotency_key` — safe to retry without double-counting |
 | **Reference tracking** | Every transaction carries a mandatory `reference` field for linking back to your own events (orders, signups, campaigns) |
 
 ## How It Works
@@ -44,7 +44,7 @@ sequenceDiagram
     Creem-->>App: Balance: 70 units
 ```
 
-1. **Create an account** for each customer (or use your own `external_customer_id` to let Creem auto-resolve).
+1. **Create an account** for each customer using their `customer_id`.
 2. **Credit or debit** units via the API. Each operation is tracked as a transaction with a reference back to your system.
 3. **Query balances and history** for dashboards, receipts, or reconciliation.
 
@@ -62,7 +62,7 @@ An account holds a credit balance for one customer. Each account has:
 
 A transaction represents a single balance change — a credit (adding units) or a debit (removing units). Every transaction requires:
 
-- An **`Idempotency-Key` header** — prevents duplicate processing on retries
+- An **`idempotency_key`** — prevents duplicate processing on retries
 - A **`reference`** — your own correlation ID (e.g., `"order_12345"`, `"referral_signup_abc"`)
 
 ### Balance History
@@ -101,49 +101,6 @@ Every credit and debit is stored as an immutable entry. You can list the full hi
 ## Quick Example
 
 <Tabs>
-  <Tab title="TypeScript SDK">
-
-```typescript
-import { createCreem } from 'creem_io';
-
-const creem = createCreem({
-  apiKey: process.env.CREEM_API_KEY!,
-});
-
-// 1. Create an account for a customer
-const account = await creem.customerCredits.accounts.create({
-  owner_id: 'cust_abc123',        // Creem customer ID or your external ID
-  name: 'loyalty_points',          // optional, defaults to "default"
-  unit_label: 'points',            // optional, defaults to "credits"
-});
-
-// 2. Credit 500 points for a purchase reward
-const creditTx = await creem.customerCredits.credit({
-  account_id: account.id,
-  amount: 500,
-  reference: 'order_789',
-  description: 'Purchase reward — Order #789',
-}, {
-  idempotencyKey: 'reward_order_789',
-});
-
-// 3. Debit 200 points for a redemption
-const debitTx = await creem.customerCredits.debit({
-  account_id: account.id,
-  amount: 200,
-  reference: 'redemption_456',
-  description: 'Points redemption at checkout',
-}, {
-  idempotencyKey: 'redeem_456',
-});
-
-// 4. Check balance
-const balance = await creem.customerCredits.accounts.getBalance(account.id);
-console.log(balance.balance); // 300
-```
-
-  </Tab>
-
   <Tab title="REST API">
 
 <Warning>
@@ -154,49 +111,77 @@ console.log(balance.balance); // 300
 # 1. Create an account
 curl -X POST https://api.creem.io/v1/customer-credits/accounts \
   -H "x-api-key: YOUR_API_KEY" \
-  -H "Idempotency-Key: create_acct_cust_abc123" \
   -H "Content-Type: application/json" \
   -d '{
-    "owner_id": "cust_abc123",
+    "customer_id": "cust_abc123",
     "name": "loyalty_points",
     "unit_label": "points"
   }'
-
-# 2. Credit 500 points
-curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
-  -H "x-api-key: YOUR_API_KEY" \
-  -H "Idempotency-Key: reward_order_789" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "amount": 500,
-    "reference": "order_789",
-    "description": "Purchase reward — Order #789"
-  }'
-
-# 3. Debit 200 points
-curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
-  -H "x-api-key: YOUR_API_KEY" \
-  -H "Idempotency-Key: redeem_456" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "amount": 200,
-    "reference": "redemption_456",
-    "description": "Points redemption at checkout"
-  }'
-
-# 4. Check balance
-curl https://api.creem.io/v1/customer-credits/accounts/{account_id}/balance \
-  -H "x-api-key: YOUR_API_KEY"
 ```
 
-### Response
+### Create Account Response
 
 ```json
 {
-  "account_id": "cca_7kXmR2pQ9vN",
-  "total_debits": 200,
-  "total_credits": 500,
-  "balance": 300
+  "id": "cca_7kXmR2pQ9vN",
+  "store_id": "store_xxx",
+  "customer_id": "cust_abc123",
+  "name": "loyalty_points",
+  "type": "liability",
+  "unit_label": "points",
+  "status": "active",
+  "created_at": "2026-04-14T12:00:00.000Z",
+  "updated_at": "2026-04-14T12:00:00.000Z"
+}
+```
+
+```bash
+# 2. Credit 500 points
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/cca_7kXmR2pQ9vN/credit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "500",
+    "reference": "order_789",
+    "idempotency_key": "reward_order_789"
+  }'
+```
+
+### Credit Response
+
+```json
+{
+  "id": "cct_3mNpK8rW2xY",
+  "store_id": "store_xxx",
+  "reference": "order_789",
+  "idempotency_key": "reward_order_789",
+  "reversal_of": null,
+  "entries": [
+    {
+      "id": "cce_2hJnR6wP5bC",
+      "transaction_id": "cct_3mNpK8rW2xY",
+      "account_id": "cca_7kXmR2pQ9vN",
+      "side": "credit",
+      "amount": "500",
+      "created_at": "2026-04-14T14:30:00.000Z"
+    }
+  ],
+  "created_at": "2026-04-14T14:30:00.000Z"
+}
+```
+
+```bash
+# 3. Check balance
+curl https://api.creem.io/v1/customer-credits/accounts/cca_7kXmR2pQ9vN/balance \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+### Balance Response
+
+```json
+{
+  "balance": "500",
+  "updated_at": "2026-04-14T14:30:00.000Z"
 }
 ```
 
@@ -224,8 +209,5 @@ Accounts have three states:
   </Card>
   <Card title="Recipes" icon="book-open" href="/guides/customer-credits-recipes">
     Step-by-step guides for loyalty programs, prepaid wallets, referral credits, and more.
-  </Card>
-  <Card title="API Reference" icon="code" href="/api-reference/endpoint/create-credits-account">
-    Full endpoint documentation.
   </Card>
 </CardGroup>

--- a/packages/docs/features/customer-credits/introduction.mdx
+++ b/packages/docs/features/customer-credits/introduction.mdx
@@ -93,7 +93,6 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts \
   "store_id": "store_xxx",
   "customer_id": "cust_abc123",
   "name": "credits",
-  "type": "liability",
   "unit_label": "credits",
   "status": "active",
   "created_at": "2026-04-14T12:00:00.000Z",

--- a/packages/docs/features/customer-credits/introduction.mdx
+++ b/packages/docs/features/customer-credits/introduction.mdx
@@ -161,11 +161,11 @@ curl https://api.creem.io/v1/customer-credits/accounts/cca_7kXmR2pQ9vN/balance \
 
 ## Account states
 
-| Status   | Can add/remove credits? | Can read? | Notes                                        |
-| -------- | ----------------------- | --------- | -------------------------------------------- |
-| `active` | ✅                      | ✅        | Default                                      |
-| `frozen` | ❌                      | ✅        | Temporarily paused — useful for fraud review |
-| `closed` | ❌                      | ✅        | Permanent. Balance and history stay readable |
+| Status | Can add/remove credits? | Can read? | Notes |
+| --- | --- | --- | --- |
+| `active` | ✅ | ✅ | Default |
+| `frozen` | ❌ | ✅ | Temporarily paused |
+| `closed` | ❌ | ✅ | Permanent. Balance and history stay readable |
 
 ## Next steps
 

--- a/packages/docs/features/customer-credits/introduction.mdx
+++ b/packages/docs/features/customer-credits/introduction.mdx
@@ -5,7 +5,8 @@ description: 'Give your customers a credit balance — points, gems, stars, or a
 ---
 
 <Note>
-  Customer Credits is in **Experimental** preview. The API is stable but may receive additive changes.
+  Customer Credits is in **Experimental** preview. The API is stable but may
+  receive additive changes.
 </Note>
 
 ## What is Customer Credits?
@@ -20,25 +21,31 @@ You add credits when something good happens (a purchase, a referral, a top-up). 
 
 <CardGroup cols={2}>
   <Card title="AI & LLM Products" icon="microchip">
-    Sell credit packs for your AI product. Customers buy credits, each API call deducts from their balance. Different models can cost different amounts.
+    Sell credit packs for your AI product. Customers buy credits, each API call
+    deducts from their balance. Different models can cost different amounts.
   </Card>
   <Card title="Loyalty & Rewards" icon="star">
-    Award points on purchases, let customers redeem them for discounts. Track earning and spending with full history.
+    Award points on purchases, let customers redeem them for discounts. Track
+    earning and spending with full history.
   </Card>
   <Card title="Prepaid Balances" icon="wallet">
-    Let customers top up a balance and draw down against it for future purchases or service usage.
+    Let customers top up a balance and draw down against it for future purchases
+    or service usage.
   </Card>
   <Card title="Referral Programs" icon="user-plus">
-    Credit both sides automatically when a referred user converts. Track the full lifecycle.
+    Credit both sides automatically when a referred user converts. Track the
+    full lifecycle.
   </Card>
   <Card title="Usage Metering" icon="gauge">
-    Allocate credit pools for API calls, compute hours, storage, or any metered resource. Debit on consumption.
+    Allocate credit pools for API calls, compute hours, storage, or any metered
+    resource. Debit on consumption.
   </Card>
   <Card title="Promotional Credits" icon="gift">
     Issue credits for marketing campaigns, seasonal offers, or beta incentives.
   </Card>
   <Card title="Goodwill & Compensation" icon="hand-holding-heart">
-    Issue credits for service disruptions or support escalations — tracked and auditable.
+    Issue credits for service disruptions or support escalations — tracked and
+    auditable.
   </Card>
 </CardGroup>
 
@@ -71,7 +78,9 @@ Three steps:
 ## Quick start
 
 <Warning>
-  If you're in test mode, use `https://test-api.creem.io` instead of `https://api.creem.io`. Learn more about [Test Mode](/getting-started/test-mode).
+  If you're in test mode, use `https://test-api.creem.io` instead of
+  `https://api.creem.io`. Learn more about [Test
+  Mode](/getting-started/test-mode).
 </Warning>
 
 ### 1. Create an account
@@ -142,21 +151,21 @@ curl https://api.creem.io/v1/customer-credits/accounts/cca_7kXmR2pQ9vN/balance \
 
 ## Key features
 
-| Feature | Detail |
-| --- | --- |
-| **Any unit** | Credits, gems, stars, points — you name them, we track them |
-| **Full history** | Every change is recorded. You can always see what happened and why |
-| **Safe retries** | Every write requires an `idempotency_key` — retry without fear of double-counting |
-| **Reference tracking** | Link every transaction to your own events with a `reference` field |
-| **Large numbers** | Amounts are strings — no overflow, no matter the scale |
+| Feature                | Detail                                                                            |
+| ---------------------- | --------------------------------------------------------------------------------- |
+| **Any unit**           | Credits, gems, stars, points — you name them, we track them                       |
+| **Full history**       | Every change is recorded. You can always see what happened and why                |
+| **Safe retries**       | Every write requires an `idempotency_key` — retry without fear of double-counting |
+| **Reference tracking** | Link every transaction to your own events with a `reference` field                |
+| **Large numbers**      | Amounts are strings — no overflow, no matter the scale                            |
 
 ## Account states
 
-| Status | Can add/remove credits? | Can read? | Notes |
-| --- | --- | --- | --- |
-| `active` | ✅ | ✅ | Default |
-| `frozen` | ❌ | ✅ | Temporarily paused — useful for fraud review |
-| `closed` | ❌ | ✅ | Permanent. Balance and history stay readable |
+| Status   | Can add/remove credits? | Can read? | Notes                                        |
+| -------- | ----------------------- | --------- | -------------------------------------------- |
+| `active` | ✅                      | ✅        | Default                                      |
+| `frozen` | ❌                      | ✅        | Temporarily paused — useful for fraud review |
+| `closed` | ❌                      | ✅        | Permanent. Balance and history stay readable |
 
 ## Next steps
 
@@ -164,13 +173,25 @@ curl https://api.creem.io/v1/customer-credits/accounts/cca_7kXmR2pQ9vN/balance \
   <Card title="Accounts" icon="user" href="/features/customer-credits/accounts">
     Create, list, freeze, and close accounts.
   </Card>
-  <Card title="Transactions" icon="arrow-right-arrow-left" href="/features/customer-credits/transactions">
+  <Card
+    title="Transactions"
+    icon="arrow-right-arrow-left"
+    href="/features/customer-credits/transactions"
+  >
     Credit, debit, reverse, and view history.
   </Card>
-  <Card title="Recipes" icon="book-open" href="/guides/customer-credits-recipes">
+  <Card
+    title="Recipes"
+    icon="book-open"
+    href="/guides/customer-credits-recipes"
+  >
     Step-by-step guides for common use cases.
   </Card>
-  <Card title="API Reference" icon="code" href="/api-reference/endpoint/create-credits-account">
+  <Card
+    title="API Reference"
+    icon="code"
+    href="/api-reference/endpoint/create-credits-account"
+  >
     Full endpoint docs with schemas.
   </Card>
 </CardGroup>

--- a/packages/docs/features/customer-credits/introduction.mdx
+++ b/packages/docs/features/customer-credits/introduction.mdx
@@ -93,6 +93,9 @@ Every credit and debit is stored as an immutable entry. You can list the full hi
   <Card title="Compensation & Goodwill" icon="hand-holding-heart">
     Issue credits for service disruptions or support escalations — tracked and auditable.
   </Card>
+  <Card title="AI Wrapper Credits" icon="microchip">
+    Sell credit packs for your AI product — customers buy credits, each API call deducts from their balance. No need to build billing infrastructure.
+  </Card>
   <Card title="Marketplace Escrow" icon="handshake">
     Hold credits between buyer payment and seller delivery, releasing on confirmation.
   </Card>

--- a/packages/docs/features/customer-credits/introduction.mdx
+++ b/packages/docs/features/customer-credits/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Customer Credits'
 sidebarTitle: 'Introduction'
-description: 'Manage customer credit balances — points, gems, tokens, coins, or any unit you want. Ship loyalty programs, in-app currencies, and prepaid balances without building balance infrastructure from scratch.'
+description: 'Manage customer credit balances — points, gems, stars, or any unit you want. Ship loyalty programs, in-app currencies, and prepaid balances without building balance infrastructure from scratch.'
 ---
 
 <Note>
@@ -10,7 +10,7 @@ description: 'Manage customer credit balances — points, gems, tokens, coins, o
 
 ## What is Customer Credits?
 
-Customer Credits lets you create and manage credit balances for your customers — points, gems, tokens, coins, or any unit you want. You credit and debit through a simple API, and Creem takes care of tracking every change with a complete history.
+Customer Credits lets you create and manage credit balances for your customers — points, gems, stars, or any unit you want. You credit and debit through a simple API, and Creem takes care of tracking every change with a complete history.
 
 Think of it as a hosted balance system: you define what your units are called, Creem stores and tracks them reliably. Every change is recorded, so you always have a full audit trail if you need it.
 
@@ -19,7 +19,7 @@ Think of it as a hosted balance system: you define what your units are called, C
 | Property | Detail |
 | --- | --- |
 | **Unit-agnostic** | Credits, gems, stars, points, tokens — you name them, we track them |
-| **Immutable history** | Every balance change is recorded permanently. Corrections are new entries, never edits to old ones |
+| **Full history** | Every balance change is recorded permanently. Corrections are new entries, never edits to old ones |
 | **BigInt amounts** | Handles any scale — amounts are strings to support arbitrarily large numbers |
 | **Idempotent writes** | Every mutation requires an `idempotency_key` — safe to retry without double-counting |
 | **Reference tracking** | Every transaction carries a mandatory `reference` field for linking back to your own events (orders, signups, campaigns) |
@@ -44,9 +44,9 @@ sequenceDiagram
     Creem-->>App: Balance: 70 units
 ```
 
-1. **Create an account** for each customer using their `customer_id`.
-2. **Credit or debit** units via the API. Each operation is tracked as a transaction with a reference back to your system.
-3. **Query balances and history** for dashboards, receipts, or reconciliation.
+1. **Create an account** for a customer — just pass their `customer_id`.
+2. **Credit or debit** — add or remove units with a single API call.
+3. **Check balance & history** — show customers their balance or export for reconciliation.
 
 ## Core Concepts
 
@@ -76,7 +76,7 @@ Every credit and debit is stored as an immutable entry. You can list the full hi
     Award points on purchases, redeem for discounts or perks. Track earning and spending with a full history.
   </Card>
   <Card title="In-App Currency" icon="coins">
-    Power virtual currencies — gems, tokens, coins — for games, marketplaces, or creator platforms.
+    Power virtual currencies — gems, stars, credits — for games, marketplaces, or creator platforms.
   </Card>
   <Card title="Prepaid Balances" icon="wallet">
     Let customers top up a balance and draw down against it for future purchases or service usage.
@@ -96,9 +96,7 @@ Every credit and debit is stored as an immutable entry. You can list the full hi
   <Card title="AI Wrapper Credits" icon="microchip">
     Sell credit packs for your AI product — customers buy credits, each API call deducts from their balance. No need to build billing infrastructure.
   </Card>
-  <Card title="Marketplace Escrow" icon="handshake">
-    Hold credits between buyer payment and seller delivery, releasing on confirmation.
-  </Card>
+
 </CardGroup>
 
 ## Quick Example

--- a/packages/docs/features/customer-credits/transactions.mdx
+++ b/packages/docs/features/customer-credits/transactions.mdx
@@ -11,56 +11,43 @@ description: 'Credit, debit, and reverse transactions on customer credit account
 
 Every time you add or remove credits from a customer's account, it creates a transaction. Transactions are permanent records — you can always see the full history of what happened and why.
 
-For most use cases, the `/credit` and `/debit` endpoints are all you need. Each one takes an amount, a reference back to your system, and an idempotency key to make retries safe.
+For most use cases, the `/credit` and `/debit` endpoints are all you need. Each one takes an amount (as a string), a reference back to your system, and an idempotency key to make retries safe.
 
 ## Credit an Account
 
 Add units to a customer's account balance.
 
-<Tabs>
-  <Tab title="TypeScript SDK">
-
-```typescript
-const tx = await creem.customerCredits.credit({
-  account_id: 'cca_7kXmR2pQ9vN',
-  amount: 500,
-  reference: 'order_789',
-  description: 'Purchase reward — 5x points on electronics',
-}, {
-  idempotencyKey: 'reward_order_789',
-});
-```
-
-  </Tab>
-
-  <Tab title="REST API">
-
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
   -H "x-api-key: YOUR_API_KEY" \
-  -H "Idempotency-Key: reward_order_789" \
   -H "Content-Type: application/json" \
   -d '{
-    "amount": 500,
+    "amount": "500",
     "reference": "order_789",
-    "description": "Purchase reward — 5x points on electronics"
+    "idempotency_key": "reward_order_789"
   }'
 ```
-
-  </Tab>
-</Tabs>
 
 ### Response
 
 ```json
 {
   "id": "cct_3mNpK8rW2xY",
-  "account_id": "cca_7kXmR2pQ9vN",
-  "type": "credit",
-  "amount": 500,
+  "store_id": "store_xxx",
   "reference": "order_789",
-  "description": "Purchase reward — 5x points on electronics",
-  "posted_at": "2026-04-14T14:30:00Z"
+  "idempotency_key": "reward_order_789",
+  "reversal_of": null,
+  "entries": [
+    {
+      "id": "cce_2hJnR6wP5bC",
+      "transaction_id": "cct_3mNpK8rW2xY",
+      "account_id": "cca_7kXmR2pQ9vN",
+      "side": "credit",
+      "amount": "500",
+      "created_at": "2026-04-14T14:30:00.000Z"
+    }
+  ],
+  "created_at": "2026-04-14T14:30:00.000Z"
 }
 ```
 
@@ -68,30 +55,22 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/cred
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `amount` | integer | ✅ | Number of units to credit. Must be positive. |
+| `amount` | string | ✅ | Number of units to credit (string to support large numbers). Must be positive. |
 | `reference` | string | ✅ | Your own correlation ID (e.g., order ID, campaign ID). |
-| `description` | string | | Human-readable note for the transaction. |
-| `metadata` | object | | Arbitrary key-value pairs for your own tracking. |
-
-### Headers
-
-| Header | Required | Description |
-| --- | --- | --- |
-| `Idempotency-Key` | ✅ | Unique key for this operation. Retries with the same key return the original response. |
+| `idempotency_key` | string | ✅ | Unique key for this operation. Retries with the same key return the original response. |
 
 ## Debit an Account
 
-Remove units from a customer's account balance.
+Remove units from a customer's account balance. Same request format as credit.
 
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
   -H "x-api-key: YOUR_API_KEY" \
-  -H "Idempotency-Key: redeem_checkout_456" \
   -H "Content-Type: application/json" \
   -d '{
-    "amount": 200,
+    "amount": "200",
     "reference": "checkout_456",
-    "description": "Points redeemed at checkout"
+    "idempotency_key": "redeem_checkout_456"
   }'
 ```
 
@@ -103,22 +82,6 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debi
 
 Mistakes happen. Reversals undo a previous transaction by creating a new opposite transaction — the original record stays intact so you always have the full history.
 
-<Tabs>
-  <Tab title="TypeScript SDK">
-
-```typescript
-const reversal = await creem.customerCredits.reverse({
-  account_id: 'cca_7kXmR2pQ9vN',
-  transaction_id: 'cct_3mNpK8rW2xY',
-}, {
-  idempotencyKey: 'reverse_order_789',
-});
-```
-
-  </Tab>
-
-  <Tab title="REST API">
-
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/reverse \
   -H "x-api-key: YOUR_API_KEY" \
@@ -127,9 +90,6 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/reve
     "transaction_id": "cct_3mNpK8rW2xY"
   }'
 ```
-
-  </Tab>
-</Tabs>
 
 The reversal transaction will have a `reversal_of` field linking back to the original, so you can always trace what happened.
 
@@ -150,17 +110,17 @@ curl "https://api.creem.io/v1/customer-credits/accounts/{account_id}/entries?lim
       "id": "cce_2hJnR6wP5bC",
       "transaction_id": "cct_3mNpK8rW2xY",
       "account_id": "cca_7kXmR2pQ9vN",
-      "type": "credit",
-      "amount": 500,
-      "created_at": "2026-04-14T14:30:00Z"
+      "side": "credit",
+      "amount": "500",
+      "created_at": "2026-04-14T14:30:00.000Z"
     },
     {
       "id": "cce_8dFmQ1tY4wK",
       "transaction_id": "cct_5pRsL9uZ3cB",
       "account_id": "cca_7kXmR2pQ9vN",
-      "type": "debit",
-      "amount": 200,
-      "created_at": "2026-04-14T15:00:00Z"
+      "side": "debit",
+      "amount": "200",
+      "created_at": "2026-04-14T15:00:00.000Z"
     }
   ],
   "has_more": false
@@ -169,7 +129,7 @@ curl "https://api.creem.io/v1/customer-credits/accounts/{account_id}/entries?lim
 
 ## Idempotency
 
-All mutation endpoints require an `Idempotency-Key` header. This makes retries completely safe — you never have to worry about double-crediting or double-debiting:
+All mutation endpoints require an `idempotency_key` in the request body. This makes retries completely safe — you never have to worry about double-crediting or double-debiting:
 
 | Scenario | Result |
 | --- | --- |

--- a/packages/docs/features/customer-credits/transactions.mdx
+++ b/packages/docs/features/customer-credits/transactions.mdx
@@ -1,0 +1,184 @@
+---
+title: 'Transactions'
+description: 'Credit, debit, and reverse transactions on customer credit accounts. Every operation is idempotent, referenced, and produces an immutable history.'
+---
+
+<Note>
+  Customer Credits is currently in **Experimental** preview. All responses include the `X-API-Stability: experimental` header.
+</Note>
+
+## Overview
+
+Every time you add or remove credits from a customer's account, it creates a transaction. Transactions are permanent records — you can always see the full history of what happened and why.
+
+For most use cases, the `/credit` and `/debit` endpoints are all you need. Each one takes an amount, a reference back to your system, and an idempotency key to make retries safe.
+
+## Credit an Account
+
+Add units to a customer's account balance.
+
+<Tabs>
+  <Tab title="TypeScript SDK">
+
+```typescript
+const tx = await creem.customerCredits.credit({
+  account_id: 'cca_7kXmR2pQ9vN',
+  amount: 500,
+  reference: 'order_789',
+  description: 'Purchase reward — 5x points on electronics',
+}, {
+  idempotencyKey: 'reward_order_789',
+});
+```
+
+  </Tab>
+
+  <Tab title="REST API">
+
+```bash
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Idempotency-Key: reward_order_789" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": 500,
+    "reference": "order_789",
+    "description": "Purchase reward — 5x points on electronics"
+  }'
+```
+
+  </Tab>
+</Tabs>
+
+### Response
+
+```json
+{
+  "id": "cct_3mNpK8rW2xY",
+  "account_id": "cca_7kXmR2pQ9vN",
+  "type": "credit",
+  "amount": 500,
+  "reference": "order_789",
+  "description": "Purchase reward — 5x points on electronics",
+  "posted_at": "2026-04-14T14:30:00Z"
+}
+```
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `amount` | integer | ✅ | Number of units to credit. Must be positive. |
+| `reference` | string | ✅ | Your own correlation ID (e.g., order ID, campaign ID). |
+| `description` | string | | Human-readable note for the transaction. |
+| `metadata` | object | | Arbitrary key-value pairs for your own tracking. |
+
+### Headers
+
+| Header | Required | Description |
+| --- | --- | --- |
+| `Idempotency-Key` | ✅ | Unique key for this operation. Retries with the same key return the original response. |
+
+## Debit an Account
+
+Remove units from a customer's account balance.
+
+```bash
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Idempotency-Key: redeem_checkout_456" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": 200,
+    "reference": "checkout_456",
+    "description": "Points redeemed at checkout"
+  }'
+```
+
+<Info>
+  Negative balances are allowed by default. If you want to prevent overdrafts, check the balance before debiting in your application logic.
+</Info>
+
+## Reverse a Transaction
+
+Mistakes happen. Reversals undo a previous transaction by creating a new opposite transaction — the original record stays intact so you always have the full history.
+
+<Tabs>
+  <Tab title="TypeScript SDK">
+
+```typescript
+const reversal = await creem.customerCredits.reverse({
+  account_id: 'cca_7kXmR2pQ9vN',
+  transaction_id: 'cct_3mNpK8rW2xY',
+}, {
+  idempotencyKey: 'reverse_order_789',
+});
+```
+
+  </Tab>
+
+  <Tab title="REST API">
+
+```bash
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/reverse \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "transaction_id": "cct_3mNpK8rW2xY"
+  }'
+```
+
+  </Tab>
+</Tabs>
+
+The reversal transaction will have a `reversal_of` field linking back to the original, so you can always trace what happened.
+
+## List Transaction History
+
+Retrieve the full history of credits and debits for an account. Useful for building activity feeds, customer-facing dashboards, or running reconciliation.
+
+```bash
+curl "https://api.creem.io/v1/customer-credits/accounts/{account_id}/entries?limit=50" \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "cce_2hJnR6wP5bC",
+      "transaction_id": "cct_3mNpK8rW2xY",
+      "account_id": "cca_7kXmR2pQ9vN",
+      "type": "credit",
+      "amount": 500,
+      "created_at": "2026-04-14T14:30:00Z"
+    },
+    {
+      "id": "cce_8dFmQ1tY4wK",
+      "transaction_id": "cct_5pRsL9uZ3cB",
+      "account_id": "cca_7kXmR2pQ9vN",
+      "type": "debit",
+      "amount": 200,
+      "created_at": "2026-04-14T15:00:00Z"
+    }
+  ],
+  "has_more": false
+}
+```
+
+## Idempotency
+
+All mutation endpoints require an `Idempotency-Key` header. This makes retries completely safe — you never have to worry about double-crediting or double-debiting:
+
+| Scenario | Result |
+| --- | --- |
+| First request with a new key | Processes normally, returns result |
+| Retry with the same key and same body | Returns the original result with `X-Idempotent-Replay: true` header |
+| Same key but different body | Returns `409 Conflict` with `idempotency_key_mismatch` error code |
+
+Keys are scoped per-store and retained for a minimum of 24 hours.
+
+<Tip>
+  Use domain-meaningful keys like `reward_order_789` rather than random UUIDs — they're easier to debug and naturally prevent duplicate business events.
+</Tip>

--- a/packages/docs/features/customer-credits/transactions.mdx
+++ b/packages/docs/features/customer-credits/transactions.mdx
@@ -3,9 +3,7 @@ title: 'Transactions'
 description: 'Add credits, remove credits, undo mistakes. Every change is tracked.'
 ---
 
-<Note>
-  Customer Credits is in **Experimental** preview.
-</Note>
+<Note>Customer Credits is in **Experimental** preview.</Note>
 
 ## How transactions work
 
@@ -63,11 +61,11 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/cred
 
 ### Parameters
 
-| Parameter | Type | Required | Description |
-| --- | --- | --- | --- |
-| `amount` | string | ✅ | How many credits to add. String to support large numbers |
-| `reference` | string | ✅ | Link this to your system — an order ID, campaign name, anything |
-| `idempotency_key` | string | ✅ | Prevents double-processing on retries |
+| Parameter         | Type   | Required | Description                                                     |
+| ----------------- | ------ | -------- | --------------------------------------------------------------- |
+| `amount`          | string | ✅       | How many credits to add. String to support large numbers        |
+| `reference`       | string | ✅       | Link this to your system — an order ID, campaign name, anything |
+| `idempotency_key` | string | ✅       | Prevents double-processing on retries                           |
 
 ---
 
@@ -89,7 +87,8 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debi
 Same parameters as credit. The response looks identical, just with `"side": "debit"` in the entry.
 
 <Info>
-  Negative balances are allowed by default. If you want to block overdrafts, check the balance before debiting in your app logic.
+  Negative balances are allowed by default. If you want to block overdrafts,
+  check the balance before debiting in your app logic.
 </Info>
 
 ---
@@ -112,7 +111,8 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/reve
 The response includes `"reversal_of": "cct_3mNpK8rW2xY"` linking back to the original.
 
 <Tip>
-  Reversals are idempotent — reversing the same transaction twice returns the original reversal.
+  Reversals are idempotent — reversing the same transaction twice returns the
+  original reversal.
 </Tip>
 
 ---
@@ -152,6 +152,7 @@ curl "https://api.creem.io/v1/customer-credits/accounts/{account_id}/entries?lim
 ```
 
 Each entry shows:
+
 - **`side`** — `"credit"` (added) or `"debit"` (removed)
 - **`amount`** — how many credits
 - **`transaction_id`** — links back to the transaction (which has the `reference` and `idempotency_key`)
@@ -176,14 +177,16 @@ sequenceDiagram
     Creem-->>App: ✅ Original result + X-Idempotent-Replay header
 ```
 
-| Scenario | Result |
-| --- | --- |
-| First request | Processes normally |
+| Scenario                        | Result                                                      |
+| ------------------------------- | ----------------------------------------------------------- |
+| First request                   | Processes normally                                          |
 | Retry with same key + same body | Returns original result, `X-Idempotent-Replay: true` header |
-| Same key but different body | `409 Conflict` error |
+| Same key but different body     | `409 Conflict` error                                        |
 
 <Tip>
-  Use meaningful keys like `reward_order_789` or `topup_sub_123_2026-04` instead of random UUIDs. They're easier to debug and naturally prevent duplicates tied to the same business event.
+  Use meaningful keys like `reward_order_789` or `topup_sub_123_2026-04` instead
+  of random UUIDs. They're easier to debug and naturally prevent duplicates tied
+  to the same business event.
 </Tip>
 
 ---
@@ -194,13 +197,25 @@ sequenceDiagram
   <Card title="Accounts" icon="user" href="/features/customer-credits/accounts">
     Create, freeze, and manage accounts.
   </Card>
-  <Card title="Recipes" icon="book-open" href="/guides/customer-credits-recipes">
+  <Card
+    title="Recipes"
+    icon="book-open"
+    href="/guides/customer-credits-recipes"
+  >
     Step-by-step guides for common patterns.
   </Card>
-  <Card title="API Reference" icon="code" href="/api-reference/endpoint/credit-account">
+  <Card
+    title="API Reference"
+    icon="code"
+    href="/api-reference/endpoint/credit-account"
+  >
     Full endpoint schemas.
   </Card>
-  <Card title="Introduction" icon="house" href="/features/customer-credits/introduction">
+  <Card
+    title="Introduction"
+    icon="house"
+    href="/features/customer-credits/introduction"
+  >
     Back to overview.
   </Card>
 </CardGroup>

--- a/packages/docs/features/customer-credits/transactions.mdx
+++ b/packages/docs/features/customer-credits/transactions.mdx
@@ -1,21 +1,17 @@
 ---
 title: 'Transactions'
-description: 'Credit, debit, and reverse transactions on customer credit accounts. Every operation is idempotent, referenced, and produces an immutable history.'
+description: 'Add credits, remove credits, undo mistakes. Every change is tracked.'
 ---
 
 <Note>
-  Customer Credits is currently in **Experimental** preview. All responses include the `X-API-Stability: experimental` header.
+  Customer Credits is in **Experimental** preview.
 </Note>
 
 ## Overview
 
-Every time you add or remove credits from a customer's account, it creates a transaction. Transactions are permanent records — you can always see the full history of what happened and why.
+Every time you add or remove credits, a transaction is created. Transactions are permanent — you can always see exactly what happened and why.
 
-For most use cases, the `/credit` and `/debit` endpoints are all you need. Each one takes an amount (as a string), a reference back to your system, and an idempotency key to make retries safe.
-
-## Credit an Account
-
-Add units to a customer's account balance.
+## Credit (add)
 
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
@@ -27,8 +23,6 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/cred
     "idempotency_key": "reward_order_789"
   }'
 ```
-
-### Response
 
 ```json
 {
@@ -51,17 +45,15 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/cred
 }
 ```
 
-### Parameters
-
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `amount` | string | ✅ | Number of units to credit (string to support large numbers). Must be positive. |
-| `reference` | string | ✅ | Your own correlation ID (e.g., order ID, campaign ID). |
-| `idempotency_key` | string | ✅ | Unique key for this operation. Retries with the same key return the original response. |
+| `amount` | string | ✅ | How many credits to add (string for large number support) |
+| `reference` | string | ✅ | Your reference — an order ID, campaign ID, whatever links this to your system |
+| `idempotency_key` | string | ✅ | Prevents double-processing on retries |
 
-## Debit an Account
+## Debit (remove)
 
-Remove units from a customer's account balance. Same request format as credit.
+Same format as credit, just a different endpoint.
 
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
@@ -75,12 +67,12 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debi
 ```
 
 <Info>
-  Negative balances are allowed by default. If you want to prevent overdrafts, check the balance before debiting in your application logic.
+  Negative balances are allowed. If you want to block overdrafts, check the balance first in your app.
 </Info>
 
-## Reverse a Transaction
+## Reverse (undo)
 
-Mistakes happen. Reversals undo a previous transaction by creating a new opposite transaction — the original record stays intact so you always have the full history.
+Made a mistake? Reverse a transaction to undo it. The original stays in the history — a new opposite transaction is created so you have a complete paper trail.
 
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/reverse \
@@ -91,11 +83,11 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/reve
   }'
 ```
 
-The reversal transaction will have a `reversal_of` field linking back to the original, so you can always trace what happened.
+The response will have `reversal_of` set to the original transaction ID.
 
-## List Transaction History
+## View history
 
-Retrieve the full history of credits and debits for an account. Useful for building activity feeds, customer-facing dashboards, or running reconciliation.
+See every credit and debit on an account.
 
 ```bash
 curl "https://api.creem.io/v1/customer-credits/accounts/{account_id}/entries?limit=50" \
@@ -127,18 +119,16 @@ curl "https://api.creem.io/v1/customer-credits/accounts/{account_id}/entries?lim
 }
 ```
 
-## Idempotency
+## Safe retries
 
-All mutation endpoints require an `idempotency_key` in the request body. This makes retries completely safe — you never have to worry about double-crediting or double-debiting:
+Every write requires an `idempotency_key`. This means you can safely retry any request without worrying about double-crediting:
 
-| Scenario | Result |
+| What happens | Result |
 | --- | --- |
-| First request with a new key | Processes normally, returns result |
-| Retry with the same key and same body | Returns the original result with `X-Idempotent-Replay: true` header |
-| Same key but different body | Returns `409 Conflict` with `idempotency_key_mismatch` error code |
-
-Keys are scoped per-store and retained for a minimum of 24 hours.
+| First request | Processes normally |
+| Retry with same key + same body | Returns original result + `X-Idempotent-Replay: true` header |
+| Same key but different body | `409 Conflict` |
 
 <Tip>
-  Use domain-meaningful keys like `reward_order_789` rather than random UUIDs — they're easier to debug and naturally prevent duplicate business events.
+  Use meaningful keys like `reward_order_789` instead of random UUIDs. They're easier to debug and naturally prevent duplicates.
 </Tip>

--- a/packages/docs/features/customer-credits/transactions.mdx
+++ b/packages/docs/features/customer-credits/transactions.mdx
@@ -7,11 +7,27 @@ description: 'Add credits, remove credits, undo mistakes. Every change is tracke
   Customer Credits is in **Experimental** preview.
 </Note>
 
-## Overview
+## How transactions work
 
-Every time you add or remove credits, a transaction is created. Transactions are permanent — you can always see exactly what happened and why.
+Every time you add or remove credits, a transaction is created. Transactions are permanent — you always have a complete history of what happened and why.
 
-## Credit (add)
+<CardGroup cols={3}>
+  <Card title="Credit" icon="plus">
+    Add credits to an account
+  </Card>
+  <Card title="Debit" icon="minus">
+    Remove credits from an account
+  </Card>
+  <Card title="Reverse" icon="rotate-left">
+    Undo a previous transaction
+  </Card>
+</CardGroup>
+
+---
+
+## Credit — add credits
+
+Use this when a customer earns credits, buys a credit pack, or receives a reward.
 
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
@@ -45,15 +61,19 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/cred
 }
 ```
 
+### Parameters
+
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `amount` | string | ✅ | How many credits to add (string for large number support) |
-| `reference` | string | ✅ | Your reference — an order ID, campaign ID, whatever links this to your system |
+| `amount` | string | ✅ | How many credits to add. String to support large numbers |
+| `reference` | string | ✅ | Link this to your system — an order ID, campaign name, anything |
 | `idempotency_key` | string | ✅ | Prevents double-processing on retries |
 
-## Debit (remove)
+---
 
-Same format as credit, just a different endpoint.
+## Debit — remove credits
+
+Use this when a customer spends credits, uses a feature, or redeems a reward.
 
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
@@ -66,13 +86,19 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debi
   }'
 ```
 
+Same parameters as credit. The response looks identical, just with `"side": "debit"` in the entry.
+
 <Info>
-  Negative balances are allowed. If you want to block overdrafts, check the balance first in your app.
+  Negative balances are allowed by default. If you want to block overdrafts, check the balance before debiting in your app logic.
 </Info>
 
-## Reverse (undo)
+---
 
-Made a mistake? Reverse a transaction to undo it. The original stays in the history — a new opposite transaction is created so you have a complete paper trail.
+## Reverse — undo a transaction
+
+Made a mistake? Order cancelled? Reverse a transaction to undo it.
+
+The original transaction stays in the history — a new opposite transaction is created so you always have a complete paper trail.
 
 ```bash
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/reverse \
@@ -83,11 +109,17 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/reve
   }'
 ```
 
-The response will have `reversal_of` set to the original transaction ID.
+The response includes `"reversal_of": "cct_3mNpK8rW2xY"` linking back to the original.
 
-## View history
+<Tip>
+  Reversals are idempotent — reversing the same transaction twice returns the original reversal.
+</Tip>
 
-See every credit and debit on an account.
+---
+
+## Viewing history
+
+See every credit and debit on an account, newest first.
 
 ```bash
 curl "https://api.creem.io/v1/customer-credits/accounts/{account_id}/entries?limit=50" \
@@ -99,36 +131,76 @@ curl "https://api.creem.io/v1/customer-credits/accounts/{account_id}/entries?lim
   "object": "list",
   "data": [
     {
-      "id": "cce_2hJnR6wP5bC",
-      "transaction_id": "cct_3mNpK8rW2xY",
-      "account_id": "cca_7kXmR2pQ9vN",
-      "side": "credit",
-      "amount": "500",
-      "created_at": "2026-04-14T14:30:00.000Z"
-    },
-    {
       "id": "cce_8dFmQ1tY4wK",
       "transaction_id": "cct_5pRsL9uZ3cB",
       "account_id": "cca_7kXmR2pQ9vN",
       "side": "debit",
       "amount": "200",
       "created_at": "2026-04-14T15:00:00.000Z"
+    },
+    {
+      "id": "cce_2hJnR6wP5bC",
+      "transaction_id": "cct_3mNpK8rW2xY",
+      "account_id": "cca_7kXmR2pQ9vN",
+      "side": "credit",
+      "amount": "500",
+      "created_at": "2026-04-14T14:30:00.000Z"
     }
   ],
   "has_more": false
 }
 ```
 
+Each entry shows:
+- **`side`** — `"credit"` (added) or `"debit"` (removed)
+- **`amount`** — how many credits
+- **`transaction_id`** — links back to the transaction (which has the `reference` and `idempotency_key`)
+
+---
+
 ## Safe retries
 
-Every write requires an `idempotency_key`. This means you can safely retry any request without worrying about double-crediting:
+Every write operation requires an `idempotency_key`. This means you can safely retry any request — network timeouts, server errors, whatever — without worrying about double-crediting.
 
-| What happens | Result |
+```mermaid
+sequenceDiagram
+    participant App as Your App
+    participant Creem as Creem API
+
+    App->>Creem: Credit 500 (key: "reward_789")
+    Creem-->>App: ✅ Transaction created
+
+    Note over App: Network timeout, not sure if it worked...
+
+    App->>Creem: Credit 500 (key: "reward_789")
+    Creem-->>App: ✅ Original result + X-Idempotent-Replay header
+```
+
+| Scenario | Result |
 | --- | --- |
 | First request | Processes normally |
-| Retry with same key + same body | Returns original result + `X-Idempotent-Replay: true` header |
-| Same key but different body | `409 Conflict` |
+| Retry with same key + same body | Returns original result, `X-Idempotent-Replay: true` header |
+| Same key but different body | `409 Conflict` error |
 
 <Tip>
-  Use meaningful keys like `reward_order_789` instead of random UUIDs. They're easier to debug and naturally prevent duplicates.
+  Use meaningful keys like `reward_order_789` or `topup_sub_123_2026-04` instead of random UUIDs. They're easier to debug and naturally prevent duplicates tied to the same business event.
 </Tip>
+
+---
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Accounts" icon="user" href="/features/customer-credits/accounts">
+    Create, freeze, and manage accounts.
+  </Card>
+  <Card title="Recipes" icon="book-open" href="/guides/customer-credits-recipes">
+    Step-by-step guides for common patterns.
+  </Card>
+  <Card title="API Reference" icon="code" href="/api-reference/endpoint/credit-account">
+    Full endpoint schemas.
+  </Card>
+  <Card title="Introduction" icon="house" href="/features/customer-credits/introduction">
+    Back to overview.
+  </Card>
+</CardGroup>

--- a/packages/docs/features/customer-credits/transactions.mdx
+++ b/packages/docs/features/customer-credits/transactions.mdx
@@ -87,8 +87,7 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debi
 Same parameters as credit. The response looks identical, just with `"side": "debit"` in the entry.
 
 <Info>
-  Negative balances are allowed by default. If you want to block overdrafts,
-  check the balance before debiting in your app logic.
+  The API prevents negative balances — if a debit would bring the balance below zero, it returns an `insufficient_balance` error. Check the balance first if you want to show your users a friendly message.
 </Info>
 
 ---

--- a/packages/docs/features/customer-credits/transactions.mdx
+++ b/packages/docs/features/customer-credits/transactions.mdx
@@ -158,9 +158,19 @@ Each entry shows:
 
 ---
 
-## Safe retries
+## What is an `idempotency_key`?
 
-Every write operation requires an `idempotency_key`. This means you can safely retry any request — network timeouts, server errors, whatever — without worrying about double-crediting.
+An `idempotency_key` is a unique string you include with every credit or debit request. It's your safety net against accidental duplicates.
+
+Imagine your app credits a customer 500 points for an order. The request goes through, but your app doesn't get the response back (network hiccup, timeout, server restart). Without protection, retrying would give the customer 1,000 points instead of 500.
+
+The `idempotency_key` prevents this. When you retry with the same key, Creem recognizes it's the same request and returns the original result — no double-crediting.
+
+<Tip>
+  Use a key that's tied to the business event, like `reward_order_789` or `topup_sub_123_2026-04`. This way, even if your code accidentally fires twice for the same order, the customer only gets credited once.
+</Tip>
+
+### How it works
 
 ```mermaid
 sequenceDiagram
@@ -173,7 +183,7 @@ sequenceDiagram
     Note over App: Network timeout, not sure if it worked...
 
     App->>Creem: Credit 500 (key: "reward_789")
-    Creem-->>App: ✅ Original result + X-Idempotent-Replay header
+    Creem-->>App: ✅ Same result, no duplicate
 ```
 
 | Scenario                        | Result                                                      |
@@ -182,11 +192,7 @@ sequenceDiagram
 | Retry with same key + same body | Returns original result, `X-Idempotent-Replay: true` header |
 | Same key but different body     | `409 Conflict` error                                        |
 
-<Tip>
-  Use meaningful keys like `reward_order_789` or `topup_sub_123_2026-04` instead
-  of random UUIDs. They're easier to debug and naturally prevent duplicates tied
-  to the same business event.
-</Tip>
+
 
 ---
 

--- a/packages/docs/guides/customer-credits-recipes.mdx
+++ b/packages/docs/guides/customer-credits-recipes.mdx
@@ -1,0 +1,316 @@
+---
+title: 'Customer Credits Recipes'
+sidebarTitle: 'Credits Recipes'
+description: 'Step-by-step guides for common Customer Credits use cases: loyalty programs, prepaid wallets, referral systems, usage metering, and more.'
+---
+
+<Note>
+  Customer Credits is currently in **Experimental** preview.
+</Note>
+
+## Recipe 1: Loyalty Points Program
+
+Award points on purchases, let customers redeem them for discounts.
+
+### Setup
+
+```typescript
+// When a customer signs up, create their points account
+const account = await creem.customerCredits.accounts.create({
+  owner_id: customer.id,
+  name: 'loyalty_points',
+  unit_label: 'points',
+  initial_credit_amount: 50,           // signup bonus
+  initial_credit_reference: 'signup_bonus',
+});
+```
+
+### Earning Points
+
+```typescript
+// After a successful purchase, credit points (e.g., 1 point per $1)
+await creem.customerCredits.credit({
+  account_id: account.id,
+  amount: Math.floor(order.total_usd),
+  reference: `order_${order.id}`,
+  description: `Purchase reward — Order #${order.id}`,
+}, {
+  idempotencyKey: `loyalty_earn_${order.id}`,
+});
+```
+
+### Redeeming Points
+
+```typescript
+// At checkout, debit points for a discount
+const balance = await creem.customerCredits.accounts.getBalance(account.id);
+
+if (balance.balance >= pointsToRedeem) {
+  await creem.customerCredits.debit({
+    account_id: account.id,
+    amount: pointsToRedeem,
+    reference: `checkout_${checkout.id}`,
+    description: `Redeemed ${pointsToRedeem} points for $${discount} discount`,
+  }, {
+    idempotencyKey: `loyalty_redeem_${checkout.id}`,
+  });
+}
+```
+
+### Handling Order Cancellations
+
+```typescript
+// If the order is cancelled, reverse the earned points
+await creem.customerCredits.transactions.reverse({
+  transaction_id: earnTxId,
+  reference: `order_${order.id}_cancelled`,
+  description: 'Order cancelled — reversing loyalty points',
+}, {
+  idempotencyKey: `loyalty_reverse_${order.id}`,
+});
+```
+
+---
+
+## Recipe 2: Prepaid Credit Balance
+
+Customers top up a balance and draw down for future purchases.
+
+### Create the Wallet
+
+```typescript
+const wallet = await creem.customerCredits.accounts.create({
+  owner_id: customer.id,
+  name: 'prepaid_balance',
+  unit_label: 'credits',
+});
+```
+
+### Top Up After Payment
+
+```typescript
+// After a Creem checkout for a "credit pack" product completes
+// (in your webhook handler for checkout.completed)
+await creem.customerCredits.credit({
+  account_id: wallet.id,
+  amount: creditPack.amount,       // e.g., 1000 credits for the $10 pack
+  reference: `topup_${order.id}`,
+  description: `Purchased ${creditPack.name}`,
+}, {
+  idempotencyKey: `topup_${order.id}`,
+});
+```
+
+### Consume Credits
+
+```typescript
+// When the customer uses a feature that costs credits
+const cost = 25;
+const balance = await creem.customerCredits.accounts.getBalance(wallet.id);
+
+if (balance.balance < cost) {
+  throw new InsufficientCreditsError(balance.balance, cost);
+}
+
+await creem.customerCredits.debit({
+  account_id: wallet.id,
+  amount: cost,
+  reference: `usage_${usageEvent.id}`,
+  description: `${featureName} — ${cost} credits`,
+}, {
+  idempotencyKey: `usage_${usageEvent.id}`,
+});
+```
+
+---
+
+## Recipe 3: Referral Credits
+
+Credit both referrer and referee when a referred user converts.
+
+```typescript
+// When a referred user completes their first purchase
+async function handleReferralConversion(referrerId: string, newCustomerId: string, orderId: string) {
+  // Credit the referrer
+  await creem.customerCredits.credit({
+    account_id: await getOrCreateAccount(referrerId, 'referral_credits'),
+    amount: 500,
+    reference: `referral_${newCustomerId}_${orderId}`,
+    description: `Referral reward — ${newCustomerId} made their first purchase`,
+  }, {
+    idempotencyKey: `referral_reward_${newCustomerId}`,
+  });
+
+  // Credit the referee (welcome bonus)
+  await creem.customerCredits.credit({
+    account_id: await getOrCreateAccount(newCustomerId, 'referral_credits'),
+    amount: 200,
+    reference: `referred_welcome_${orderId}`,
+    description: 'Welcome bonus — referred by a friend',
+  }, {
+    idempotencyKey: `referred_welcome_${newCustomerId}`,
+  });
+}
+```
+
+---
+
+## Recipe 4: API Usage Metering
+
+Allocate a monthly credit pool for API access, debit per call.
+
+### Monthly Allocation
+
+```typescript
+// On subscription renewal (webhook: subscription.renewed)
+await creem.customerCredits.credit({
+  account_id: apiCreditsAccount.id,
+  amount: plan.monthlyApiCredits,    // e.g., 10000
+  reference: `subscription_${subscription.id}_period_${periodStart}`,
+  description: `Monthly API credit allocation — ${plan.name}`,
+}, {
+  idempotencyKey: `api_alloc_${subscription.id}_${periodStart}`,
+});
+```
+
+### Per-Request Debit
+
+```typescript
+// In your API middleware
+async function deductApiCredit(customerId: string, requestId: string, cost: number = 1) {
+  const account = await getOrCreateAccount(customerId, 'api_credits');
+  const balance = await creem.customerCredits.accounts.getBalance(account.id);
+
+  if (balance.balance <= 0) {
+    throw new RateLimitError('API credit balance exhausted');
+  }
+
+  await creem.customerCredits.debit({
+    account_id: account.id,
+    amount: cost,
+    reference: `api_call_${requestId}`,
+    description: `API call`,
+  }, {
+    idempotencyKey: `api_debit_${requestId}`,
+  });
+}
+```
+
+<Tip>
+  For high-frequency API metering, consider batching debits (e.g., debit every 100 calls) rather than per-request to reduce API overhead. Use the `reference` field to link back to your internal batch records.
+</Tip>
+
+---
+
+## Recipe 5: Promotional Campaign Credits
+
+Issue time-limited credits for a marketing campaign.
+
+```typescript
+// Bulk issue promo credits to a list of customers
+async function issuePromoCampaign(campaignId: string, customerIds: string[], amount: number) {
+  for (const customerId of customerIds) {
+    const account = await getOrCreateAccount(customerId, 'promo_credits');
+
+    await creem.customerCredits.credit({
+      account_id: account.id,
+      amount,
+      reference: `campaign_${campaignId}`,
+      description: `Promotional credits — ${campaignId}`,
+      metadata: {
+        campaign_id: campaignId,
+        expires_at: '2026-05-14T23:59:59Z',  // tracked in your app logic
+      },
+    }, {
+      idempotencyKey: `promo_${campaignId}_${customerId}`,
+    });
+  }
+}
+```
+
+<Info>
+  Expiration logic is handled in your application, not in Creem. Creem stores the credit and its metadata — your app checks the `expires_at` before allowing redemption. This keeps the credit system simple and the business rules in your control.
+</Info>
+
+---
+
+## Recipe 6: Compensation & Goodwill Credits
+
+Issue credits for service disruptions or customer support escalations.
+
+```typescript
+// Support agent issues goodwill credits via your admin panel
+await creem.customerCredits.credit({
+  account_id: customerAccount.id,
+  amount: 100,
+  reference: `support_ticket_${ticketId}`,
+  description: `Goodwill credit — service disruption on ${incidentDate}`,
+  metadata: {
+    support_agent: agentId,
+    ticket_id: ticketId,
+    reason: 'service_disruption',
+  },
+}, {
+  idempotencyKey: `goodwill_${ticketId}`,
+});
+```
+
+---
+
+## Recipe 7: In-Game Currency (Gems / Coins)
+
+Power a virtual economy for games or creator platforms.
+
+```typescript
+// Player earns gems from completing a quest
+await creem.customerCredits.credit({
+  account_id: playerGemsAccount.id,
+  amount: 50,
+  reference: `quest_complete_${questId}_${playerId}`,
+  description: `Quest reward — "${questName}"`,
+}, {
+  idempotencyKey: `quest_reward_${questId}_${playerId}`,
+});
+
+// Player buys an item from the in-game shop
+await creem.customerCredits.debit({
+  account_id: playerGemsAccount.id,
+  amount: item.price,
+  reference: `shop_purchase_${purchaseId}`,
+  description: `Purchased "${item.name}"`,
+}, {
+  idempotencyKey: `shop_${purchaseId}`,
+});
+```
+
+---
+
+## Recipe 8: Reconciliation Without Webhooks
+
+Since v1 ships without webhooks, use the reference field and transaction history for reconciliation.
+
+```typescript
+// Periodically reconcile your orders with credit history
+async function reconcileOrders(accountId: string, since: string) {
+  const entries = await creem.customerCredits.entries.list({
+    account_id: accountId,
+    starting_after: since,
+    limit: 100,
+  });
+
+  for (const entry of entries.data) {
+    // Look up the transaction to get the reference
+    const tx = await creem.customerCredits.transactions.get(entry.transaction_id);
+
+    // Match against your order system
+    const order = await db.orders.findByReference(tx.reference);
+    if (!order) {
+      console.warn(`Unmatched transaction: ${tx.id}, reference: ${tx.reference}`);
+    }
+  }
+}
+```
+
+<Tip>
+  The `reference` field is your primary reconciliation key. Use consistent, predictable references like `order_{id}`, `subscription_{id}_period_{date}`, or `campaign_{id}` to make matching trivial.
+</Tip>

--- a/packages/docs/guides/customer-credits-recipes.mdx
+++ b/packages/docs/guides/customer-credits-recipes.mdx
@@ -254,7 +254,67 @@ curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debi
 
 ---
 
-## Recipe 8: Reconciliation Without Webhooks
+## Recipe 8: AI Wrapper / SaaS Usage Credits
+
+If you're building an AI wrapper (or any SaaS that proxies a paid API), Customer Credits handles the billing balance so you don't have to build it yourself. Customers buy credit packs via Creem checkout, credits get added to their account, and each AI call deducts from their balance.
+
+### Create a Credits Account on Signup
+
+```bash
+curl -X POST https://api.creem.io/v1/customer-credits/accounts \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "customer_id": "cust_abc123",
+    "name": "ai_credits",
+    "unit_label": "credits"
+  }'
+```
+
+### Top Up When Customer Buys a Credit Pack
+
+```bash
+# In your checkout.completed webhook handler
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "5000",
+    "reference": "order_credit_pack_500",
+    "idempotency_key": "topup_order_credit_pack_500"
+  }'
+```
+
+### Deduct Per AI Call
+
+```bash
+# Before proxying to OpenAI/Anthropic, check balance and debit
+# Different models can cost different amounts
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "10",
+    "reference": "ai_call_gpt4_req_abc123",
+    "idempotency_key": "ai_debit_req_abc123"
+  }'
+```
+
+### Check Remaining Balance
+
+```bash
+# Show the user how many credits they have left
+curl https://api.creem.io/v1/customer-credits/accounts/{account_id}/balance \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+<Tip>
+  Price different models at different credit costs (e.g., GPT-4 = 10 credits, GPT-3.5 = 1 credit) by varying the `amount` on each debit. Use the `reference` field to record which model was called for reconciliation.
+</Tip>
+
+---
+
+## Recipe 9: Reconciliation Without Webhooks
 
 Since v1 ships without webhooks, use the reference field and transaction history for reconciliation.
 

--- a/packages/docs/guides/customer-credits-recipes.mdx
+++ b/packages/docs/guides/customer-credits-recipes.mdx
@@ -14,60 +14,57 @@ Award points on purchases, let customers redeem them for discounts.
 
 ### Setup
 
-```typescript
-// When a customer signs up, create their points account
-const account = await creem.customerCredits.accounts.create({
-  owner_id: customer.id,
-  name: 'loyalty_points',
-  unit_label: 'points',
-  initial_credit_amount: 50,           // signup bonus
-  initial_credit_reference: 'signup_bonus',
-});
+```bash
+# Create a points account when a customer signs up
+curl -X POST https://api.creem.io/v1/customer-credits/accounts \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "customer_id": "cust_abc123",
+    "name": "loyalty_points",
+    "unit_label": "points",
+    "initial_balance": "50"
+  }'
 ```
 
 ### Earning Points
 
-```typescript
-// After a successful purchase, credit points (e.g., 1 point per $1)
-await creem.customerCredits.credit({
-  account_id: account.id,
-  amount: Math.floor(order.total_usd),
-  reference: `order_${order.id}`,
-  description: `Purchase reward — Order #${order.id}`,
-}, {
-  idempotencyKey: `loyalty_earn_${order.id}`,
-});
+```bash
+# After a successful purchase, credit points (e.g., 1 point per $1)
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "75",
+    "reference": "order_789",
+    "idempotency_key": "loyalty_earn_order_789"
+  }'
 ```
 
 ### Redeeming Points
 
-```typescript
-// At checkout, debit points for a discount
-const balance = await creem.customerCredits.accounts.getBalance(account.id);
-
-if (balance.balance >= pointsToRedeem) {
-  await creem.customerCredits.debit({
-    account_id: account.id,
-    amount: pointsToRedeem,
-    reference: `checkout_${checkout.id}`,
-    description: `Redeemed ${pointsToRedeem} points for $${discount} discount`,
-  }, {
-    idempotencyKey: `loyalty_redeem_${checkout.id}`,
-  });
-}
+```bash
+# At checkout, debit points for a discount
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "50",
+    "reference": "checkout_456",
+    "idempotency_key": "loyalty_redeem_checkout_456"
+  }'
 ```
 
 ### Handling Order Cancellations
 
-```typescript
-// If the order is cancelled, reverse the earned points
-await creem.customerCredits.transactions.reverse({
-  transaction_id: earnTxId,
-  reference: `order_${order.id}_cancelled`,
-  description: 'Order cancelled — reversing loyalty points',
-}, {
-  idempotencyKey: `loyalty_reverse_${order.id}`,
-});
+```bash
+# If the order is cancelled, reverse the earned points
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/reverse \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "transaction_id": "cct_3mNpK8rW2xY"
+  }'
 ```
 
 ---
@@ -78,48 +75,47 @@ Customers top up a balance and draw down for future purchases.
 
 ### Create the Wallet
 
-```typescript
-const wallet = await creem.customerCredits.accounts.create({
-  owner_id: customer.id,
-  name: 'prepaid_balance',
-  unit_label: 'credits',
-});
+```bash
+curl -X POST https://api.creem.io/v1/customer-credits/accounts \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "customer_id": "cust_abc123",
+    "name": "prepaid_balance",
+    "unit_label": "credits"
+  }'
 ```
 
 ### Top Up After Payment
 
-```typescript
-// After a Creem checkout for a "credit pack" product completes
-// (in your webhook handler for checkout.completed)
-await creem.customerCredits.credit({
-  account_id: wallet.id,
-  amount: creditPack.amount,       // e.g., 1000 credits for the $10 pack
-  reference: `topup_${order.id}`,
-  description: `Purchased ${creditPack.name}`,
-}, {
-  idempotencyKey: `topup_${order.id}`,
-});
+```bash
+# After a Creem checkout for a "credit pack" product completes
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "1000",
+    "reference": "topup_order_123",
+    "idempotency_key": "topup_order_123"
+  }'
 ```
 
 ### Consume Credits
 
-```typescript
-// When the customer uses a feature that costs credits
-const cost = 25;
-const balance = await creem.customerCredits.accounts.getBalance(wallet.id);
+```bash
+# When the customer uses a feature that costs credits
+# First check balance, then debit
+curl https://api.creem.io/v1/customer-credits/accounts/{account_id}/balance \
+  -H "x-api-key: YOUR_API_KEY"
 
-if (balance.balance < cost) {
-  throw new InsufficientCreditsError(balance.balance, cost);
-}
-
-await creem.customerCredits.debit({
-  account_id: wallet.id,
-  amount: cost,
-  reference: `usage_${usageEvent.id}`,
-  description: `${featureName} — ${cost} credits`,
-}, {
-  idempotencyKey: `usage_${usageEvent.id}`,
-});
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "25",
+    "reference": "usage_evt_456",
+    "idempotency_key": "usage_evt_456"
+  }'
 ```
 
 ---
@@ -128,29 +124,26 @@ await creem.customerCredits.debit({
 
 Credit both referrer and referee when a referred user converts.
 
-```typescript
-// When a referred user completes their first purchase
-async function handleReferralConversion(referrerId: string, newCustomerId: string, orderId: string) {
-  // Credit the referrer
-  await creem.customerCredits.credit({
-    account_id: await getOrCreateAccount(referrerId, 'referral_credits'),
-    amount: 500,
-    reference: `referral_${newCustomerId}_${orderId}`,
-    description: `Referral reward — ${newCustomerId} made their first purchase`,
-  }, {
-    idempotencyKey: `referral_reward_${newCustomerId}`,
-  });
+```bash
+# Credit the referrer (500 points)
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{referrer_account_id}/credit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "500",
+    "reference": "referral_cust_newuser_order_789",
+    "idempotency_key": "referral_reward_cust_newuser"
+  }'
 
-  // Credit the referee (welcome bonus)
-  await creem.customerCredits.credit({
-    account_id: await getOrCreateAccount(newCustomerId, 'referral_credits'),
-    amount: 200,
-    reference: `referred_welcome_${orderId}`,
-    description: 'Welcome bonus — referred by a friend',
-  }, {
-    idempotencyKey: `referred_welcome_${newCustomerId}`,
-  });
-}
+# Credit the referee (200 points welcome bonus)
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{referee_account_id}/credit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "200",
+    "reference": "referred_welcome_order_789",
+    "idempotency_key": "referred_welcome_cust_newuser"
+  }'
 ```
 
 ---
@@ -161,39 +154,30 @@ Allocate a monthly credit pool for API access, debit per call.
 
 ### Monthly Allocation
 
-```typescript
-// On subscription renewal (webhook: subscription.renewed)
-await creem.customerCredits.credit({
-  account_id: apiCreditsAccount.id,
-  amount: plan.monthlyApiCredits,    // e.g., 10000
-  reference: `subscription_${subscription.id}_period_${periodStart}`,
-  description: `Monthly API credit allocation — ${plan.name}`,
-}, {
-  idempotencyKey: `api_alloc_${subscription.id}_${periodStart}`,
-});
+```bash
+# On subscription renewal, credit the monthly API allowance
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "10000",
+    "reference": "subscription_sub_123_period_2026-04",
+    "idempotency_key": "api_alloc_sub_123_2026-04"
+  }'
 ```
 
 ### Per-Request Debit
 
-```typescript
-// In your API middleware
-async function deductApiCredit(customerId: string, requestId: string, cost: number = 1) {
-  const account = await getOrCreateAccount(customerId, 'api_credits');
-  const balance = await creem.customerCredits.accounts.getBalance(account.id);
-
-  if (balance.balance <= 0) {
-    throw new RateLimitError('API credit balance exhausted');
-  }
-
-  await creem.customerCredits.debit({
-    account_id: account.id,
-    amount: cost,
-    reference: `api_call_${requestId}`,
-    description: `API call`,
-  }, {
-    idempotencyKey: `api_debit_${requestId}`,
-  });
-}
+```bash
+# In your API middleware, debit 1 credit per call
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "1",
+    "reference": "api_call_req_abc123",
+    "idempotency_key": "api_debit_req_abc123"
+  }'
 ```
 
 <Tip>
@@ -206,30 +190,20 @@ async function deductApiCredit(customerId: string, requestId: string, cost: numb
 
 Issue time-limited credits for a marketing campaign.
 
-```typescript
-// Bulk issue promo credits to a list of customers
-async function issuePromoCampaign(campaignId: string, customerIds: string[], amount: number) {
-  for (const customerId of customerIds) {
-    const account = await getOrCreateAccount(customerId, 'promo_credits');
-
-    await creem.customerCredits.credit({
-      account_id: account.id,
-      amount,
-      reference: `campaign_${campaignId}`,
-      description: `Promotional credits — ${campaignId}`,
-      metadata: {
-        campaign_id: campaignId,
-        expires_at: '2026-05-14T23:59:59Z',  // tracked in your app logic
-      },
-    }, {
-      idempotencyKey: `promo_${campaignId}_${customerId}`,
-    });
-  }
-}
+```bash
+# Issue promo credits to a customer
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "100",
+    "reference": "campaign_summer2026",
+    "idempotency_key": "promo_summer2026_cust_abc123"
+  }'
 ```
 
 <Info>
-  Expiration logic is handled in your application, not in Creem. Creem stores the credit and its metadata — your app checks the `expires_at` before allowing redemption. This keeps the credit system simple and the business rules in your control.
+  Expiration logic is handled in your application, not in Creem. Creem stores the credit and its metadata — your app checks the expiry before allowing redemption. This keeps the credit system simple and the business rules in your control.
 </Info>
 
 ---
@@ -238,21 +212,16 @@ async function issuePromoCampaign(campaignId: string, customerIds: string[], amo
 
 Issue credits for service disruptions or customer support escalations.
 
-```typescript
-// Support agent issues goodwill credits via your admin panel
-await creem.customerCredits.credit({
-  account_id: customerAccount.id,
-  amount: 100,
-  reference: `support_ticket_${ticketId}`,
-  description: `Goodwill credit — service disruption on ${incidentDate}`,
-  metadata: {
-    support_agent: agentId,
-    ticket_id: ticketId,
-    reason: 'service_disruption',
-  },
-}, {
-  idempotencyKey: `goodwill_${ticketId}`,
-});
+```bash
+# Support agent issues goodwill credits
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "100",
+    "reference": "support_ticket_TK-4567",
+    "idempotency_key": "goodwill_TK-4567"
+  }'
 ```
 
 ---
@@ -261,26 +230,26 @@ await creem.customerCredits.credit({
 
 Power a virtual economy for games or creator platforms.
 
-```typescript
-// Player earns gems from completing a quest
-await creem.customerCredits.credit({
-  account_id: playerGemsAccount.id,
-  amount: 50,
-  reference: `quest_complete_${questId}_${playerId}`,
-  description: `Quest reward — "${questName}"`,
-}, {
-  idempotencyKey: `quest_reward_${questId}_${playerId}`,
-});
+```bash
+# Player earns gems from completing a quest
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "50",
+    "reference": "quest_complete_dragon_slayer_player_123",
+    "idempotency_key": "quest_reward_dragon_slayer_player_123"
+  }'
 
-// Player buys an item from the in-game shop
-await creem.customerCredits.debit({
-  account_id: playerGemsAccount.id,
-  amount: item.price,
-  reference: `shop_purchase_${purchaseId}`,
-  description: `Purchased "${item.name}"`,
-}, {
-  idempotencyKey: `shop_${purchaseId}`,
-});
+# Player buys an item from the in-game shop
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "30",
+    "reference": "shop_purchase_magic_sword_001",
+    "idempotency_key": "shop_magic_sword_001"
+  }'
 ```
 
 ---
@@ -289,27 +258,13 @@ await creem.customerCredits.debit({
 
 Since v1 ships without webhooks, use the reference field and transaction history for reconciliation.
 
-```typescript
-// Periodically reconcile your orders with credit history
-async function reconcileOrders(accountId: string, since: string) {
-  const entries = await creem.customerCredits.entries.list({
-    account_id: accountId,
-    starting_after: since,
-    limit: 100,
-  });
-
-  for (const entry of entries.data) {
-    // Look up the transaction to get the reference
-    const tx = await creem.customerCredits.transactions.get(entry.transaction_id);
-
-    // Match against your order system
-    const order = await db.orders.findByReference(tx.reference);
-    if (!order) {
-      console.warn(`Unmatched transaction: ${tx.id}, reference: ${tx.reference}`);
-    }
-  }
-}
+```bash
+# List recent entries for an account
+curl "https://api.creem.io/v1/customer-credits/accounts/{account_id}/entries?limit=100" \
+  -H "x-api-key: YOUR_API_KEY"
 ```
+
+Each entry includes a `transaction_id` — you can look up the full transaction to get the `reference` field, which links back to your order system.
 
 <Tip>
   The `reference` field is your primary reconciliation key. Use consistent, predictable references like `order_{id}`, `subscription_{id}_period_{date}`, or `campaign_{id}` to make matching trivial.

--- a/packages/docs/guides/customer-credits-recipes.mdx
+++ b/packages/docs/guides/customer-credits-recipes.mdx
@@ -1,331 +1,188 @@
 ---
 title: 'Customer Credits Recipes'
 sidebarTitle: 'Credits Recipes'
-description: 'Step-by-step guides for common Customer Credits use cases: loyalty programs, prepaid wallets, referral systems, usage metering, and more.'
+description: 'Copy-paste examples for common credit use cases.'
 ---
 
 <Note>
-  Customer Credits is currently in **Experimental** preview.
+  Customer Credits is in **Experimental** preview.
 </Note>
 
-## Recipe 1: Loyalty Points Program
+## Loyalty points
 
-Award points on purchases, let customers redeem them for discounts.
-
-### Setup
+Award points on purchases, let customers redeem them later.
 
 ```bash
-# Create a points account when a customer signs up
+# Create a points account
 curl -X POST https://api.creem.io/v1/customer-credits/accounts \
   -H "x-api-key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-    "customer_id": "cust_abc123",
-    "name": "loyalty_points",
-    "unit_label": "points",
-    "initial_balance": "50"
-  }'
-```
+  -d '{ "customer_id": "cust_abc123", "name": "loyalty_points", "unit_label": "points", "initial_balance": "50" }'
 
-### Earning Points
-
-```bash
-# After a successful purchase, credit points (e.g., 1 point per $1)
+# Award points after a purchase
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
   -H "x-api-key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-    "amount": "75",
-    "reference": "order_789",
-    "idempotency_key": "loyalty_earn_order_789"
-  }'
-```
+  -d '{ "amount": "75", "reference": "order_789", "idempotency_key": "loyalty_earn_order_789" }'
 
-### Redeeming Points
-
-```bash
-# At checkout, debit points for a discount
+# Redeem points at checkout
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
   -H "x-api-key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-    "amount": "50",
-    "reference": "checkout_456",
-    "idempotency_key": "loyalty_redeem_checkout_456"
-  }'
-```
+  -d '{ "amount": "50", "reference": "checkout_456", "idempotency_key": "loyalty_redeem_checkout_456" }'
 
-### Handling Order Cancellations
-
-```bash
-# If the order is cancelled, reverse the earned points
+# Order cancelled? Reverse the points
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/reverse \
   -H "x-api-key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-    "transaction_id": "cct_3mNpK8rW2xY"
-  }'
+  -d '{ "transaction_id": "cct_3mNpK8rW2xY" }'
 ```
 
 ---
 
-## Recipe 2: Prepaid Credit Balance
+## Prepaid balance
 
-Customers top up a balance and draw down for future purchases.
-
-### Create the Wallet
+Customers buy credit packs, then spend them over time.
 
 ```bash
+# Create wallet
 curl -X POST https://api.creem.io/v1/customer-credits/accounts \
   -H "x-api-key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-    "customer_id": "cust_abc123",
-    "name": "prepaid_balance",
-    "unit_label": "credits"
-  }'
-```
+  -d '{ "customer_id": "cust_abc123", "name": "prepaid_balance", "unit_label": "credits" }'
 
-### Top Up After Payment
-
-```bash
-# After a Creem checkout for a "credit pack" product completes
+# Top up after they buy a credit pack (in your checkout.completed webhook)
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
   -H "x-api-key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-    "amount": "1000",
-    "reference": "topup_order_123",
-    "idempotency_key": "topup_order_123"
-  }'
+  -d '{ "amount": "1000", "reference": "topup_order_123", "idempotency_key": "topup_order_123" }'
+
+# Deduct when they use a feature
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "amount": "25", "reference": "usage_evt_456", "idempotency_key": "usage_evt_456" }'
 ```
 
-### Consume Credits
+---
+
+## AI product credits
+
+Sell credit packs for your AI product. Deduct per API call — different models can cost different amounts.
 
 ```bash
-# When the customer uses a feature that costs credits
-# First check balance, then debit
+# Create credits account on signup
+curl -X POST https://api.creem.io/v1/customer-credits/accounts \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "customer_id": "cust_abc123", "name": "ai_credits", "unit_label": "credits" }'
+
+# Customer buys a credit pack → top up
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "amount": "5000", "reference": "order_credit_pack_500", "idempotency_key": "topup_order_credit_pack_500" }'
+
+# Deduct per AI call (e.g., 10 credits for a premium model)
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "amount": "10", "reference": "ai_call_gpt4_req_abc123", "idempotency_key": "ai_debit_req_abc123" }'
+
+# Check remaining balance
 curl https://api.creem.io/v1/customer-credits/accounts/{account_id}/balance \
   -H "x-api-key: YOUR_API_KEY"
-
-curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
-  -H "x-api-key: YOUR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "amount": "25",
-    "reference": "usage_evt_456",
-    "idempotency_key": "usage_evt_456"
-  }'
-```
-
----
-
-## Recipe 3: Referral Credits
-
-Credit both referrer and referee when a referred user converts.
-
-```bash
-# Credit the referrer (500 points)
-curl -X POST https://api.creem.io/v1/customer-credits/accounts/{referrer_account_id}/credit \
-  -H "x-api-key: YOUR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "amount": "500",
-    "reference": "referral_cust_newuser_order_789",
-    "idempotency_key": "referral_reward_cust_newuser"
-  }'
-
-# Credit the referee (200 points welcome bonus)
-curl -X POST https://api.creem.io/v1/customer-credits/accounts/{referee_account_id}/credit \
-  -H "x-api-key: YOUR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "amount": "200",
-    "reference": "referred_welcome_order_789",
-    "idempotency_key": "referred_welcome_cust_newuser"
-  }'
-```
-
----
-
-## Recipe 4: API Usage Metering
-
-Allocate a monthly credit pool for API access, debit per call.
-
-### Monthly Allocation
-
-```bash
-# On subscription renewal, credit the monthly API allowance
-curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
-  -H "x-api-key: YOUR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "amount": "10000",
-    "reference": "subscription_sub_123_period_2026-04",
-    "idempotency_key": "api_alloc_sub_123_2026-04"
-  }'
-```
-
-### Per-Request Debit
-
-```bash
-# In your API middleware, debit 1 credit per call
-curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
-  -H "x-api-key: YOUR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "amount": "1",
-    "reference": "api_call_req_abc123",
-    "idempotency_key": "api_debit_req_abc123"
-  }'
 ```
 
 <Tip>
-  For high-frequency API metering, consider batching debits (e.g., debit every 100 calls) rather than per-request to reduce API overhead. Use the `reference` field to link back to your internal batch records.
+  Price different models at different credit costs (e.g., premium = 10 credits, standard = 1 credit). Use the `reference` field to record which model was called.
 </Tip>
 
 ---
 
-## Recipe 5: Promotional Campaign Credits
+## Referral credits
 
-Issue time-limited credits for a marketing campaign.
+Credit both sides when a referred user converts.
 
 ```bash
-# Issue promo credits to a customer
+# Credit the referrer
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{referrer_account_id}/credit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "amount": "500", "reference": "referral_cust_newuser", "idempotency_key": "referral_reward_cust_newuser" }'
+
+# Credit the new user (welcome bonus)
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{referee_account_id}/credit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "amount": "200", "reference": "referred_welcome", "idempotency_key": "referred_welcome_cust_newuser" }'
+```
+
+---
+
+## API usage metering
+
+Give customers a monthly credit allowance, deduct per API call.
+
+```bash
+# Monthly allocation (in your subscription.renewed webhook)
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
   -H "x-api-key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-    "amount": "100",
-    "reference": "campaign_summer2026",
-    "idempotency_key": "promo_summer2026_cust_abc123"
-  }'
+  -d '{ "amount": "10000", "reference": "subscription_sub_123_period_2026-04", "idempotency_key": "api_alloc_sub_123_2026-04" }'
+
+# Deduct per call
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "amount": "1", "reference": "api_call_req_abc123", "idempotency_key": "api_debit_req_abc123" }'
+```
+
+<Tip>
+  For high-volume APIs, batch debits (e.g., debit every 100 calls) instead of one-per-request.
+</Tip>
+
+---
+
+## Promo credits
+
+Issue credits for a marketing campaign.
+
+```bash
+curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "amount": "100", "reference": "campaign_summer2026", "idempotency_key": "promo_summer2026_cust_abc123" }'
 ```
 
 <Info>
-  Expiration logic is handled in your application, not in Creem. Creem stores the credit and its metadata — your app checks the expiry before allowing redemption. This keeps the credit system simple and the business rules in your control.
+  Expiration is up to your app — Creem stores the credit, your app decides when it's no longer redeemable.
 </Info>
 
 ---
 
-## Recipe 6: Compensation & Goodwill Credits
+## Goodwill credits
 
-Issue credits for service disruptions or customer support escalations.
+Issue credits for service disruptions or support escalations.
 
 ```bash
-# Support agent issues goodwill credits
 curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
   -H "x-api-key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-    "amount": "100",
-    "reference": "support_ticket_TK-4567",
-    "idempotency_key": "goodwill_TK-4567"
-  }'
+  -d '{ "amount": "100", "reference": "support_ticket_TK-4567", "idempotency_key": "goodwill_TK-4567" }'
 ```
 
 ---
 
-## Recipe 7: In-Game Currency (Gems / Coins)
+## Reconciliation
 
-Power a virtual economy for games or creator platforms.
-
-```bash
-# Player earns gems from completing a quest
-curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
-  -H "x-api-key: YOUR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "amount": "50",
-    "reference": "quest_complete_dragon_slayer_player_123",
-    "idempotency_key": "quest_reward_dragon_slayer_player_123"
-  }'
-
-# Player buys an item from the in-game shop
-curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
-  -H "x-api-key: YOUR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "amount": "30",
-    "reference": "shop_purchase_magic_sword_001",
-    "idempotency_key": "shop_magic_sword_001"
-  }'
-```
-
----
-
-## Recipe 8: AI Wrapper / SaaS Usage Credits
-
-If you're building an AI wrapper (or any SaaS that proxies a paid API), Customer Credits handles the billing balance so you don't have to build it yourself. Customers buy credit packs via Creem checkout, credits get added to their account, and each AI call deducts from their balance.
-
-### Create a Credits Account on Signup
+Use the `reference` field and entry history to match credits back to your system.
 
 ```bash
-curl -X POST https://api.creem.io/v1/customer-credits/accounts \
-  -H "x-api-key: YOUR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "customer_id": "cust_abc123",
-    "name": "ai_credits",
-    "unit_label": "credits"
-  }'
-```
-
-### Top Up When Customer Buys a Credit Pack
-
-```bash
-# In your checkout.completed webhook handler
-curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/credit \
-  -H "x-api-key: YOUR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "amount": "5000",
-    "reference": "order_credit_pack_500",
-    "idempotency_key": "topup_order_credit_pack_500"
-  }'
-```
-
-### Deduct Per AI Call
-
-```bash
-# Before proxying to OpenAI/Anthropic, check balance and debit
-# Different models can cost different amounts
-curl -X POST https://api.creem.io/v1/customer-credits/accounts/{account_id}/debit \
-  -H "x-api-key: YOUR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "amount": "10",
-    "reference": "ai_call_gpt4_req_abc123",
-    "idempotency_key": "ai_debit_req_abc123"
-  }'
-```
-
-### Check Remaining Balance
-
-```bash
-# Show the user how many credits they have left
-curl https://api.creem.io/v1/customer-credits/accounts/{account_id}/balance \
-  -H "x-api-key: YOUR_API_KEY"
-```
-
-<Tip>
-  Price different models at different credit costs (e.g., GPT-4 = 10 credits, GPT-3.5 = 1 credit) by varying the `amount` on each debit. Use the `reference` field to record which model was called for reconciliation.
-</Tip>
-
----
-
-## Recipe 9: Reconciliation Without Webhooks
-
-Since v1 ships without webhooks, use the reference field and transaction history for reconciliation.
-
-```bash
-# List recent entries for an account
 curl "https://api.creem.io/v1/customer-credits/accounts/{account_id}/entries?limit=100" \
   -H "x-api-key: YOUR_API_KEY"
 ```
 
-Each entry includes a `transaction_id` — you can look up the full transaction to get the `reference` field, which links back to your order system.
-
 <Tip>
-  The `reference` field is your primary reconciliation key. Use consistent, predictable references like `order_{id}`, `subscription_{id}_period_{date}`, or `campaign_{id}` to make matching trivial.
+  Use consistent references like `order_{id}` or `subscription_{id}_period_{date}` — they make reconciliation trivial.
 </Tip>


### PR DESCRIPTION
## What

Public documentation for the Customer Credits feature (Experimental).

### Files added

| File | Description |
|------|-------------|
| `features/customer-credits/introduction.mdx` | Overview, how it works, core concepts, 8 use case cards, quick start (SDK + REST) |
| `features/customer-credits/accounts.mdx` | Create, list, balance, freeze/unfreeze, close, delete |
| `features/customer-credits/transactions.mdx` | Credit, debit, reverse, history listing, idempotency contract |
| `guides/customer-credits-recipes.mdx` | 8 step-by-step recipes: loyalty, prepaid, referral, API metering, promo, goodwill, gaming, reconciliation |
| `docs.json` | Navigation entries in Features + Guides tabs |

### Notes

- All descriptions use merchant-friendly language — no accounting/ledger jargon
- All pages marked as Experimental preview
- SDK examples assume a future `customerCredits` namespace in `creem_io` (ENG-268)
- OpenAPI spec was already updated in #26 with the simplified endpoint descriptions
- Reverse endpoint documented as `POST /accounts/:id/reverse` (matching the simplified public API)