### PR TITLE
feat: add x-speakeasy-pagination to all paginated endpoints

### DIFF
--- a/packages/creem-sdk/openapi.json
+++ b/packages/creem-sdk/openapi.json
@@ -152,7 +152,26 @@
           {
             "ApiKey": []
           }
-        ]
+        ],
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "page_number",
+              "in": "parameters",
+              "type": "page"
+            },
+            {
+              "name": "page_size",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "numPages": "$.pagination.total_pages",
+            "results": "$.items"
+          }
+        }
       }
     },
     "/v1/customers/list": {
@@ -212,7 +231,26 @@
           {
             "ApiKey": []
           }
-        ]
+        ],
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "page_number",
+              "in": "parameters",
+              "type": "page"
+            },
+            {
+              "name": "page_size",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "numPages": "$.pagination.total_pages",
+            "results": "$.items"
+          }
+        }
       }
     },
     "/v1/customers": {
@@ -426,7 +464,26 @@
           {
             "ApiKey": []
           }
-        ]
+        ],
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "page_number",
+              "in": "parameters",
+              "type": "page"
+            },
+            {
+              "name": "page_size",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "numPages": "$.pagination.total_pages",
+            "results": "$.items"
+          }
+        }
       }
     },
     "/v1/subscriptions/{id}/cancel": {
@@ -1048,7 +1105,26 @@
           {
             "ApiKey": []
           }
-        ]
+        ],
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "page_number",
+              "in": "parameters",
+              "type": "page"
+            },
+            {
+              "name": "page_size",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "numPages": "$.pagination.total_pages",
+            "results": "$.items"
+          }
+        }
       }
     },
     "/v1/discounts": {
@@ -1337,7 +1413,26 @@
           {
             "ApiKey": []
           }
-        ]
+        ],
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "page_number",
+              "in": "parameters",
+              "type": "page"
+            },
+            {
+              "name": "page_size",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "numPages": "$.pagination.total_pages",
+            "results": "$.items"
+          }
+        }
       }
     },
     "/v1/stats/summary": {
@@ -2049,7 +2144,7 @@
           },
           "object": {
             "type": "string",
-            "description": "String representing the object’s type. Objects of the same type share the same value."
+            "description": "String representing the object\u2019s type. Objects of the same type share the same value."
           },
           "email": {
             "type": "string",
@@ -2151,7 +2246,7 @@
           },
           "object": {
             "type": "string",
-            "description": "String representing the object’s type. Objects of the same type share the same value."
+            "description": "String representing the object\u2019s type. Objects of the same type share the same value."
           },
           "product_id": {
             "type": "string",
@@ -2722,7 +2817,7 @@
           },
           "object": {
             "type": "string",
-            "description": "A string representing the object’s type. Objects of the same type share the same value.",
+            "description": "A string representing the object\u2019s type. Objects of the same type share the same value.",
             "example": "license-instance"
           },
           "name": {
@@ -3204,7 +3299,7 @@
           },
           "object": {
             "type": "string",
-            "description": "A string representing the object’s type. Objects of the same type share the same value.",
+            "description": "A string representing the object\u2019s type. Objects of the same type share the same value.",
             "example": "discount"
           },
           "status": {


### PR DESCRIPTION
## Summary

Adds the `x-speakeasy-pagination` extension to all 5 paginated list/search endpoints in the OpenAPI spec. This enables Speakeasy to auto-generate `.next()` pagination methods in the TypeScript SDK, giving users a much nicer DX:

```typescript
let response = await creem.products.search({ pageNumber: 1, pageSize: 20 });
while (response) {
  // handle response.items
  response = await response.next();
}
```

## Endpoints Updated

| Endpoint | Operation |
|----------|-----------|
| `GET /v1/products/search` | searchProducts |
| `GET /v1/customers/list` | listCustomers |
| `GET /v1/subscriptions/search` | searchSubscriptions |
| `GET /v1/discounts/search` | searchDiscounts |
| `GET /v1/transactions/search` | searchTransactions |

## Pagination Config

All endpoints use the same pattern:
- **Type:** `offsetLimit` (page-based)
- **Inputs:** `page_number` (page) + `page_size` (limit)
- **Outputs:** `$.pagination.total_pages` (numPages) + `$.items` (results)

The SDK will auto-increment `page_number` on each `.next()` call and stop when `page_number > total_pages` or when `items` is empty (fewer results than `page_size`).

## Reference
- [Speakeasy Pagination Docs](https://www.speakeasy.com/docs/sdks/customize/runtime/pagination)
- Closes ENG-320