### PR TITLE
fix(better-auth): await user-facing webhook callbacks

### DIFF
--- a/.changeset/await-user-callbacks.md
+++ b/.changeset/await-user-callbacks.md
@@ -1,0 +1,9 @@
+---
+"@creem_io/better-auth": patch
+---
+
+Await user-facing webhook callbacks so async work completes on serverless
+
+User-facing callbacks (`onCheckoutCompleted`, `onSubscriptionActive`, `onGrantAccess`, `onRevokeAccess`, etc.) were invoked without `await`, causing returned Promises to be silently dropped on serverless runtimes (Cloudflare Workers, Vercel Edge) where the worker terminates before async DB writes / API calls complete. Callback signatures in `CreemOptions` are widened from `=> void` to `=> void | Promise<void>` to match the JSDoc examples (which already showed `async` callbacks).
+
+Credit: original fix by @nirgn975 in armitage-labs/creem-betterauth#20.

--- a/packages/better-auth/src/__tests__/webhook.test.ts
+++ b/packages/better-auth/src/__tests__/webhook.test.ts
@@ -335,4 +335,86 @@ describe("webhook handler", () => {
     const ctx = await callWebhook(defaultOptions, event);
     expect(ctx.json).toHaveBeenCalledWith({ error: "Failed to process webhook" }, { status: 500 });
   });
+
+  // Regression: async user callbacks must be awaited so async work (DB writes,
+  // API calls) finishes before the response returns. Without await, serverless
+  // runtimes (Cloudflare Workers, Vercel Edge) terminate the worker and drop
+  // the pending Promise.
+  describe("async user-facing callbacks are awaited", () => {
+    const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+    it("awaits onCheckoutCompleted before returning", async () => {
+      let completed = false;
+      const onCheckoutCompleted = vi.fn(async () => {
+        await flushMicrotasks();
+        completed = true;
+      });
+      const options = { ...defaultOptions, onCheckoutCompleted };
+      const event = {
+        eventType: "checkout.completed",
+        id: "e1",
+        created_at: 1234567890,
+        object: mockCheckout,
+      };
+      await callWebhook(options, event);
+      expect(completed).toBe(true);
+    });
+
+    it("awaits onGrantAccess and onSubscriptionActive before returning", async () => {
+      let grantDone = false;
+      let activeDone = false;
+      const onGrantAccess = vi.fn(async () => {
+        await flushMicrotasks();
+        grantDone = true;
+      });
+      const onSubscriptionActive = vi.fn(async () => {
+        await flushMicrotasks();
+        activeDone = true;
+      });
+      const options = { ...defaultOptions, onGrantAccess, onSubscriptionActive };
+      const event = {
+        eventType: "subscription.active",
+        id: "e1",
+        created_at: 1234567890,
+        object: mockSubscription,
+      };
+      await callWebhook(options, event);
+      expect(grantDone).toBe(true);
+      expect(activeDone).toBe(true);
+    });
+
+    it("awaits onRevokeAccess on subscription.expired", async () => {
+      let revoked = false;
+      const onRevokeAccess = vi.fn(async () => {
+        await flushMicrotasks();
+        revoked = true;
+      });
+      const options = { ...defaultOptions, onRevokeAccess };
+      const event = {
+        eventType: "subscription.expired",
+        id: "e1",
+        created_at: 1234567890,
+        object: { ...mockSubscription, status: "expired" },
+      };
+      await callWebhook(options, event);
+      expect(revoked).toBe(true);
+    });
+
+    it("awaits onRefundCreated before returning", async () => {
+      let done = false;
+      const onRefundCreated = vi.fn(async () => {
+        await flushMicrotasks();
+        done = true;
+      });
+      const options = { ...defaultOptions, onRefundCreated };
+      const event = {
+        eventType: "refund.created",
+        id: "e1",
+        created_at: 1234567890,
+        object: mockRefund,
+      };
+      await callWebhook(options, event);
+      expect(done).toBe(true);
+    });
+  });
 });

--- a/packages/better-auth/src/__tests__/webhook.test.ts
+++ b/packages/better-auth/src/__tests__/webhook.test.ts
@@ -341,12 +341,12 @@ describe("webhook handler", () => {
   // runtimes (Cloudflare Workers, Vercel Edge) terminate the worker and drop
   // the pending Promise.
   describe("async user-facing callbacks are awaited", () => {
-    const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 10));
+    const delayMacrotask = () => new Promise((resolve) => setTimeout(resolve, 10));
 
     it("awaits onCheckoutCompleted before returning", async () => {
       let completed = false;
       const onCheckoutCompleted = vi.fn(async () => {
-        await flushMicrotasks();
+        await delayMacrotask();
         completed = true;
       });
       const options = { ...defaultOptions, onCheckoutCompleted };
@@ -364,11 +364,11 @@ describe("webhook handler", () => {
       let grantDone = false;
       let activeDone = false;
       const onGrantAccess = vi.fn(async () => {
-        await flushMicrotasks();
+        await delayMacrotask();
         grantDone = true;
       });
       const onSubscriptionActive = vi.fn(async () => {
-        await flushMicrotasks();
+        await delayMacrotask();
         activeDone = true;
       });
       const options = { ...defaultOptions, onGrantAccess, onSubscriptionActive };
@@ -386,7 +386,7 @@ describe("webhook handler", () => {
     it("awaits onRevokeAccess on subscription.expired", async () => {
       let revoked = false;
       const onRevokeAccess = vi.fn(async () => {
-        await flushMicrotasks();
+        await delayMacrotask();
         revoked = true;
       });
       const options = { ...defaultOptions, onRevokeAccess };
@@ -403,7 +403,7 @@ describe("webhook handler", () => {
     it("awaits onRefundCreated before returning", async () => {
       let done = false;
       const onRefundCreated = vi.fn(async () => {
-        await flushMicrotasks();
+        await delayMacrotask();
         done = true;
       });
       const options = { ...defaultOptions, onRefundCreated };

--- a/packages/better-auth/src/types.ts
+++ b/packages/better-auth/src/types.ts
@@ -153,19 +153,19 @@ export interface CreemOptions {
    *   console.log(`Checkout completed: ${customer?.email} purchased ${product.name}`);
    * }
    */
-  onCheckoutCompleted?: (data: FlatCheckoutCompleted) => void;
+  onCheckoutCompleted?: (data: FlatCheckoutCompleted) => void | Promise<void>;
 
   /**
    * Called when a refund is created.
    * All properties are flattened for easy destructuring.
    */
-  onRefundCreated?: (data: FlatRefundCreated) => void;
+  onRefundCreated?: (data: FlatRefundCreated) => void | Promise<void>;
 
   /**
    * Called when a dispute is created.
    * All properties are flattened for easy destructuring.
    */
-  onDisputeCreated?: (data: FlatDisputeCreated) => void;
+  onDisputeCreated?: (data: FlatDisputeCreated) => void | Promise<void>;
 
   /**
    * Called when a subscription becomes active.
@@ -177,55 +177,71 @@ export interface CreemOptions {
    *   console.log(`${customer.email} subscribed to ${product.name}`);
    * }
    */
-  onSubscriptionActive?: (data: FlatSubscriptionEvent<"subscription.active">) => void;
+  onSubscriptionActive?: (
+    data: FlatSubscriptionEvent<"subscription.active">,
+  ) => void | Promise<void>;
 
   /**
    * Called when a subscription is in trialing state.
    * All properties are flattened for easy destructuring.
    */
-  onSubscriptionTrialing?: (data: FlatSubscriptionEvent<"subscription.trialing">) => void;
+  onSubscriptionTrialing?: (
+    data: FlatSubscriptionEvent<"subscription.trialing">,
+  ) => void | Promise<void>;
 
   /**
    * Called when a subscription is canceled.
    * All properties are flattened for easy destructuring.
    */
-  onSubscriptionCanceled?: (data: FlatSubscriptionEvent<"subscription.canceled">) => void;
+  onSubscriptionCanceled?: (
+    data: FlatSubscriptionEvent<"subscription.canceled">,
+  ) => void | Promise<void>;
 
   /**
    * Called when a subscription is paid.
    * All properties are flattened for easy destructuring.
    */
-  onSubscriptionPaid?: (data: FlatSubscriptionEvent<"subscription.paid">) => void;
+  onSubscriptionPaid?: (data: FlatSubscriptionEvent<"subscription.paid">) => void | Promise<void>;
 
   /**
    * Called when a subscription has expired.
    * All properties are flattened for easy destructuring.
    */
-  onSubscriptionExpired?: (data: FlatSubscriptionEvent<"subscription.expired">) => void;
+  onSubscriptionExpired?: (
+    data: FlatSubscriptionEvent<"subscription.expired">,
+  ) => void | Promise<void>;
 
   /**
    * Called when a subscription is unpaid.
    * All properties are flattened for easy destructuring.
    */
-  onSubscriptionUnpaid?: (data: FlatSubscriptionEvent<"subscription.unpaid">) => void;
+  onSubscriptionUnpaid?: (
+    data: FlatSubscriptionEvent<"subscription.unpaid">,
+  ) => void | Promise<void>;
 
   /**
    * Called when a subscription is updated.
    * All properties are flattened for easy destructuring.
    */
-  onSubscriptionUpdate?: (data: FlatSubscriptionEvent<"subscription.update">) => void;
+  onSubscriptionUpdate?: (
+    data: FlatSubscriptionEvent<"subscription.update">,
+  ) => void | Promise<void>;
 
   /**
    * Called when a subscription is past due.
    * All properties are flattened for easy destructuring.
    */
-  onSubscriptionPastDue?: (data: FlatSubscriptionEvent<"subscription.past_due">) => void;
+  onSubscriptionPastDue?: (
+    data: FlatSubscriptionEvent<"subscription.past_due">,
+  ) => void | Promise<void>;
 
   /**
    * Called when a subscription is paused.
    * All properties are flattened for easy destructuring.
    */
-  onSubscriptionPaused?: (data: FlatSubscriptionEvent<"subscription.paused">) => void;
+  onSubscriptionPaused?: (
+    data: FlatSubscriptionEvent<"subscription.paused">,
+  ) => void | Promise<void>;
 
   /**
    * Called when a user should be granted access to the platform.

--- a/packages/better-auth/src/webhook.ts
+++ b/packages/better-auth/src/webhook.ts
@@ -45,10 +45,15 @@ const createWebhookHandler = (options: CreemOptions) => {
       // TypeScript now knows the exact event type in each case
       // The parsed event from Creem webhooks always has expanded objects
       // We flatten the structure for easier destructuring in callbacks
+      //
+      // All user-facing callbacks are awaited so async work (DB writes, API calls)
+      // completes before the response returns. Without await, serverless runtimes
+      // (Cloudflare Workers, Vercel Edge) terminate the worker and silently drop
+      // the pending Promise.
       switch (event.eventType) {
         case "checkout.completed":
           await onCheckoutCompleted(ctx, event, options);
-          options.onCheckoutCompleted?.({
+          await options.onCheckoutCompleted?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -57,7 +62,7 @@ const createWebhookHandler = (options: CreemOptions) => {
           break;
 
         case "refund.created":
-          options.onRefundCreated?.({
+          await options.onRefundCreated?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -66,7 +71,7 @@ const createWebhookHandler = (options: CreemOptions) => {
           break;
 
         case "dispute.created":
-          options.onDisputeCreated?.({
+          await options.onDisputeCreated?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -76,11 +81,11 @@ const createWebhookHandler = (options: CreemOptions) => {
 
         case "subscription.active":
           await onSubscriptionActive(ctx, event, options);
-          options.onGrantAccess?.({
+          await options.onGrantAccess?.({
             reason: "subscription_active",
             ...event.object,
           });
-          options.onSubscriptionActive?.({
+          await options.onSubscriptionActive?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -90,11 +95,11 @@ const createWebhookHandler = (options: CreemOptions) => {
 
         case "subscription.trialing":
           await onSubscriptionTrialing(ctx, event, options);
-          options.onGrantAccess?.({
+          await options.onGrantAccess?.({
             reason: "subscription_trialing",
             ...event.object,
           });
-          options.onSubscriptionTrialing?.({
+          await options.onSubscriptionTrialing?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -104,7 +109,7 @@ const createWebhookHandler = (options: CreemOptions) => {
           break;
         case "subscription.canceled":
           await onSubscriptionCanceled(ctx, event, options);
-          options.onSubscriptionCanceled?.({
+          await options.onSubscriptionCanceled?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -114,11 +119,11 @@ const createWebhookHandler = (options: CreemOptions) => {
 
         case "subscription.paid":
           await onSubscriptionPaid(ctx, event, options);
-          options.onGrantAccess?.({
+          await options.onGrantAccess?.({
             reason: "subscription_paid",
             ...event.object,
           });
-          options.onSubscriptionPaid?.({
+          await options.onSubscriptionPaid?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -128,11 +133,11 @@ const createWebhookHandler = (options: CreemOptions) => {
 
         case "subscription.expired":
           await onSubscriptionExpired(ctx, event, options);
-          options.onRevokeAccess?.({
+          await options.onRevokeAccess?.({
             reason: "subscription_expired",
             ...event.object,
           });
-          options.onSubscriptionExpired?.({
+          await options.onSubscriptionExpired?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -142,7 +147,7 @@ const createWebhookHandler = (options: CreemOptions) => {
 
         case "subscription.unpaid":
           await onSubscriptionUnpaid(ctx, event, options);
-          options.onSubscriptionUnpaid?.({
+          await options.onSubscriptionUnpaid?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -152,7 +157,7 @@ const createWebhookHandler = (options: CreemOptions) => {
 
         case "subscription.update":
           await onSubscriptionUpdate(ctx, event, options);
-          options.onSubscriptionUpdate?.({
+          await options.onSubscriptionUpdate?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -162,7 +167,7 @@ const createWebhookHandler = (options: CreemOptions) => {
 
         case "subscription.past_due":
           await onSubscriptionPastDue(ctx, event, options);
-          options.onSubscriptionPastDue?.({
+          await options.onSubscriptionPastDue?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -172,11 +177,11 @@ const createWebhookHandler = (options: CreemOptions) => {
 
         case "subscription.paused":
           await onSubscriptionPaused(ctx, event, options);
-          options.onRevokeAccess?.({
+          await options.onRevokeAccess?.({
             reason: "subscription_paused",
             ...event.object,
           });
-          options.onSubscriptionPaused?.({
+          await options.onSubscriptionPaused?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,


### PR DESCRIPTION
User-facing callbacks (onCheckoutCompleted, onSubscriptionActive, onGrantAccess, onRevokeAccess, etc.) were called without await, so the returned Promises were silently dropped on serverless runtimes (Cloudflare Workers, Vercel Edge) where the worker terminates before async DB writes / API calls complete.

Widens callback signatures in CreemOptions from `=> void` to `=> void | Promise<void>` to match the JSDoc examples, and awaits every invocation in the webhook handler.

Credit: original fix by @nirgn975 in armitage-labs/creem-betterauth#20.