### PR TITLE
fix(openapi): add "canceled" to TransactionStatus enum

### DIFF
--- a/packages/creem-sdk/openapi.json
+++ b/packages/creem-sdk/openapi.json
@@ -2414,7 +2414,8 @@
           "chargedBack",
           "uncollectible",
           "declined",
-          "void"
+          "void",
+          "canceled"
         ]
       },
       "TransactionEntity": {

--- a/packages/docs/api-reference/openapi.json
+++ b/packages/docs/api-reference/openapi.json
@@ -2414,7 +2414,8 @@
           "chargedBack",
           "uncollectible",
           "declined",
-          "void"
+          "void",
+          "canceled"
         ]
       },
       "TransactionEntity": {


### PR DESCRIPTION
Backend can return status="canceled" for cancelled subscription invoices,                              
  but the OpenAPI spec only listed eight statuses. The Speakeasy-generated                               
  SDK enum is therefore closed and rejects responses containing this value                               
  with "Response validation failed", breaking creem transactions list (and                               
  any other consumer of the search endpoint) for stores that have at least                               
  one cancelled subscription transaction.                                                                
                                                                                                         
  Add "canceled" to the TransactionStatus enum in both the SDK spec and                                  
  the docs spec so they match what the API actually returns. The SDK will
  pick this up on the next Speakeasy generation.          
  
  featurebase link: https://creem.featurebase.app/dashboard/inbox/admin/69e5da92f8a12f7eef2049c7/conversation/14299