### PR TITLE
docs: remove per-affiliate commission and product restriction features from affiliate program documentation

### DIFF
--- a/packages/docs/features/affiliate-program.mdx
+++ b/packages/docs/features/affiliate-program.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Affiliate Program'
 sidebarTitle: 'Affiliate Program'
-description: 'Launch your own affiliate marketing program to grow revenue through partner referrals. Invite affiliates, set custom commission rates, and track performance from your dashboard.'
+description: 'Launch your own affiliate marketing program to grow revenue through partner referrals. Invite affiliates, set a program commission rate, and track performance from your dashboard.'
 ---
 
 The Creem Affiliate Platform is a complete affiliate marketing solution that enables merchants to create referral programs and affiliates to earn commissions by promoting products. The platform handles tracking, attribution, payouts, and compliance automatically.
@@ -136,13 +136,25 @@ The Affiliate Hub provides comprehensive analytics for your program:
 | **Conversions** | Conversion rate (sales / unique leads) |
 | **Affiliates** | Number of active affiliate partners |
 
-### Managing Individual Affiliates
+### Partners List
 
-Click on any affiliate in your Partners list to open their details panel. From here you can:
+The Partners list shows each affiliate in your program and their current performance at a glance:
 
-- **Set Custom Commission Rate**: Override the program default (0-95%)
-- **Select Allowed Products**: Restrict which products this affiliate can promote
-- **View Performance**: See clicks, conversions, and earnings for this affiliate
+| Column | Description |
+|--------|-------------|
+| **Name** | Affiliate's display name |
+| **Email** | Affiliate's email address |
+| **Status** | Current partner status, such as Active or Invited |
+| **Clicks** | Total clicks tracked for this affiliate |
+| **Conversions** | Total referred purchases for this affiliate |
+| **Conversion Rate** | Percentage of clicks that converted into purchases |
+| **Earnings** | Total commissions earned by this affiliate |
+
+#### Limitations
+
+At this time, managing individual partners is not supported, including deleting pending affiliate invitations, setting per-affiliate commission rates, or configuring per-affiliate product restrictions.
+
+Want this workflow? Upvote and follow the [Manage affiliate partners feature request](https://creem.featurebase.app/en/p/manage-affiliate-partners) to get updates if it is implemented.
 
 ---
 
@@ -314,12 +326,6 @@ If you're an affiliate for multiple merchants, you can switch between programs u
 | **Payout Threshold** | Minimum balance required for withdrawal | None |
 | **Requires Approval** | Whether new affiliates need manual approval | Yes |
 | **Public Program** | Whether anyone can join without invitation | No |
-
-### Per-Affiliate Overrides
-
-Merchants can customize settings for individual affiliates:
-- Custom commission rates (override program default)
-- Product restrictions (limit which products an affiliate can promote)
 
 ---
 


### PR DESCRIPTION
This PR solves the users' confusion in https://discord.com/channels/1262843562140241952/1495822723883208834/1495822723883208834 

I've also referenced a feature request for user demand and tracking https://creem.featurebase.app/en/p/manage-affiliate-partners, but it may be worth polishing the description of the feature request to something like:

```
Merchants should be able to manage individual affiliate partners from the Affiliate Hub.

This could include:
- Opening a partner details view from the Partners list
- Removing pending affiliate invitations or existing partners
- Setting a custom commission rate for a specific affiliate
- Restricting which products a specific affiliate can promote

Today, the Partners list only shows partner-level performance metrics such as clicks, conversions, conversion rate, and earnings.
```
