### PR TITLE
chore: fix prettier drift and unblock speakeasy run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,6 @@ jobs:
 
       - name: Lint
         run: pnpm turbo lint ${{ steps.filter.outputs.args }} --filter='!./packages/creem-io' --filter='!./packages/creem-sdk'
+
+      - name: Format check
+        run: pnpm format:check

--- a/.github/workflows/sdk-generation.yml
+++ b/.github/workflows/sdk-generation.yml
@@ -20,6 +20,10 @@ jobs:
       speakeasy_version: latest
       working_directory: packages/creem-sdk
       mode: pr
+      # Speakeasy's compile step runs `npm install`, which collides with this
+      # repo's pnpm-managed node_modules and corrupts esbuild's binary. The
+      # monorepo's own `pnpm turbo build` covers compile/typecheck.
+      skip_compile: "true"
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,10 @@ build
 *.lock
 pnpm-lock.yaml
 package-lock.json
+
+# Speakeasy-generated SDK — formatting is owned by `speakeasy run`, not prettier.
+# Any prettier reformat here is overwritten on the next regen.
+packages/creem-sdk/
+
+# OpenAPI spec — synced from upstream / generated, not hand-edited.
+packages/docs/api-reference/openapi.json

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,mjs,cjs}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,mjs,cjs}\"",
+    "gen:sdk": "cd packages/creem-sdk && speakeasy run --skip-compile",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "turbo run build && changeset publish",

--- a/packages/better-auth/examples/nextjs/src/app/layout.tsx
+++ b/packages/better-auth/examples/nextjs/src/app/layout.tsx
@@ -5,11 +5,7 @@ export const metadata: Metadata = {
   description: "Minimal Next.js example for the @creem_io/better-auth plugin",
 };
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <body

--- a/packages/better-auth/examples/nextjs/src/app/page.tsx
+++ b/packages/better-auth/examples/nextjs/src/app/page.tsx
@@ -87,11 +87,7 @@ export default function Home() {
               />
             </label>
           </div>
-          <button
-            type="submit"
-            disabled={loading}
-            style={{ padding: "8px 16px", marginRight: 8 }}
-          >
+          <button type="submit" disabled={loading} style={{ padding: "8px 16px", marginRight: 8 }}>
             {loading ? "..." : isSignUp ? "Sign Up" : "Sign In"}
           </button>
           <button type="button" onClick={() => setIsSignUp(!isSignUp)}>
@@ -168,8 +164,7 @@ function Dashboard() {
   };
 
   const onetimeProductId = process.env.NEXT_PUBLIC_CREEM_ONETIME_PRODUCT_ID;
-  const subscriptionProductId =
-    process.env.NEXT_PUBLIC_CREEM_SUBSCRIPTION_PRODUCT_ID;
+  const subscriptionProductId = process.env.NEXT_PUBLIC_CREEM_SUBSCRIPTION_PRODUCT_ID;
 
   return (
     <div>
@@ -187,28 +182,22 @@ function Dashboard() {
             disabled={checkoutLoading !== null}
             style={{ padding: "8px 16px" }}
           >
-            {checkoutLoading === "onetime"
-              ? "..."
-              : "Buy One-Time Product"}
+            {checkoutLoading === "onetime" ? "..." : "Buy One-Time Product"}
           </button>
         )}
         {subscriptionProductId && (
           <button
-            onClick={() =>
-              handleCheckout(subscriptionProductId, "subscription")
-            }
+            onClick={() => handleCheckout(subscriptionProductId, "subscription")}
             disabled={checkoutLoading !== null}
             style={{ padding: "8px 16px" }}
           >
-            {checkoutLoading === "subscription"
-              ? "..."
-              : "Subscribe"}
+            {checkoutLoading === "subscription" ? "..." : "Subscribe"}
           </button>
         )}
         {!onetimeProductId && !subscriptionProductId && (
           <p style={{ color: "#888" }}>
-            Set NEXT_PUBLIC_CREEM_ONETIME_PRODUCT_ID or
-            NEXT_PUBLIC_CREEM_SUBSCRIPTION_PRODUCT_ID in .env.local
+            Set NEXT_PUBLIC_CREEM_ONETIME_PRODUCT_ID or NEXT_PUBLIC_CREEM_SUBSCRIPTION_PRODUCT_ID in
+            .env.local
           </p>
         )}
       </div>
@@ -220,13 +209,8 @@ function Dashboard() {
       </button>
       {accessStatus && (
         <p>
-          Access:{" "}
-          <strong>
-            {accessStatus.hasAccessGranted ? "Granted" : "Not granted"}
-          </strong>
-          {accessStatus.message && (
-            <span style={{ color: "#888" }}> — {accessStatus.message}</span>
-          )}
+          Access: <strong>{accessStatus.hasAccessGranted ? "Granted" : "Not granted"}</strong>
+          {accessStatus.message && <span style={{ color: "#888" }}> — {accessStatus.message}</span>}
         </p>
       )}
 
@@ -239,10 +223,7 @@ function Dashboard() {
         <button onClick={handleTransactions} style={{ padding: "8px 16px" }}>
           View Transactions
         </button>
-        <button
-          onClick={() => authClient.signOut()}
-          style={{ padding: "8px 16px" }}
-        >
+        <button onClick={() => authClient.signOut()} style={{ padding: "8px 16px" }}>
           Sign Out
         </button>
       </div>

--- a/packages/better-auth/test/nextjs-app/next.config.js
+++ b/packages/better-auth/test/nextjs-app/next.config.js
@@ -2,10 +2,9 @@
 const nextConfig = {
   experimental: {
     serverActions: {
-      bodySizeLimit: '2mb',
+      bodySizeLimit: "2mb",
     },
   },
-}
+};
 
-module.exports = nextConfig
-
+module.exports = nextConfig;

--- a/packages/better-auth/test/nextjs-app/postcss.config.mjs
+++ b/packages/better-auth/test/nextjs-app/postcss.config.mjs
@@ -6,4 +6,3 @@ const config = {
 };
 
 export default config;
-

--- a/packages/better-auth/test/nextjs-app/src/app/api/auth/[...all]/route.ts
+++ b/packages/better-auth/test/nextjs-app/src/app/api/auth/[...all]/route.ts
@@ -2,4 +2,3 @@ import { auth } from "@/lib/auth";
 import { toNextJsHandler } from "better-auth/next-js";
 
 export const { GET, POST } = toNextJsHandler(auth);
-

--- a/packages/better-auth/test/nextjs-app/src/app/api/webhook/creem/route.ts
+++ b/packages/better-auth/test/nextjs-app/src/app/api/webhook/creem/route.ts
@@ -2,10 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 
 /**
  * Webhook endpoint for Creem events
- * 
+ *
  * Note: The Better-Auth plugin already handles webhooks at /api/auth/creem-webhook
  * This is just an example of how you could set up a custom webhook endpoint if needed.
- * 
+ *
  * For production use, rely on the built-in webhook handler provided by the plugin.
  */
 export async function POST(request: NextRequest) {
@@ -24,10 +24,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ received: true });
   } catch (error: any) {
     console.error("Webhook error:", error);
-    return NextResponse.json(
-      { error: error.message },
-      { status: 400 }
-    );
+    return NextResponse.json({ error: error.message }, { status: 400 });
   }
 }
-

--- a/packages/better-auth/test/nextjs-app/src/app/auth/signin/page.tsx
+++ b/packages/better-auth/test/nextjs-app/src/app/auth/signin/page.tsx
@@ -39,9 +39,7 @@ export default function SignIn() {
     <main className="min-h-screen flex items-center justify-center p-8">
       <div className="max-w-md w-full">
         <div className="bg-white rounded-lg shadow-lg p-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-6 text-center">
-            Sign In
-          </h1>
+          <h1 className="text-3xl font-bold text-gray-900 mb-6 text-center">Sign In</h1>
 
           {error && (
             <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
@@ -108,4 +106,3 @@ export default function SignIn() {
     </main>
   );
 }
-

--- a/packages/better-auth/test/nextjs-app/src/app/auth/signup/page.tsx
+++ b/packages/better-auth/test/nextjs-app/src/app/auth/signup/page.tsx
@@ -41,9 +41,7 @@ export default function SignUp() {
     <main className="min-h-screen flex items-center justify-center p-8">
       <div className="max-w-md w-full">
         <div className="bg-white rounded-lg shadow-lg p-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-6 text-center">
-            Sign Up
-          </h1>
+          <h1 className="text-3xl font-bold text-gray-900 mb-6 text-center">Sign Up</h1>
 
           {error && (
             <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
@@ -96,9 +94,7 @@ export default function SignUp() {
                 className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 placeholder="••••••••"
               />
-              <p className="text-xs text-gray-500 mt-1">
-                Must be at least 8 characters
-              </p>
+              <p className="text-xs text-gray-500 mt-1">Must be at least 8 characters</p>
             </div>
 
             <button
@@ -129,4 +125,3 @@ export default function SignUp() {
     </main>
   );
 }
-

--- a/packages/better-auth/test/nextjs-app/src/app/dashboard/page.tsx
+++ b/packages/better-auth/test/nextjs-app/src/app/dashboard/page.tsx
@@ -15,7 +15,7 @@ export default function Dashboard() {
   useEffect(() => {
     const fetchData = async () => {
       const session = await authClient.getSession();
-      
+
       if (!session.data?.user) {
         router.push("/auth/signin");
         return;
@@ -75,9 +75,7 @@ export default function Dashboard() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
           {/* User Info Card */}
           <div className="bg-white rounded-lg shadow-lg p-6">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">
-              Account Information
-            </h2>
+            <h2 className="text-xl font-semibold text-gray-900 mb-4">Account Information</h2>
             <div className="space-y-2">
               <div>
                 <span className="text-sm text-gray-600">Name:</span>
@@ -96,15 +94,11 @@ export default function Dashboard() {
 
           {/* Subscription Status Card */}
           <div className="bg-white rounded-lg shadow-lg p-6">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">
-              Subscription Status
-            </h2>
+            <h2 className="text-xl font-semibold text-gray-900 mb-4">Subscription Status</h2>
             <div className="space-y-4">
               <div className="flex items-center space-x-2">
                 <div
-                  className={`w-3 h-3 rounded-full ${
-                    hasAccess ? "bg-green-500" : "bg-gray-300"
-                  }`}
+                  className={`w-3 h-3 rounded-full ${hasAccess ? "bg-green-500" : "bg-gray-300"}`}
                 ></div>
                 <span className="font-medium">
                   {hasAccess ? "Active Subscription" : "No Active Subscription"}
@@ -142,18 +136,14 @@ export default function Dashboard() {
 
         {/* Quick Actions */}
         <div className="bg-white rounded-lg shadow-lg p-6">
-          <h2 className="text-xl font-semibold text-gray-900 mb-4">
-            Quick Actions
-          </h2>
+          <h2 className="text-xl font-semibold text-gray-900 mb-4">Quick Actions</h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <Link
               href="/pricing"
               className="p-4 border-2 border-gray-200 rounded-lg hover:border-blue-500 hover:bg-blue-50 transition"
             >
               <h3 className="font-semibold text-gray-900 mb-1">View Pricing</h3>
-              <p className="text-sm text-gray-600">
-                Explore available subscription plans
-              </p>
+              <p className="text-sm text-gray-600">Explore available subscription plans</p>
             </Link>
 
             <Link
@@ -161,9 +151,7 @@ export default function Dashboard() {
               className="p-4 border-2 border-gray-200 rounded-lg hover:border-purple-500 hover:bg-purple-50 transition"
             >
               <h3 className="font-semibold text-gray-900 mb-1">Customer Portal</h3>
-              <p className="text-sm text-gray-600">
-                Manage billing and subscriptions
-              </p>
+              <p className="text-sm text-gray-600">Manage billing and subscriptions</p>
             </Link>
 
             <Link
@@ -171,9 +159,7 @@ export default function Dashboard() {
               className="p-4 border-2 border-gray-200 rounded-lg hover:border-green-500 hover:bg-green-50 transition"
             >
               <h3 className="font-semibold text-gray-900 mb-1">Transactions</h3>
-              <p className="text-sm text-gray-600">
-                View your payment history
-              </p>
+              <p className="text-sm text-gray-600">View your payment history</p>
             </Link>
           </div>
         </div>
@@ -187,4 +173,3 @@ export default function Dashboard() {
     </main>
   );
 }
-

--- a/packages/better-auth/test/nextjs-app/src/app/layout.tsx
+++ b/packages/better-auth/test/nextjs-app/src/app/layout.tsx
@@ -13,10 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased bg-gray-50">
-        {children}
-      </body>
+      <body className="antialiased bg-gray-50">{children}</body>
     </html>
   );
 }
-

--- a/packages/better-auth/test/nextjs-app/src/app/page.tsx
+++ b/packages/better-auth/test/nextjs-app/src/app/page.tsx
@@ -29,9 +29,7 @@ export default function Home() {
     <main className="min-h-screen flex flex-col items-center justify-center p-8">
       <div className="max-w-4xl w-full space-y-8">
         <div className="text-center">
-          <h1 className="text-4xl font-bold text-gray-900 mb-4">
-            Creem Better-Auth Test App
-          </h1>
+          <h1 className="text-4xl font-bold text-gray-900 mb-4">Creem Better-Auth Test App</h1>
           <p className="text-lg text-gray-600">
             Test the Creem integration with Better-Auth locally
           </p>
@@ -44,9 +42,7 @@ export default function Home() {
                 <h2 className="text-2xl font-semibold text-gray-900">
                   Welcome, {user.name || user.email}!
                 </h2>
-                <p className="text-gray-600 mt-2">
-                  You&apos;re successfully authenticated.
-                </p>
+                <p className="text-gray-600 mt-2">You&apos;re successfully authenticated.</p>
               </div>
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -55,9 +51,7 @@ export default function Home() {
                   className="block p-6 bg-blue-50 rounded-lg hover:bg-blue-100 transition"
                 >
                   <h3 className="font-semibold text-blue-900 mb-2">Dashboard</h3>
-                  <p className="text-sm text-blue-700">
-                    View your account and subscription status
-                  </p>
+                  <p className="text-sm text-blue-700">View your account and subscription status</p>
                 </Link>
 
                 <Link
@@ -65,9 +59,7 @@ export default function Home() {
                   className="block p-6 bg-green-50 rounded-lg hover:bg-green-100 transition"
                 >
                   <h3 className="font-semibold text-green-900 mb-2">Pricing</h3>
-                  <p className="text-sm text-green-700">
-                    Subscribe to a plan using Creem
-                  </p>
+                  <p className="text-sm text-green-700">Subscribe to a plan using Creem</p>
                 </Link>
 
                 <Link
@@ -75,9 +67,7 @@ export default function Home() {
                   className="block p-6 bg-purple-50 rounded-lg hover:bg-purple-100 transition"
                 >
                   <h3 className="font-semibold text-purple-900 mb-2">Customer Portal</h3>
-                  <p className="text-sm text-purple-700">
-                    Manage your subscription
-                  </p>
+                  <p className="text-sm text-purple-700">Manage your subscription</p>
                 </Link>
 
                 <Link
@@ -85,18 +75,14 @@ export default function Home() {
                   className="block p-6 bg-orange-50 rounded-lg hover:bg-orange-100 transition"
                 >
                   <h3 className="font-semibold text-orange-900 mb-2">Transactions</h3>
-                  <p className="text-sm text-orange-700">
-                    View your transaction history
-                  </p>
+                  <p className="text-sm text-orange-700">View your transaction history</p>
                 </Link>
               </div>
             </>
           ) : (
             <>
               <div className="text-center space-y-4">
-                <p className="text-gray-600">
-                  Please sign in to test the Creem integration
-                </p>
+                <p className="text-gray-600">Please sign in to test the Creem integration</p>
                 <div className="space-x-4">
                   <Link
                     href="/auth/signin"
@@ -133,4 +119,3 @@ export default function Home() {
     </main>
   );
 }
-

--- a/packages/better-auth/test/nextjs-app/src/app/portal/page.tsx
+++ b/packages/better-auth/test/nextjs-app/src/app/portal/page.tsx
@@ -13,12 +13,12 @@ export default function Portal() {
   useEffect(() => {
     const getUser = async () => {
       const session = await authClient.getSession();
-      
+
       if (!session.data?.user) {
         router.push("/auth/signin");
         return;
       }
-      
+
       setUser(session.data.user);
     };
     getUser();
@@ -56,25 +56,19 @@ export default function Portal() {
   return (
     <main className="min-h-screen p-8">
       <div className="max-w-4xl mx-auto">
-        <h1 className="text-4xl font-bold text-gray-900 mb-8">
-          Customer Portal
-        </h1>
+        <h1 className="text-4xl font-bold text-gray-900 mb-8">Customer Portal</h1>
 
         <div className="bg-white rounded-lg shadow-lg p-8 space-y-6">
           <div>
-            <h2 className="text-2xl font-semibold text-gray-900 mb-4">
-              Manage Your Subscription
-            </h2>
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Manage Your Subscription</h2>
             <p className="text-gray-600 mb-6">
-              Access the Creem customer portal to manage your subscription, update
-              payment methods, view invoices, and more.
+              Access the Creem customer portal to manage your subscription, update payment methods,
+              view invoices, and more.
             </p>
           </div>
 
           <div className="border-t pt-6">
-            <h3 className="font-semibold text-gray-900 mb-3">
-              What you can do in the portal:
-            </h3>
+            <h3 className="font-semibold text-gray-900 mb-3">What you can do in the portal:</h3>
             <ul className="space-y-2 text-gray-700">
               <li className="flex items-start">
                 <svg
@@ -155,22 +149,12 @@ export default function Portal() {
         </div>
 
         <div className="mt-8 bg-blue-50 rounded-lg p-6 border border-blue-200">
-          <h3 className="font-semibold text-blue-900 mb-3">
-            💡 Testing the Portal
-          </h3>
+          <h3 className="font-semibold text-blue-900 mb-3">💡 Testing the Portal</h3>
           <ul className="space-y-2 text-sm text-blue-800">
-            <li>
-              1. Make sure you have a Creem customer associated with your email
-            </li>
-            <li>
-              2. Click &quot;Open Customer Portal&quot; to create a portal session
-            </li>
-            <li>
-              3. You&apos;ll be redirected to Creem&apos;s hosted portal page
-            </li>
-            <li>
-              4. After making changes, you&apos;ll be redirected back to the dashboard
-            </li>
+            <li>1. Make sure you have a Creem customer associated with your email</li>
+            <li>2. Click &quot;Open Customer Portal&quot; to create a portal session</li>
+            <li>3. You&apos;ll be redirected to Creem&apos;s hosted portal page</li>
+            <li>4. After making changes, you&apos;ll be redirected back to the dashboard</li>
           </ul>
         </div>
 
@@ -183,4 +167,3 @@ export default function Portal() {
     </main>
   );
 }
-

--- a/packages/better-auth/test/nextjs-app/src/app/pricing/page.tsx
+++ b/packages/better-auth/test/nextjs-app/src/app/pricing/page.tsx
@@ -60,12 +60,7 @@ export default function Pricing() {
       name: "Starter",
       price: "$9",
       period: "month",
-      features: [
-        "Basic features",
-        "Up to 10 users",
-        "Email support",
-        "1GB storage",
-      ],
+      features: ["Basic features", "Up to 10 users", "Email support", "1GB storage"],
     },
     {
       id: "add-your-product-id-here",
@@ -101,12 +96,8 @@ export default function Pricing() {
     <main className="min-h-screen p-8">
       <div className="max-w-7xl mx-auto">
         <div className="text-center mb-12">
-          <h1 className="text-4xl font-bold text-gray-900 mb-4">
-            Choose Your Plan
-          </h1>
-          <p className="text-lg text-gray-600">
-            Select a plan that works best for you
-          </p>
+          <h1 className="text-4xl font-bold text-gray-900 mb-4">Choose Your Plan</h1>
+          <p className="text-lg text-gray-600">Select a plan that works best for you</p>
         </div>
 
         {!user && (
@@ -135,13 +126,9 @@ export default function Pricing() {
                 </div>
               )}
 
-              <h2 className="text-2xl font-bold text-gray-900 mb-2">
-                {plan.name}
-              </h2>
+              <h2 className="text-2xl font-bold text-gray-900 mb-2">{plan.name}</h2>
               <div className="mb-6">
-                <span className="text-4xl font-bold text-gray-900">
-                  {plan.price}
-                </span>
+                <span className="text-4xl font-bold text-gray-900">{plan.price}</span>
                 <span className="text-gray-600">/{plan.period}</span>
               </div>
 
@@ -175,43 +162,34 @@ export default function Pricing() {
                     : "bg-gray-200 text-gray-900 hover:bg-gray-300"
                 } disabled:opacity-50 disabled:cursor-not-allowed`}
               >
-                {loading && selectedPlan === plan.id
-                  ? "Processing..."
-                  : "Subscribe"}
+                {loading && selectedPlan === plan.id ? "Processing..." : "Subscribe"}
               </button>
             </div>
           ))}
         </div>
 
         <div className="bg-gray-100 rounded-lg p-6">
-          <h3 className="font-semibold text-gray-900 mb-3">
-            💡 Testing Instructions
-          </h3>
+          <h3 className="font-semibold text-gray-900 mb-3">💡 Testing Instructions</h3>
           <ul className="space-y-2 text-sm text-gray-700">
             <li>
               1. Make sure you have set up your Creem API key in{" "}
               <code className="bg-white px-2 py-1 rounded">.env.local</code>
             </li>
             <li>
-              2. Replace the{" "}
-              <code className="bg-white px-2 py-1 rounded">productId</code>{" "}
-              values above with actual product IDs from your Creem dashboard
+              2. Replace the <code className="bg-white px-2 py-1 rounded">productId</code> values
+              above with actual product IDs from your Creem dashboard
             </li>
             <li>3. Click "Subscribe" to create a checkout session</li>
             <li>4. Complete the checkout on Creem's hosted page</li>
             <li>
               5. The webhook will trigger the{" "}
-              <code className="bg-white px-2 py-1 rounded">onGrantAccess</code>{" "}
-              callback
+              <code className="bg-white px-2 py-1 rounded">onGrantAccess</code> callback
             </li>
           </ul>
         </div>
 
         <div className="mt-6 text-center">
-          <Link
-            href="/dashboard"
-            className="text-sm text-gray-500 hover:text-gray-700"
-          >
+          <Link href="/dashboard" className="text-sm text-gray-500 hover:text-gray-700">
             ← Back to Dashboard
           </Link>
         </div>

--- a/packages/better-auth/test/nextjs-app/src/app/success/page.tsx
+++ b/packages/better-auth/test/nextjs-app/src/app/success/page.tsx
@@ -23,13 +23,10 @@ export default function Success() {
             </svg>
           </div>
 
-          <h1 className="text-3xl font-bold text-gray-900 mb-4">
-            Payment Successful!
-          </h1>
-          
+          <h1 className="text-3xl font-bold text-gray-900 mb-4">Payment Successful!</h1>
+
           <p className="text-gray-600 mb-8">
-            Thank you for your subscription. Your payment has been processed
-            successfully.
+            Thank you for your subscription. Your payment has been processed successfully.
           </p>
 
           <div className="space-y-3">
@@ -39,7 +36,7 @@ export default function Success() {
             >
               Go to Dashboard
             </Link>
-            
+
             <Link
               href="/portal"
               className="block px-6 py-3 bg-gray-200 text-gray-900 rounded-lg hover:bg-gray-300 transition font-medium"
@@ -59,4 +56,3 @@ export default function Success() {
     </main>
   );
 }
-

--- a/packages/better-auth/test/nextjs-app/src/app/transactions/page.tsx
+++ b/packages/better-auth/test/nextjs-app/src/app/transactions/page.tsx
@@ -14,12 +14,12 @@ export default function Transactions() {
   useEffect(() => {
     const fetchData = async () => {
       const session = await authClient.getSession();
-      
+
       if (!session.data?.user) {
         router.push("/auth/signin");
         return;
       }
-      
+
       setUser(session.data.user);
 
       // Fetch transactions
@@ -52,9 +52,7 @@ export default function Transactions() {
   return (
     <main className="min-h-screen p-8">
       <div className="max-w-6xl mx-auto">
-        <h1 className="text-4xl font-bold text-gray-900 mb-8">
-          Transaction History
-        </h1>
+        <h1 className="text-4xl font-bold text-gray-900 mb-8">Transaction History</h1>
 
         <div className="bg-white rounded-lg shadow-lg overflow-hidden">
           {transactions.length === 0 ? (
@@ -72,9 +70,7 @@ export default function Transactions() {
                   d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
                 />
               </svg>
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">
-                No transactions yet
-              </h3>
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">No transactions yet</h3>
               <p className="text-gray-600 mb-6">
                 Your transaction history will appear here after your first purchase.
               </p>
@@ -125,8 +121,8 @@ export default function Transactions() {
                             transaction.status === "succeeded"
                               ? "bg-green-100 text-green-800"
                               : transaction.status === "pending"
-                              ? "bg-yellow-100 text-yellow-800"
-                              : "bg-red-100 text-red-800"
+                                ? "bg-yellow-100 text-yellow-800"
+                                : "bg-red-100 text-red-800"
                           }`}
                         >
                           {transaction.status}
@@ -144,13 +140,11 @@ export default function Transactions() {
         </div>
 
         <div className="mt-8 bg-blue-50 rounded-lg p-6 border border-blue-200">
-          <h3 className="font-semibold text-blue-900 mb-3">
-            💡 Transaction Search
-          </h3>
+          <h3 className="font-semibold text-blue-900 mb-3">💡 Transaction Search</h3>
           <p className="text-sm text-blue-800">
             The <code className="bg-white px-2 py-1 rounded">searchTransactions</code> endpoint
-            fetches your transaction history from Creem. You can filter by date range, amount,
-            and other parameters.
+            fetches your transaction history from Creem. You can filter by date range, amount, and
+            other parameters.
           </p>
         </div>
 
@@ -163,4 +157,3 @@ export default function Transactions() {
     </main>
   );
 }
-

--- a/packages/better-auth/test/nextjs-app/src/components/LoadingSpinner.tsx
+++ b/packages/better-auth/test/nextjs-app/src/components/LoadingSpinner.tsx
@@ -5,4 +5,3 @@ export function LoadingSpinner({ className = "" }: { className?: string }) {
     </div>
   );
 }
-

--- a/packages/better-auth/test/nextjs-app/src/components/SubscriptionBadge.tsx
+++ b/packages/better-auth/test/nextjs-app/src/components/SubscriptionBadge.tsx
@@ -48,4 +48,3 @@ export function SubscriptionBadge({ status, className = "" }: SubscriptionBadgeP
     </div>
   );
 }
-

--- a/packages/better-auth/test/nextjs-app/src/lib/auth-client.ts
+++ b/packages/better-auth/test/nextjs-app/src/lib/auth-client.ts
@@ -4,9 +4,6 @@ import { createCreemAuthClient } from "../../../../dist/esm/create-creem-auth-cl
 import { creemClient } from "../../../../dist/esm/client";
 
 export const authClient = createCreemAuthClient({
-  baseURL: typeof window !== "undefined" 
-    ? window.location.origin 
-    : "http://localhost:3000",
+  baseURL: typeof window !== "undefined" ? window.location.origin : "http://localhost:3000",
   plugins: [creemClient()],
 });
-

--- a/packages/better-auth/test/nextjs-app/src/lib/auth.ts
+++ b/packages/better-auth/test/nextjs-app/src/lib/auth.ts
@@ -16,9 +16,8 @@ const db = new Kysely({
 });
 
 // Check if Creem is configured
-const hasValidCreemApiKey = 
-  process.env.CREEM_API_KEY && 
-  process.env.CREEM_API_KEY !== "your-creem-api-key-here";
+const hasValidCreemApiKey =
+  process.env.CREEM_API_KEY && process.env.CREEM_API_KEY !== "your-creem-api-key-here";
 
 // Build plugins array conditionally
 const plugins = [];
@@ -30,7 +29,7 @@ if (hasValidCreemApiKey) {
       testMode: process.env.CREEM_TEST_MODE === "true",
       defaultSuccessUrl: "/dashboard",
       webhookSecret: process.env.CREEM_WEBHOOK_SECRET,
-      
+
       // Grant access when subscription is created or updated
       onGrantAccess: async (context) => {
         console.log("🎉 Granting access to user:", {
@@ -39,22 +38,22 @@ if (hasValidCreemApiKey) {
           reason: context.reason,
           metadata: context.metadata,
         });
-        
+
         // Here you would typically:
         // 1. Update user's role/permissions in your database
         // 2. Send welcome email
         // 3. Log the event
-        
+
         // Example: Update user subscription status
         // await db.prepare(`
-        //   UPDATE user 
-        //   SET subscriptionStatus = ?, 
+        //   UPDATE user
+        //   SET subscriptionStatus = ?,
         //       subscriptionId = ?,
         //       productId = ?
         //   WHERE id = ?
         // `).run('active', context.metadata.subscriptionId, context.product.id, context.customer.userId);
       },
-      
+
       // Revoke access when subscription ends or is cancelled
       onRevokeAccess: async (context) => {
         console.log("🚫 Revoking access from user:", {
@@ -63,23 +62,25 @@ if (hasValidCreemApiKey) {
           reason: context.reason,
           metadata: context.metadata,
         });
-        
+
         // Here you would typically:
         // 1. Remove user's premium permissions
         // 2. Send notification email
         // 3. Log the event
-        
+
         // Example: Update user subscription status
         // await db.prepare(`
-        //   UPDATE user 
+        //   UPDATE user
         //   SET subscriptionStatus = ?
         //   WHERE id = ?
         // `).run('cancelled', context.customer.userId);
       },
-    })
+    }),
   );
 } else {
-  console.warn("⚠️  Creem plugin not configured. Set CREEM_API_KEY in .env.local to enable payment features.");
+  console.warn(
+    "⚠️  Creem plugin not configured. Set CREEM_API_KEY in .env.local to enable payment features.",
+  );
 }
 
 export const auth = betterAuth({
@@ -99,4 +100,3 @@ export const auth = betterAuth({
   },
   plugins,
 });
-

--- a/packages/better-auth/test/nextjs-app/tailwind.config.ts
+++ b/packages/better-auth/test/nextjs-app/tailwind.config.ts
@@ -17,4 +17,3 @@ const config: Config = {
   plugins: [],
 };
 export default config;
-

--- a/packages/better-auth/vitest.integration.config.ts
+++ b/packages/better-auth/vitest.integration.config.ts
@@ -14,8 +14,10 @@ function loadEnvFile(filename: string): Record<string, string> {
       const key = trimmed.slice(0, eqIdx).trim();
       let value = trimmed.slice(eqIdx + 1).trim();
       // Strip surrounding quotes
-      if ((value.startsWith('"') && value.endsWith('"')) ||
-          (value.startsWith("'") && value.endsWith("'"))) {
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
         value = value.slice(1, -1);
       }
       env[key] = value;

--- a/packages/cli/src/commands/checkouts.ts
+++ b/packages/cli/src/commands/checkouts.ts
@@ -37,9 +37,7 @@ function formatStatus(status: string): string {
 }
 
 export function createCheckoutsCommand(): Command {
-  const command = new Command("checkouts").description(
-    "Manage checkout sessions",
-  );
+  const command = new Command("checkouts").description("Manage checkout sessions");
 
   // Create checkout
   command
@@ -89,9 +87,7 @@ export function createCheckoutsCommand(): Command {
             params.requestId = options.requestId;
           }
 
-          const checkout = (await client.checkouts.create(
-            params,
-          )) as unknown as Checkout;
+          const checkout = (await client.checkouts.create(params)) as unknown as Checkout;
 
           spinner.stop();
 
@@ -110,9 +106,7 @@ export function createCheckoutsCommand(): Command {
             "Product ID": checkout.product || "-",
             "Customer ID": checkout.customer || "-",
             Mode: checkout.mode,
-            Created: checkout.createdAt
-              ? output.formatDate(checkout.createdAt)
-              : "N/A",
+            Created: checkout.createdAt ? output.formatDate(checkout.createdAt) : "N/A",
           });
 
           output.newline();
@@ -124,11 +118,7 @@ export function createCheckoutsCommand(): Command {
           output.newline();
         } catch (error) {
           spinner.stop();
-          output.error(
-            error instanceof Error
-              ? error.message
-              : "Failed to create checkout",
-          );
+          output.error(error instanceof Error ? error.message : "Failed to create checkout");
           process.exit(1);
         }
       },
@@ -144,9 +134,7 @@ export function createCheckoutsCommand(): Command {
 
       try {
         const client = getClient();
-        const checkout = (await client.checkouts.retrieve(
-          checkoutId,
-        )) as unknown as Checkout;
+        const checkout = (await client.checkouts.retrieve(checkoutId)) as unknown as Checkout;
 
         spinner.stop();
 
@@ -165,9 +153,7 @@ export function createCheckoutsCommand(): Command {
           "Product ID": checkout.product || "-",
           "Customer ID": checkout.customer || "-",
           Mode: checkout.mode,
-          Created: checkout.createdAt
-            ? output.formatDate(checkout.createdAt)
-            : "N/A",
+          Created: checkout.createdAt ? output.formatDate(checkout.createdAt) : "N/A",
         });
 
         if (checkout.checkoutUrl) {
@@ -185,17 +171,13 @@ export function createCheckoutsCommand(): Command {
         if (checkout.expiresAt) {
           output.newline();
           output.dim("Expires:");
-          console.log(
-            checkout.expiresAt ? output.formatDate(checkout.expiresAt) : "N/A",
-          );
+          console.log(checkout.expiresAt ? output.formatDate(checkout.expiresAt) : "N/A");
         }
 
         output.newline();
       } catch (error) {
         spinner.stop();
-        output.error(
-          error instanceof Error ? error.message : "Failed to fetch checkout",
-        );
+        output.error(error instanceof Error ? error.message : "Failed to fetch checkout");
         process.exit(1);
       }
     });

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,10 +1,5 @@
 import { Command } from "commander";
-import {
-  loadConfig,
-  setConfigValue,
-  getConfigPath,
-  CreemConfig,
-} from "../lib/config";
+import { loadConfig, setConfigValue, getConfigPath, CreemConfig } from "../lib/config";
 import { resetClient } from "../lib/api";
 import { detectEnvironment } from "../lib/auth";
 import * as output from "../utils/output";
@@ -32,9 +27,7 @@ function displayConfig(): void {
 }
 
 export function createConfigCommand(): Command {
-  const command = new Command("config").description(
-    "View and manage CLI configuration",
-  );
+  const command = new Command("config").description("View and manage CLI configuration");
 
   // Show all config
   command
@@ -65,9 +58,7 @@ export function createConfigCommand(): Command {
       const config = loadConfig();
 
       if (key === "api_key") {
-        output.warning(
-          "API key cannot be displayed. Use `creem whoami` instead.",
-        );
+        output.warning("API key cannot be displayed. Use `creem whoami` instead.");
         return;
       }
 
@@ -129,10 +120,7 @@ export function createConfigCommand(): Command {
         }
       }
 
-      setConfigValue(
-        key as keyof CreemConfig,
-        value as CreemConfig[keyof CreemConfig],
-      );
+      setConfigValue(key as keyof CreemConfig, value as CreemConfig[keyof CreemConfig]);
 
       // Reset client when environment changes so subsequent API calls use new endpoint
       if (key === "environment") {

--- a/packages/cli/src/commands/customers.ts
+++ b/packages/cli/src/commands/customers.ts
@@ -151,61 +151,57 @@ export function createCustomersCommand(): Command {
     .option("--page <number>", "Page number", "1")
     .option("--limit <number>", "Number of results per page", "20")
     .option("--json", "Output as JSON")
-    .action(
-      async (options: { page: string; limit: string; json?: boolean }) => {
-        const spinner = ora("Fetching customers...").start();
+    .action(async (options: { page: string; limit: string; json?: boolean }) => {
+      const spinner = ora("Fetching customers...").start();
 
-        try {
-          const client = getClient();
-          const result = (await client.customers.list(
-            parseInt(options.page, 10),
-            parseInt(options.limit, 10),
-          )) as unknown as CustomerListResponse;
+      try {
+        const client = getClient();
+        const result = (await client.customers.list(
+          parseInt(options.page, 10),
+          parseInt(options.limit, 10),
+        )) as unknown as CustomerListResponse;
 
-          spinner.stop();
+        spinner.stop();
 
-          const { items, pagination } = result;
+        const { items, pagination } = result;
 
-          if (shouldOutputJson(options.json)) {
-            output.outputJson(result);
-            return;
-          }
-
-          if (items.length === 0) {
-            output.info("No customers found.");
-            return;
-          }
-
-          // Table output
-          const headers = ["ID", "Email", "Name", "Country", "Created"];
-          const rows = items.map((c) => [
-            output.truncate(c.id, 24),
-            output.truncate(c.email, 30),
-            c.name || "-",
-            c.country || "-",
-            output.formatDate(c.createdAt),
-          ]);
-
-          output.outputTable(headers, rows);
-
-          // Pagination info
-          output.newline();
-          output.dim(
-            `Page ${pagination.currentPage} of ${pagination.totalPages} (${pagination.totalRecords} total customers)`,
-          );
-
-          if (pagination.nextPage) {
-            output.dim(`Use --page ${pagination.nextPage} for next page`);
-          }
-        } catch (error) {
-          spinner.fail("Failed to fetch customers");
-          output.error(
-            error instanceof Error ? error.message : "Unknown error",
-          );
-          process.exit(1);
+        if (shouldOutputJson(options.json)) {
+          output.outputJson(result);
+          return;
         }
-      },
-    );
+
+        if (items.length === 0) {
+          output.info("No customers found.");
+          return;
+        }
+
+        // Table output
+        const headers = ["ID", "Email", "Name", "Country", "Created"];
+        const rows = items.map((c) => [
+          output.truncate(c.id, 24),
+          output.truncate(c.email, 30),
+          c.name || "-",
+          c.country || "-",
+          output.formatDate(c.createdAt),
+        ]);
+
+        output.outputTable(headers, rows);
+
+        // Pagination info
+        output.newline();
+        output.dim(
+          `Page ${pagination.currentPage} of ${pagination.totalPages} (${pagination.totalRecords} total customers)`,
+        );
+
+        if (pagination.nextPage) {
+          output.dim(`Use --page ${pagination.nextPage} for next page`);
+        }
+      } catch (error) {
+        spinner.fail("Failed to fetch customers");
+        output.error(error instanceof Error ? error.message : "Unknown error");
+        process.exit(1);
+      }
+    });
 
   // Get customer
   command
@@ -213,37 +209,25 @@ export function createCustomersCommand(): Command {
     .description("Get customer details by ID or email")
     .option("--email", "Treat the argument as an email instead of ID")
     .option("--json", "Output as JSON")
-    .action(
-      async (
-        idOrEmail: string,
-        options: { email?: boolean; json?: boolean },
-      ) => {
-        const spinner = ora("Fetching customer...").start();
+    .action(async (idOrEmail: string, options: { email?: boolean; json?: boolean }) => {
+      const spinner = ora("Fetching customer...").start();
 
-        try {
-          const client = getClient();
+      try {
+        const client = getClient();
 
-          // SDK method: retrieve(customerId?, email?)
-          const result = options.email
-            ? ((await client.customers.retrieve(
-                undefined,
-                idOrEmail,
-              )) as unknown as Customer)
-            : ((await client.customers.retrieve(
-                idOrEmail,
-              )) as unknown as Customer);
+        // SDK method: retrieve(customerId?, email?)
+        const result = options.email
+          ? ((await client.customers.retrieve(undefined, idOrEmail)) as unknown as Customer)
+          : ((await client.customers.retrieve(idOrEmail)) as unknown as Customer);
 
-          spinner.stop();
-          formatCustomer(result, options.json);
-        } catch (error) {
-          spinner.fail("Failed to fetch customer");
-          output.error(
-            error instanceof Error ? error.message : "Unknown error",
-          );
-          process.exit(1);
-        }
-      },
-    );
+        spinner.stop();
+        formatCustomer(result, options.json);
+      } catch (error) {
+        spinner.fail("Failed to fetch customer");
+        output.error(error instanceof Error ? error.message : "Unknown error");
+        process.exit(1);
+      }
+    });
 
   // Get billing portal link
   command
@@ -276,9 +260,7 @@ export function createCustomersCommand(): Command {
         output.outputKeyValue(data);
 
         output.newline();
-        output.dim(
-          "This link allows the customer to manage their billing and subscriptions.",
-        );
+        output.dim("This link allows the customer to manage their billing and subscriptions.");
       } catch (error) {
         spinner.fail("Failed to generate billing portal link");
         output.error(error instanceof Error ? error.message : "Unknown error");

--- a/packages/cli/src/commands/discounts.ts
+++ b/packages/cli/src/commands/discounts.ts
@@ -84,11 +84,9 @@ function formatDuration(discount: Discount): string {
 }
 
 export function createDiscountsCommand(): Command {
-  const command = new Command("discounts")
-    .description("Manage discounts")
-    .action(() => {
-      command.help();
-    });
+  const command = new Command("discounts").description("Manage discounts").action(() => {
+    command.help();
+  });
 
   // List discounts
   command
@@ -97,116 +95,103 @@ export function createDiscountsCommand(): Command {
     .option("--json", "Output as JSON")
     .option("--page <number>", "Page number", "1")
     .option("--limit <number>", "Number of results per page", "20")
-    .action(
-      async (options: { json?: boolean; page: string; limit: string }) => {
-        const spinner = ora("Fetching discounts...").start();
+    .action(async (options: { json?: boolean; page: string; limit: string }) => {
+      const spinner = ora("Fetching discounts...").start();
 
-        try {
-          // Note: The SDK doesn't have a list method for discounts yet,
-          // so we make a direct API call to the internal endpoint
-          const apiKey = getConfigValue("api_key");
-          if (!apiKey) {
+      try {
+        // Note: The SDK doesn't have a list method for discounts yet,
+        // so we make a direct API call to the internal endpoint
+        const apiKey = getConfigValue("api_key");
+        if (!apiKey) {
+          spinner.stop();
+          output.error("Not authenticated. Run `creem login` first.");
+          process.exit(1);
+        }
+
+        const baseUrl = getBaseUrl();
+
+        const url = new URL(`${baseUrl}/v1/discounts/list`);
+        url.searchParams.set("page", options.page);
+        url.searchParams.set("limit", options.limit);
+
+        const response = await fetch(url.toString(), {
+          method: "GET",
+          headers: {
+            "x-api-key": apiKey,
+            "Content-Type": "application/json",
+          },
+        });
+
+        if (!response.ok) {
+          // If endpoint doesn't exist, show helpful message
+          if (response.status === 404) {
             spinner.stop();
-            output.error("Not authenticated. Run `creem login` first.");
-            process.exit(1);
-          }
-
-          const baseUrl = getBaseUrl();
-
-          const url = new URL(`${baseUrl}/v1/discounts/list`);
-          url.searchParams.set("page", options.page);
-          url.searchParams.set("limit", options.limit);
-
-          const response = await fetch(url.toString(), {
-            method: "GET",
-            headers: {
-              "x-api-key": apiKey,
-              "Content-Type": "application/json",
-            },
-          });
-
-          if (!response.ok) {
-            // If endpoint doesn't exist, show helpful message
-            if (response.status === 404) {
-              spinner.stop();
-              output.newline();
-              output.info("Discount list endpoint is not available via API.");
-              output.dim(
-                "View your discounts at: https://creem.io/dashboard/discounts",
-              );
-              output.newline();
-              output.dim("You can retrieve a specific discount using:");
-              console.log(chalk.cyan("  creem discounts get <discount-id>"));
-              console.log(
-                chalk.cyan("  creem discounts get --code <discount-code>"),
-              );
-              return;
-            }
-            throw new Error(
-              `API error: ${response.status} ${response.statusText}`,
-            );
-          }
-
-          const data = (await response.json()) as DiscountListResponse;
-          spinner.stop();
-
-          const { items, pagination } = data;
-
-          if (shouldOutputJson(options.json)) {
-            output.outputJson(data);
-            return;
-          }
-
-          output.newline();
-
-          if (items.length === 0) {
-            output.info("No discounts found.");
-            output.dim("Create a discount with: creem discounts create");
-            return;
-          }
-
-          output.outputTable(
-            ["ID", "Code", "Value", "Duration", "Status"],
-            items.map((d) => [
-              d.id,
-              d.code,
-              formatDiscountValue(d),
-              formatDuration(d),
-              formatStatus(d.status),
-            ]),
-          );
-
-          output.newline();
-          output.dim(
-            `Page ${pagination.currentPage} of ${pagination.totalPages} (${pagination.totalRecords} total)`,
-          );
-          output.newline();
-        } catch (error) {
-          spinner.stop();
-
-          // Check if it's a network/API error that suggests the endpoint doesn't exist
-          const errorMsg =
-            error instanceof Error ? error.message : "Unknown error";
-          if (errorMsg.includes("404") || errorMsg.includes("Not Found")) {
             output.newline();
             output.info("Discount list endpoint is not available via API.");
-            output.dim(
-              "View your discounts at: https://creem.io/dashboard/discounts",
-            );
+            output.dim("View your discounts at: https://creem.io/dashboard/discounts");
             output.newline();
             output.dim("You can retrieve a specific discount using:");
             console.log(chalk.cyan("  creem discounts get <discount-id>"));
-            console.log(
-              chalk.cyan("  creem discounts get --code <discount-code>"),
-            );
+            console.log(chalk.cyan("  creem discounts get --code <discount-code>"));
             return;
           }
-
-          output.error(errorMsg);
-          process.exit(1);
+          throw new Error(`API error: ${response.status} ${response.statusText}`);
         }
-      },
-    );
+
+        const data = (await response.json()) as DiscountListResponse;
+        spinner.stop();
+
+        const { items, pagination } = data;
+
+        if (shouldOutputJson(options.json)) {
+          output.outputJson(data);
+          return;
+        }
+
+        output.newline();
+
+        if (items.length === 0) {
+          output.info("No discounts found.");
+          output.dim("Create a discount with: creem discounts create");
+          return;
+        }
+
+        output.outputTable(
+          ["ID", "Code", "Value", "Duration", "Status"],
+          items.map((d) => [
+            d.id,
+            d.code,
+            formatDiscountValue(d),
+            formatDuration(d),
+            formatStatus(d.status),
+          ]),
+        );
+
+        output.newline();
+        output.dim(
+          `Page ${pagination.currentPage} of ${pagination.totalPages} (${pagination.totalRecords} total)`,
+        );
+        output.newline();
+      } catch (error) {
+        spinner.stop();
+
+        // Check if it's a network/API error that suggests the endpoint doesn't exist
+        const errorMsg = error instanceof Error ? error.message : "Unknown error";
+        if (errorMsg.includes("404") || errorMsg.includes("Not Found")) {
+          output.newline();
+          output.info("Discount list endpoint is not available via API.");
+          output.dim("View your discounts at: https://creem.io/dashboard/discounts");
+          output.newline();
+          output.dim("You can retrieve a specific discount using:");
+          console.log(chalk.cyan("  creem discounts get <discount-id>"));
+          console.log(chalk.cyan("  creem discounts get --code <discount-code>"));
+          return;
+        }
+
+        output.error(errorMsg);
+        process.exit(1);
+      }
+    });
 
   // Get discount by ID or code
   command
@@ -214,80 +199,65 @@ export function createDiscountsCommand(): Command {
     .description("Get discount details by ID or code")
     .option("--code <code>", "Get discount by code instead of ID")
     .option("--json", "Output as JSON")
-    .action(
-      async (
-        discountId: string | undefined,
-        options: { code?: string; json?: boolean },
-      ) => {
-        if (!discountId && !options.code) {
-          output.error("Please provide a discount ID or use --code <code>");
-          process.exit(1);
+    .action(async (discountId: string | undefined, options: { code?: string; json?: boolean }) => {
+      if (!discountId && !options.code) {
+        output.error("Please provide a discount ID or use --code <code>");
+        process.exit(1);
+      }
+
+      if (discountId && options.code) {
+        output.error("Please provide either a discount ID or --code, not both");
+        process.exit(1);
+      }
+
+      const spinner = ora("Fetching discount...").start();
+
+      try {
+        const client = getClient();
+        const discount = (await client.discounts.get(
+          discountId || undefined,
+          options.code || undefined,
+        )) as unknown as Discount;
+
+        spinner.stop();
+
+        if (shouldOutputJson(options.json)) {
+          output.outputJson(discount);
+          return;
         }
 
-        if (discountId && options.code) {
-          output.error(
-            "Please provide either a discount ID or --code, not both",
-          );
-          process.exit(1);
-        }
+        output.newline();
+        output.header(discount.name);
+        output.newline();
 
-        const spinner = ora("Fetching discount...").start();
+        output.outputKeyValue({
+          ID: discount.id,
+          Code: discount.code,
+          Status: formatStatus(discount.status),
+          Type: discount.type,
+          Value: formatDiscountValue(discount),
+          Duration: formatDuration(discount),
+          Mode: discount.mode,
+          "Max Redemptions": discount.maxRedemptions?.toString() || "Unlimited",
+          "Times Redeemed": discount.redeemCount?.toString() || "0",
+          "Expiry Date": discount.expiryDate ? output.formatDate(discount.expiryDate) : "Never",
+        });
 
-        try {
-          const client = getClient();
-          const discount = (await client.discounts.get(
-            discountId || undefined,
-            options.code || undefined,
-          )) as unknown as Discount;
-
-          spinner.stop();
-
-          if (shouldOutputJson(options.json)) {
-            output.outputJson(discount);
-            return;
-          }
-
+        if (discount.appliesToProducts && discount.appliesToProducts.length > 0) {
           output.newline();
-          output.header(discount.name);
-          output.newline();
-
-          output.outputKeyValue({
-            ID: discount.id,
-            Code: discount.code,
-            Status: formatStatus(discount.status),
-            Type: discount.type,
-            Value: formatDiscountValue(discount),
-            Duration: formatDuration(discount),
-            Mode: discount.mode,
-            "Max Redemptions":
-              discount.maxRedemptions?.toString() || "Unlimited",
-            "Times Redeemed": discount.redeemCount?.toString() || "0",
-            "Expiry Date": discount.expiryDate
-              ? output.formatDate(discount.expiryDate)
-              : "Never",
+          output.dim("Applies to Products:");
+          discount.appliesToProducts.forEach((productId) => {
+            console.log(`  • ${productId}`);
           });
-
-          if (
-            discount.appliesToProducts &&
-            discount.appliesToProducts.length > 0
-          ) {
-            output.newline();
-            output.dim("Applies to Products:");
-            discount.appliesToProducts.forEach((productId) => {
-              console.log(`  • ${productId}`);
-            });
-          }
-
-          output.newline();
-        } catch (error) {
-          spinner.stop();
-          output.error(
-            error instanceof Error ? error.message : "Failed to fetch discount",
-          );
-          process.exit(1);
         }
-      },
-    );
+
+        output.newline();
+      } catch (error) {
+        spinner.stop();
+        output.error(error instanceof Error ? error.message : "Failed to fetch discount");
+        process.exit(1);
+      }
+    });
 
   // Create discount
   command
@@ -296,31 +266,13 @@ export function createDiscountsCommand(): Command {
     .requiredOption("--name <name>", "Discount name")
     .option("--code <code>", "Discount code (auto-generated if not provided)")
     .requiredOption("--type <type>", 'Discount type: "percentage" or "fixed"')
-    .option(
-      "--amount <cents>",
-      "Discount amount in cents (required for fixed type)",
-    )
-    .option(
-      "--percentage <number>",
-      "Discount percentage 1-100 (required for percentage type)",
-    )
-    .option(
-      "--currency <code>",
-      "Currency code for fixed discounts (default: USD)",
-    )
+    .option("--amount <cents>", "Discount amount in cents (required for fixed type)")
+    .option("--percentage <number>", "Discount percentage 1-100 (required for percentage type)")
+    .option("--currency <code>", "Currency code for fixed discounts (default: USD)")
     .option("--expires <date>", "Expiry date (ISO format, e.g., 2025-12-31)")
-    .option(
-      "--max-redemptions <number>",
-      "Maximum number of times the discount can be used",
-    )
-    .requiredOption(
-      "--duration <type>",
-      'Duration type: "once", "forever", or "repeating"',
-    )
-    .option(
-      "--duration-months <number>",
-      "Number of months for repeating duration",
-    )
+    .option("--max-redemptions <number>", "Maximum number of times the discount can be used")
+    .requiredOption("--duration <type>", 'Duration type: "once", "forever", or "repeating"')
+    .option("--duration-months <number>", "Number of months for repeating duration")
     .requiredOption(
       "--products <ids>",
       "Comma-separated list of product IDs this discount applies to",
@@ -416,9 +368,7 @@ ${chalk.dim("Examples:")}
 
         // Validate repeating duration requires months
         if (options.duration === "repeating" && !options.durationMonths) {
-          output.error(
-            '--duration-months is required when duration is "repeating"',
-          );
+          output.error('--duration-months is required when duration is "repeating"');
           process.exit(1);
         }
 
@@ -481,9 +431,7 @@ ${chalk.dim("Examples:")}
             params.durationInMonths = parseInt(options.durationMonths, 10);
           }
 
-          const discount = (await client.discounts.create(
-            params,
-          )) as unknown as Discount;
+          const discount = (await client.discounts.create(params)) as unknown as Discount;
 
           spinner.stop();
 
@@ -513,9 +461,7 @@ ${chalk.dim("Examples:")}
           output.newline();
         } catch (error) {
           spinner.fail("Failed to create discount");
-          output.error(
-            error instanceof Error ? error.message : "Unknown error",
-          );
+          output.error(error instanceof Error ? error.message : "Unknown error");
           process.exit(1);
         }
       },
@@ -531,9 +477,7 @@ ${chalk.dim("Examples:")}
 
       try {
         const client = getClient();
-        const discount = (await client.discounts.delete(
-          discountId,
-        )) as unknown as Discount;
+        const discount = (await client.discounts.delete(discountId)) as unknown as Discount;
 
         spinner.stop();
 
@@ -543,15 +487,11 @@ ${chalk.dim("Examples:")}
         }
 
         output.newline();
-        output.success(
-          `Discount "${discount.name}" (${discount.code}) deleted`,
-        );
+        output.success(`Discount "${discount.name}" (${discount.code}) deleted`);
         output.newline();
       } catch (error) {
         spinner.stop();
-        output.error(
-          error instanceof Error ? error.message : "Failed to delete discount",
-        );
+        output.error(error instanceof Error ? error.message : "Failed to delete discount");
         process.exit(1);
       }
     });

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -18,9 +18,7 @@ export function createLoginCommand(): Command {
         if (isAuthenticated() && !options.force) {
           const env = getConfigValue("environment");
           output.warning(`Already logged in (${env} mode).`);
-          output.info(
-            "Use --force to re-authenticate, or run `creem logout` first.",
-          );
+          output.info("Use --force to re-authenticate, or run `creem logout` first.");
           return;
         }
 
@@ -36,9 +34,7 @@ export function createLoginCommand(): Command {
         if (!apiKey) {
           output.newline();
           output.info("Enter your API key from the Creem dashboard.");
-          output.dim(
-            "Get your API key at: https://creem.io/dashboard/api-keys",
-          );
+          output.dim("Get your API key at: https://creem.io/dashboard/api-keys");
           output.newline();
 
           apiKey = await password({
@@ -67,9 +63,7 @@ export function createLoginCommand(): Command {
           const env = getConfigValue("environment");
           output.info(`Environment: ${env}`);
           if (env !== "live") {
-            output.dim(
-              "Use `creem config set environment live` to switch to live mode.",
-            );
+            output.dim("Use `creem config set environment live` to switch to live mode.");
           }
         } else {
           spinner.fail("Authentication failed");

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -302,9 +302,7 @@ async function withRetry<T>(
       if (attempt < maxAttempts && isRetryableError(error)) {
         const delayMs = baseDelayMs * Math.pow(2, attempt - 1);
         console.error(
-          chalk.dim(
-            `  ↻ Attempt ${attempt + 1}/${maxAttempts} for ${label} in ${delayMs}ms...`,
-          ),
+          chalk.dim(`  ↻ Attempt ${attempt + 1}/${maxAttempts} for ${label} in ${delayMs}ms...`),
         );
         await new Promise((resolve) => setTimeout(resolve, delayMs));
       } else {
@@ -357,29 +355,19 @@ class LemonSqueezyClient {
 
       if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(
-          `Lemon Squeezy API error (${response.status}): ${errorText}`,
-        );
+        throw new Error(`Lemon Squeezy API error (${response.status}): ${errorText}`);
       }
 
       return response.json() as Promise<LSApiResponse<T>>;
     }, `${endpoint} (page ${page})`);
   }
 
-  async *paginate<T>(
-    endpoint: string,
-    filterByStore = false,
-  ): AsyncGenerator<T[], void, unknown> {
+  async *paginate<T>(endpoint: string, filterByStore = false): AsyncGenerator<T[], void, unknown> {
     let page = 1;
     let hasMore = true;
 
     while (hasMore) {
-      const response = await this.request<T>(
-        endpoint,
-        page,
-        100,
-        filterByStore,
-      );
+      const response = await this.request<T>(endpoint, page, 100, filterByStore);
       yield response.data;
 
       // Check for both undefined and null - JSON:API spec allows null for unavailable links
@@ -443,8 +431,7 @@ class LemonSqueezyClient {
       if (!currency) {
         return {
           valid: false,
-          error:
-            "Store currency not found in API response. Cannot proceed with migration.",
+          error: "Store currency not found in API response. Cannot proceed with migration.",
         };
       }
       return { valid: true, storeId, currency };
@@ -467,17 +454,13 @@ interface BillingPeriodResult {
   skip?: boolean;
 }
 
-function mapBillingPeriod(
-  interval?: string,
-  intervalCount?: number,
-): BillingPeriodResult {
+function mapBillingPeriod(interval?: string, intervalCount?: number): BillingPeriodResult {
   // Missing interval for subscriptions should be skipped - can happen with deprecated LS variant fields
   // This function is only called when is_subscription is true, so missing interval is invalid
   if (!interval) {
     return {
       period: undefined,
-      warning:
-        "Subscription variant missing billing interval (possibly deprecated LS field)",
+      warning: "Subscription variant missing billing interval (possibly deprecated LS field)",
       skip: true,
     };
   }
@@ -485,8 +468,7 @@ function mapBillingPeriod(
   // Map LS intervals to CREEM billing periods
   if (interval === "month") {
     // Handle undefined intervalCount as default monthly (same pattern as year branch)
-    if (intervalCount === 1 || intervalCount === undefined)
-      return { period: "every-month" };
+    if (intervalCount === 1 || intervalCount === undefined) return { period: "every-month" };
     if (intervalCount === 3) return { period: "every-three-months" };
     if (intervalCount === 6) return { period: "every-six-months" };
     // Unsupported month intervals (2, 4, 5, etc.) - skip with warning
@@ -516,9 +498,7 @@ function mapBillingPeriod(
   };
 }
 
-function mapDiscountType(
-  amountType: "percent" | "fixed",
-): "percentage" | "fixed" {
+function mapDiscountType(amountType: "percent" | "fixed"): "percentage" | "fixed" {
   return amountType === "percent" ? "percentage" : "fixed";
 }
 
@@ -565,9 +545,7 @@ function getVariantPrice(variant: LSVariant): number {
   if (variant.attributes.pay_what_you_want) {
     // For PWYW, prefer min_price (sets a floor), fall back to suggested_price, then 0
     // Use || instead of ?? because min_price: 0 means "no minimum" in LS (should fall through)
-    return (
-      variant.attributes.min_price || variant.attributes.suggested_price || 0
-    );
+    return variant.attributes.min_price || variant.attributes.suggested_price || 0;
   }
   return variant.attributes.price;
 }
@@ -576,10 +554,7 @@ function getVariantPrice(variant: LSVariant): number {
  * Check if a variant is eligible for migration.
  * Must match the same criteria used in the main migration loop.
  */
-function isVariantMigrateable(
-  variant: LSVariant,
-  product: LSProduct | undefined,
-): boolean {
+function isVariantMigrateable(variant: LSVariant, product: LSProduct | undefined): boolean {
   if (!product) return false;
 
   // Import all products regardless of status (draft, pending, published)
@@ -620,10 +595,7 @@ function buildMigrationPlan(
     const productId = variant.attributes.product_id;
     const product = productMap.get(productId);
     if (isVariantMigrateable(variant, product)) {
-      migrateableVariantCounts.set(
-        productId,
-        (migrateableVariantCounts.get(productId) || 0) + 1,
-      );
+      migrateableVariantCounts.set(productId, (migrateableVariantCounts.get(productId) || 0) + 1);
     }
   }
 
@@ -636,16 +608,12 @@ function buildMigrationPlan(
 
     const isRecurring = variant.attributes.is_subscription;
     const billingResult = isRecurring
-      ? mapBillingPeriod(
-          variant.attributes.interval,
-          variant.attributes.interval_count,
-        )
+      ? mapBillingPeriod(variant.attributes.interval, variant.attributes.interval_count)
       : { period: undefined };
 
     // Use pre-computed count for naming decision
     const productId = parseInt(product.id, 10);
-    const migrateableVariantCount =
-      migrateableVariantCounts.get(productId) || 0;
+    const migrateableVariantCount = migrateableVariantCounts.get(productId) || 0;
     const productName =
       migrateableVariantCount > 1
         ? `${product.attributes.name} - ${variant.attributes.name}`
@@ -655,8 +623,7 @@ function buildMigrationPlan(
     if (!isVariantMigrateable(variant, product)) {
       // Determine the specific reason for skipping - ALWAYS track and report
       let skipReason: string;
-      const hasPrice =
-        variant.attributes.price > 0 || variant.attributes.pay_what_you_want;
+      const hasPrice = variant.attributes.price > 0 || variant.attributes.pay_what_you_want;
 
       if (!hasPrice) {
         skipReason = "Variant has no price set";
@@ -758,12 +725,8 @@ function buildMigrationPlan(
   // Filter to only include files belonging to products in our store (via productMap)
   const filePlan: MigrationPlan["files"] = [];
   for (const file of files) {
-    const variant = variants.find(
-      (v) => parseInt(v.id, 10) === file.attributes.variant_id,
-    );
-    const product = variant
-      ? productMap.get(variant.attributes.product_id)
-      : undefined;
+    const variant = variants.find((v) => parseInt(v.id, 10) === file.attributes.variant_id);
+    const product = variant ? productMap.get(variant.attributes.product_id) : undefined;
 
     // Skip files that don't belong to products in our store
     if (!product) continue;
@@ -839,9 +802,7 @@ async function executeMigration(
     const item = migrateableProducts[i];
     const progress = `[${i + 1}/${migrateableProducts.length}]`;
 
-    const spinner = ora(
-      `${progress} Creating: ${item.creemProduct.name}`,
-    ).start();
+    const spinner = ora(`${progress} Creating: ${item.creemProduct.name}`).start();
 
     try {
       const params: Parameters<typeof client.products.create>[0] = {
@@ -852,10 +813,7 @@ async function executeMigration(
         price: item.creemProduct.price,
         currency: item.creemProduct.currency as "USD" | "EUR",
         billingType: item.creemProduct.billingType as "recurring" | "onetime",
-        taxCategory: item.creemProduct.taxCategory as
-          | "saas"
-          | "digital-goods-service"
-          | "ebooks",
+        taxCategory: item.creemProduct.taxCategory as "saas" | "digital-goods-service" | "ebooks",
       };
 
       if (item.creemProduct.billingPeriod) {
@@ -881,9 +839,7 @@ async function executeMigration(
         name: item.creemProduct.name,
         error: errorMsg,
       });
-      spinner.fail(
-        `${progress} Failed: ${item.creemProduct.name} - ${errorMsg}`,
-      );
+      spinner.fail(`${progress} Failed: ${item.creemProduct.name} - ${errorMsg}`);
       result.success = false;
     }
 
@@ -909,10 +865,7 @@ async function executeMigration(
 
     // Skip discount creation if no products were successfully created
     // CREEM API requires at least one product for discounts to apply to
-    if (
-      result.created.products.length === 0 &&
-      migrateableDiscounts.length > 0
-    ) {
+    if (result.created.products.length === 0 && migrateableDiscounts.length > 0) {
       console.log(
         chalk.yellow(
           `  ⚠ Skipping ${migrateableDiscounts.length} discount(s): No products were created to apply them to`,
@@ -929,16 +882,13 @@ async function executeMigration(
     // Create discounts - apply to all created products
     for (
       let i = 0;
-      i <
-      (result.created.products.length > 0 ? migrateableDiscounts.length : 0);
+      i < (result.created.products.length > 0 ? migrateableDiscounts.length : 0);
       i++
     ) {
       const item = migrateableDiscounts[i];
       const progress = `[${i + 1}/${migrateableDiscounts.length}]`;
 
-      const spinner = ora(
-        `${progress} Creating: ${item.creemDiscount.code}`,
-      ).start();
+      const spinner = ora(`${progress} Creating: ${item.creemDiscount.code}`).start();
 
       try {
         // Build discount creation params
@@ -957,10 +907,7 @@ async function executeMigration(
           item.creemDiscount.percentage !== undefined
         ) {
           params.percentage = item.creemDiscount.percentage;
-        } else if (
-          item.creemDiscount.type === "fixed" &&
-          item.creemDiscount.amount !== undefined
-        ) {
+        } else if (item.creemDiscount.type === "fixed" && item.creemDiscount.amount !== undefined) {
           params.amount = item.creemDiscount.amount;
           params.currency = item.creemDiscount.currency;
         }
@@ -989,15 +936,12 @@ async function executeMigration(
         result.created.discounts.push(created.id);
         spinner.succeed(`${progress} Created: ${item.creemDiscount.code}`);
       } catch (error) {
-        const errorMsg =
-          error instanceof Error ? error.message : "Unknown error";
+        const errorMsg = error instanceof Error ? error.message : "Unknown error";
         result.failed.discounts.push({
           code: item.creemDiscount.code,
           error: errorMsg,
         });
-        spinner.fail(
-          `${progress} Failed: ${item.creemDiscount.code} - ${errorMsg}`,
-        );
+        spinner.fail(`${progress} Failed: ${item.creemDiscount.code} - ${errorMsg}`);
         result.success = false;
       }
 
@@ -1017,22 +961,14 @@ async function executeMigration(
       ),
     );
     console.log(
-      chalk.dim(
-        "  Customers are auto-created in CREEM when they make their first purchase",
-      ),
+      chalk.dim("  Customers are auto-created in CREEM when they make their first purchase"),
     );
   }
 
   if (plan.files.length > 0) {
     console.log();
-    console.log(
-      chalk.yellow(
-        `⚠ ${plan.files.length} files found - manual upload required`,
-      ),
-    );
-    console.log(
-      chalk.dim("  Upload downloadable files in the CREEM dashboard"),
-    );
+    console.log(chalk.yellow(`⚠ ${plan.files.length} files found - manual upload required`));
+    console.log(chalk.dim("  Upload downloadable files in the CREEM dashboard"));
   }
 
   return result;
@@ -1061,9 +997,7 @@ function createLemonSqueezyCommand(): Command {
         if (!options.json) {
           console.log();
           console.log(chalk.bold.cyan("🍋 Lemon Squeezy → CREEM Migration"));
-          console.log(
-            chalk.dim("Migrate your products, customers, and discounts"),
-          );
+          console.log(chalk.dim("Migrate your products, customers, and discounts"));
           console.log();
         }
 
@@ -1071,9 +1005,7 @@ function createLemonSqueezyCommand(): Command {
         try {
           getClient();
         } catch {
-          output.error(
-            "Not authenticated with CREEM. Run `creem login` first.",
-          );
+          output.error("Not authenticated with CREEM. Run `creem login` first.");
           process.exit(1);
         }
 
@@ -1084,8 +1016,7 @@ function createLemonSqueezyCommand(): Command {
           try {
             lsApiKey = await password({
               message: "Enter your Lemon Squeezy API key:",
-              validate: (value) =>
-                value.length > 0 ? true : "API key is required",
+              validate: (value) => (value.length > 0 ? true : "API key is required"),
             });
           } catch {
             console.log(chalk.dim("\nMigration cancelled."));
@@ -1100,9 +1031,7 @@ function createLemonSqueezyCommand(): Command {
 
         // Validate Lemon Squeezy API key
         const lsClient = new LemonSqueezyClient(lsApiKey);
-        const validateSpinner = ora(
-          "Validating Lemon Squeezy API key...",
-        ).start();
+        const validateSpinner = ora("Validating Lemon Squeezy API key...").start();
 
         const validation = await lsClient.validateKey();
         if (!validation.valid) {
@@ -1111,9 +1040,7 @@ function createLemonSqueezyCommand(): Command {
           process.exit(1);
         }
 
-        validateSpinner.succeed(
-          `Connected to Lemon Squeezy (Store ID: ${validation.storeId})`,
-        );
+        validateSpinner.succeed(`Connected to Lemon Squeezy (Store ID: ${validation.storeId})`);
 
         // Set store ID for filtering subsequent API requests
         lsClient.setStoreId(validation.storeId!);
@@ -1121,9 +1048,7 @@ function createLemonSqueezyCommand(): Command {
         // Validate store currency - CREEM only supports USD and EUR
         // Currency must exist (validated in validateKey), but guard against edge cases
         if (!validation.currency) {
-          output.error(
-            "Store currency not found. Cannot proceed with migration.",
-          );
+          output.error("Store currency not found. Cannot proceed with migration.");
           process.exit(1);
         }
         const rawCurrency = validation.currency.toUpperCase();
@@ -1182,8 +1107,7 @@ function createLemonSqueezyCommand(): Command {
           try {
             discounts = await lsClient.getDiscounts();
           } catch (error) {
-            const msg =
-              error instanceof Error ? error.message : "Unknown error";
+            const msg = error instanceof Error ? error.message : "Unknown error";
             fetchFailures.push({
               type: "discount",
               label: "all discounts",
@@ -1230,16 +1154,12 @@ function createLemonSqueezyCommand(): Command {
 
         if (fetchFailures.length > 0 && !options.json) {
           console.error();
-          console.error(
-            chalk.yellow("⚠ Some data could not be fetched after retries:"),
-          );
+          console.error(chalk.yellow("⚠ Some data could not be fetched after retries:"));
           for (const f of fetchFailures) {
             console.error(`  • ${f.type}: ${f.label} - ${f.error}`);
           }
           console.error(
-            chalk.dim(
-              "  Migration will continue with the data that was successfully fetched.",
-            ),
+            chalk.dim("  Migration will continue with the data that was successfully fetched."),
           );
         }
 
@@ -1257,8 +1177,7 @@ function createLemonSqueezyCommand(): Command {
 
         // If JSON output requested, print and exit
         if (options.json) {
-          const jsonOutput =
-            fetchFailures.length > 0 ? { ...plan, fetchFailures } : plan;
+          const jsonOutput = fetchFailures.length > 0 ? { ...plan, fetchFailures } : plan;
           output.outputJson(jsonOutput);
           return;
         }
@@ -1276,24 +1195,17 @@ function createLemonSqueezyCommand(): Command {
           );
         }
         if (options.excludeDiscounts) {
-          console.log(
-            `  Discounts: ${chalk.yellow("excluded")} (--exclude-discounts)`,
-          );
+          console.log(`  Discounts: ${chalk.yellow("excluded")} (--exclude-discounts)`);
         } else {
           console.log(
             `  Discounts: ${chalk.cyan(plan.summary.totalDiscounts)}${plan.summary.skippedDiscounts > 0 ? chalk.yellow(` (${plan.summary.skippedDiscounts} skipped)`) : ""}`,
           );
         }
         console.log(`  Customers: ${chalk.cyan(plan.summary.totalCustomers)}`);
-        console.log(
-          `  Files:     ${chalk.cyan(plan.summary.totalFiles)} (manual upload required)`,
-        );
+        console.log(`  Files:     ${chalk.cyan(plan.summary.totalFiles)} (manual upload required)`);
         console.log(chalk.dim("─".repeat(50)));
 
-        if (
-          plan.summary.totalProducts === 0 &&
-          plan.summary.totalCustomers === 0
-        ) {
+        if (plan.summary.totalProducts === 0 && plan.summary.totalCustomers === 0) {
           console.log();
           if (plan.summary.skippedProducts > 0) {
             // All products were skipped - show why
@@ -1318,20 +1230,12 @@ function createLemonSqueezyCommand(): Command {
             }
             console.log();
             console.log(
-              chalk.dim(
-                "Products may be skipped due to unsupported billing intervals or pricing.",
-              ),
+              chalk.dim("Products may be skipped due to unsupported billing intervals or pricing."),
             );
-            console.log(
-              chalk.dim(
-                "CREEM supports one-time, monthly, and yearly billing cycles.",
-              ),
-            );
+            console.log(chalk.dim("CREEM supports one-time, monthly, and yearly billing cycles."));
           } else {
             console.log(
-              chalk.yellow(
-                "Nothing to migrate. Your Lemon Squeezy account appears empty.",
-              ),
+              chalk.yellow("Nothing to migrate. Your Lemon Squeezy account appears empty."),
             );
           }
           return;
@@ -1346,10 +1250,7 @@ function createLemonSqueezyCommand(): Command {
           console.log(chalk.dim("Sample products to be created:"));
           const sample = migrateableProducts.slice(0, 5);
           for (const p of sample) {
-            const price = output.formatCurrency(
-              p.creemProduct.price,
-              p.creemProduct.currency,
-            );
+            const price = output.formatCurrency(p.creemProduct.price, p.creemProduct.currency);
             const billing =
               p.creemProduct.billingType === "recurring"
                 ? `Recurring / ${p.creemProduct.billingPeriod?.replace("every-", "")}`
@@ -1357,9 +1258,7 @@ function createLemonSqueezyCommand(): Command {
             console.log(`  • ${p.creemProduct.name} - ${price} (${billing})`);
           }
           if (migrateableProducts.length > 5) {
-            console.log(
-              chalk.dim(`  ... and ${migrateableProducts.length - 5} more`),
-            );
+            console.log(chalk.dim(`  ... and ${migrateableProducts.length - 5} more`));
           }
         }
 
@@ -1367,9 +1266,7 @@ function createLemonSqueezyCommand(): Command {
         if (skippedProductsList.length > 0) {
           console.log();
           console.log(
-            chalk.yellow(
-              `⚠ ${skippedProductsList.length} variant(s) cannot be migrated:`,
-            ),
+            chalk.yellow(`⚠ ${skippedProductsList.length} variant(s) cannot be migrated:`),
           );
 
           // Group by skip reason for cleaner output
@@ -1383,9 +1280,7 @@ function createLemonSqueezyCommand(): Command {
           }
 
           for (const [reason, names] of reasonCounts) {
-            console.log(
-              `  • ${reason}: ${chalk.dim(`${names.length} variant(s)`)}`,
-            );
+            console.log(`  • ${reason}: ${chalk.dim(`${names.length} variant(s)`)}`);
             // Show first 2 names as examples
             for (const name of names.slice(0, 2)) {
               console.log(chalk.dim(`      - ${name}`));
@@ -1401,9 +1296,7 @@ function createLemonSqueezyCommand(): Command {
         if (skippedDiscountsList.length > 0) {
           console.log();
           console.log(
-            chalk.yellow(
-              `⚠ ${skippedDiscountsList.length} discount(s) require manual setup:`,
-            ),
+            chalk.yellow(`⚠ ${skippedDiscountsList.length} discount(s) require manual setup:`),
           );
 
           // Group by skip reason for cleaner output
@@ -1417,9 +1310,7 @@ function createLemonSqueezyCommand(): Command {
           }
 
           for (const [reason, codes] of discountReasonCounts) {
-            console.log(
-              `  • ${reason}: ${chalk.dim(`${codes.length} discount(s)`)}`,
-            );
+            console.log(`  • ${reason}: ${chalk.dim(`${codes.length} discount(s)`)}`);
             // Show first 3 codes as examples
             for (const code of codes.slice(0, 3)) {
               console.log(chalk.dim(`      - ${code}`));
@@ -1434,11 +1325,7 @@ function createLemonSqueezyCommand(): Command {
         if (options.dryRun) {
           console.log();
           console.log(chalk.yellow.bold("DRY RUN MODE"));
-          console.log(
-            chalk.dim(
-              "No changes were made. Remove --dry-run to execute migration.",
-            ),
-          );
+          console.log(chalk.dim("No changes were made. Remove --dry-run to execute migration."));
           return;
         }
 
@@ -1472,17 +1359,10 @@ function createLemonSqueezyCommand(): Command {
         console.log();
         console.log(chalk.bold("Migration Complete"));
         console.log(chalk.dim("─".repeat(50)));
-        console.log(
-          `  Products created:  ${chalk.green(result.created.products.length)}`,
-        );
-        console.log(
-          `  Discounts created: ${chalk.green(result.created.discounts.length)}`,
-        );
+        console.log(`  Products created:  ${chalk.green(result.created.products.length)}`);
+        console.log(`  Discounts created: ${chalk.green(result.created.discounts.length)}`);
 
-        if (
-          result.failed.products.length > 0 ||
-          result.failed.discounts.length > 0
-        ) {
+        if (result.failed.products.length > 0 || result.failed.discounts.length > 0) {
           console.log();
           console.log(chalk.red("Failed items:"));
           for (const f of result.failed.products) {
@@ -1500,11 +1380,7 @@ function createLemonSqueezyCommand(): Command {
             console.log(`  • ${s.code}: ${s.reason}`);
           }
           if (result.skipped.discounts.length > 5) {
-            console.log(
-              chalk.dim(
-                `  ... and ${result.skipped.discounts.length - 5} more`,
-              ),
-            );
+            console.log(chalk.dim(`  ... and ${result.skipped.discounts.length - 5} more`));
           }
         }
 
@@ -1523,33 +1399,19 @@ function createLemonSqueezyCommand(): Command {
           console.log(chalk.green.bold("✓ Migration completed successfully!"));
         } else {
           console.log();
-          console.log(
-            chalk.yellow.bold("⚠ Migration completed with some errors."),
-          );
+          console.log(chalk.yellow.bold("⚠ Migration completed with some errors."));
           if (fetchFailures.length > 0) {
-            console.log(
-              chalk.dim("  Re-run the migration to retry failed fetches."),
-            );
+            console.log(chalk.dim("  Re-run the migration to retry failed fetches."));
           }
         }
 
         console.log();
         console.log(chalk.dim("Next steps:"));
+        console.log(chalk.dim("  1. Review your products at https://creem.io/dashboard/products"));
         console.log(
-          chalk.dim(
-            "  1. Review your products at https://creem.io/dashboard/products",
-          ),
+          chalk.dim("  2. Review your discounts at https://creem.io/dashboard/discounts"),
         );
-        console.log(
-          chalk.dim(
-            "  2. Review your discounts at https://creem.io/dashboard/discounts",
-          ),
-        );
-        console.log(
-          chalk.dim(
-            "  3. Upload downloadable files in the dashboard if needed",
-          ),
-        );
+        console.log(chalk.dim("  3. Upload downloadable files in the dashboard if needed"));
         console.log(chalk.dim("  4. Update your checkout links to use CREEM"));
       },
     );

--- a/packages/cli/src/commands/products.ts
+++ b/packages/cli/src/commands/products.ts
@@ -78,9 +78,7 @@ function getProductDetailLines(product: Product): string[] {
   lines.push(dl("ID", product.id));
   lines.push(dl("Name", product.name));
   lines.push(dl("Status", formatStatus(product.status)));
-  lines.push(
-    dl("Price", output.formatCurrency(product.price, product.currency)),
-  );
+  lines.push(dl("Price", output.formatCurrency(product.price, product.currency)));
   lines.push(dl("Currency", product.currency.toUpperCase()));
   lines.push(dl("Billing", formatBilling(product)));
   lines.push(dl("Tax Mode", product.taxMode));
@@ -155,13 +153,11 @@ function getProductsTuiDescriptor(): TuiModuleDescriptor<Product> {
 }
 
 export function createProductsCommand(): Command {
-  const command = new Command("products")
-    .description("Manage products")
-    .action(async () => {
-      const { launchInteractiveMode } = await import("../tui");
-      const descriptor = getProductsTuiDescriptor();
-      await launchInteractiveMode(descriptor);
-    });
+  const command = new Command("products").description("Manage products").action(async () => {
+    const { launchInteractiveMode } = await import("../tui");
+    const descriptor = getProductsTuiDescriptor();
+    await launchInteractiveMode(descriptor);
+  });
 
   // Create product
   command
@@ -169,26 +165,14 @@ export function createProductsCommand(): Command {
     .description("Create a new product")
     .requiredOption("--name <name>", "Product name")
     .requiredOption("--description <text>", "Product description")
-    .requiredOption(
-      "--price <cents>",
-      "Price in cents (e.g. 1000 = $10.00, minimum 100)",
-    )
-    .requiredOption(
-      "--currency <code>",
-      "Three-letter ISO currency code (USD, EUR)",
-    )
-    .requiredOption(
-      "--billing-type <type>",
-      'Billing method: "recurring" or "onetime"',
-    )
+    .requiredOption("--price <cents>", "Price in cents (e.g. 1000 = $10.00, minimum 100)")
+    .requiredOption("--currency <code>", "Three-letter ISO currency code (USD, EUR)")
+    .requiredOption("--billing-type <type>", 'Billing method: "recurring" or "onetime"')
     .option(
       "--billing-period <period>",
       "Billing period (required for recurring): every-month, every-three-months, every-six-months, every-year",
     )
-    .option(
-      "--tax-mode <mode>",
-      'Tax calculation mode: "inclusive" or "exclusive"',
-    )
+    .option("--tax-mode <mode>", 'Tax calculation mode: "inclusive" or "exclusive"')
     .option(
       "--tax-category <category>",
       'Tax category: "saas", "digital-goods-service", or "ebooks"',
@@ -266,15 +250,10 @@ ${chalk.dim("Examples:")}
           "every-year",
         ];
         if (options.billingType === "recurring" && !options.billingPeriod) {
-          output.error(
-            "Billing period is required for recurring products. Use --billing-period.",
-          );
+          output.error("Billing period is required for recurring products. Use --billing-period.");
           process.exit(1);
         }
-        if (
-          options.billingPeriod &&
-          !validBillingPeriods.includes(options.billingPeriod)
-        ) {
+        if (options.billingPeriod && !validBillingPeriods.includes(options.billingPeriod)) {
           output.error(
             `Invalid billing period "${options.billingPeriod}". Must be one of: ${validBillingPeriods.join(", ")}.`,
           );
@@ -282,10 +261,7 @@ ${chalk.dim("Examples:")}
         }
 
         // Validate tax mode
-        if (
-          options.taxMode &&
-          !["inclusive", "exclusive"].includes(options.taxMode)
-        ) {
+        if (options.taxMode && !["inclusive", "exclusive"].includes(options.taxMode)) {
           output.error(
             `Invalid tax mode "${options.taxMode}". Must be "inclusive" or "exclusive".`,
           );
@@ -294,10 +270,7 @@ ${chalk.dim("Examples:")}
 
         // Validate tax category
         const validTaxCategories = ["saas", "digital-goods-service", "ebooks"];
-        if (
-          options.taxCategory &&
-          !validTaxCategories.includes(options.taxCategory)
-        ) {
+        if (options.taxCategory && !validTaxCategories.includes(options.taxCategory)) {
           output.error(
             `Invalid tax category "${options.taxCategory}". Must be one of: ${validTaxCategories.join(", ")}.`,
           );
@@ -307,9 +280,7 @@ ${chalk.dim("Examples:")}
         // Validate currency
         const currency = options.currency.toUpperCase();
         if (!["USD", "EUR"].includes(currency)) {
-          output.error(
-            `Invalid currency "${options.currency}". Supported currencies: USD, EUR.`,
-          );
+          output.error(`Invalid currency "${options.currency}". Supported currencies: USD, EUR.`);
           process.exit(1);
         }
 
@@ -400,9 +371,7 @@ ${chalk.dim("Examples:")}
           output.newline();
         } catch (error) {
           spinner.fail("Failed to create product");
-          output.error(
-            error instanceof Error ? error.message : "Unknown error",
-          );
+          output.error(error instanceof Error ? error.message : "Unknown error");
           process.exit(1);
         }
       },
@@ -415,61 +384,55 @@ ${chalk.dim("Examples:")}
     .option("--json", "Output as JSON")
     .option("--page <number>", "Page number", "1")
     .option("--limit <number>", "Number of results per page", "20")
-    .action(
-      async (options: { json?: boolean; page: string; limit: string }) => {
-        const spinner = ora("Fetching products...").start();
+    .action(async (options: { json?: boolean; page: string; limit: string }) => {
+      const spinner = ora("Fetching products...").start();
 
-        try {
-          const client = getClient();
-          const response = (await client.products.search(
-            parseInt(options.page, 10),
-            parseInt(options.limit, 10),
-          )) as unknown as ProductListResponse;
+      try {
+        const client = getClient();
+        const response = (await client.products.search(
+          parseInt(options.page, 10),
+          parseInt(options.limit, 10),
+        )) as unknown as ProductListResponse;
 
-          spinner.stop();
+        spinner.stop();
 
-          const { items, pagination } = response;
+        const { items, pagination } = response;
 
-          if (shouldOutputJson(options.json)) {
-            output.outputJson(response);
-            return;
-          }
-
-          output.newline();
-
-          if (items.length === 0) {
-            output.info("No products found.");
-            output.dim(
-              "Create a product at: https://creem.io/dashboard/products",
-            );
-            return;
-          }
-
-          output.outputTable(
-            ["ID", "Name", "Price", "Billing", "Status"],
-            items.map((p) => [
-              p.id,
-              output.truncate(p.name, 30),
-              output.formatCurrency(p.price, p.currency),
-              formatBilling(p),
-              formatStatus(p.status),
-            ]),
-          );
-
-          output.newline();
-          output.dim(
-            `Page ${pagination.currentPage} of ${pagination.totalPages} (${pagination.totalRecords} total)`,
-          );
-          output.newline();
-        } catch (error) {
-          spinner.stop();
-          output.error(
-            error instanceof Error ? error.message : "Failed to fetch products",
-          );
-          process.exit(1);
+        if (shouldOutputJson(options.json)) {
+          output.outputJson(response);
+          return;
         }
-      },
-    );
+
+        output.newline();
+
+        if (items.length === 0) {
+          output.info("No products found.");
+          output.dim("Create a product at: https://creem.io/dashboard/products");
+          return;
+        }
+
+        output.outputTable(
+          ["ID", "Name", "Price", "Billing", "Status"],
+          items.map((p) => [
+            p.id,
+            output.truncate(p.name, 30),
+            output.formatCurrency(p.price, p.currency),
+            formatBilling(p),
+            formatStatus(p.status),
+          ]),
+        );
+
+        output.newline();
+        output.dim(
+          `Page ${pagination.currentPage} of ${pagination.totalPages} (${pagination.totalRecords} total)`,
+        );
+        output.newline();
+      } catch (error) {
+        spinner.stop();
+        output.error(error instanceof Error ? error.message : "Failed to fetch products");
+        process.exit(1);
+      }
+    });
 
   // Get product by ID
   command
@@ -481,9 +444,7 @@ ${chalk.dim("Examples:")}
 
       try {
         const client = getClient();
-        const product = (await client.products.get(
-          productId,
-        )) as unknown as Product;
+        const product = (await client.products.get(productId)) as unknown as Product;
 
         spinner.stop();
 
@@ -532,9 +493,7 @@ ${chalk.dim("Examples:")}
         output.newline();
       } catch (error) {
         spinner.stop();
-        output.error(
-          error instanceof Error ? error.message : "Failed to fetch product",
-        );
+        output.error(error instanceof Error ? error.message : "Failed to fetch product");
         process.exit(1);
       }
     });

--- a/packages/cli/src/commands/subscriptions.ts
+++ b/packages/cli/src/commands/subscriptions.ts
@@ -70,12 +70,7 @@ async function fetchSubscriptionsFromTransactions(
   options: FetchSubscriptionsOptions,
 ): Promise<FetchSubscriptionsResult> {
   const client = getClient();
-  const {
-    targetCount,
-    maxTransactionPages = 20,
-    statusFilter,
-    onProgress,
-  } = options;
+  const { targetCount, maxTransactionPages = 20, statusFilter, onProgress } = options;
 
   // Phase 1: Collect unique subscription IDs from transactions
   const subscriptionIds = new Set<string>();
@@ -84,10 +79,7 @@ async function fetchSubscriptionsFromTransactions(
 
   onProgress?.("Scanning transactions for subscriptions...");
 
-  while (
-    subscriptionIds.size < targetCount &&
-    transactionPage <= maxTransactionPages
-  ) {
+  while (subscriptionIds.size < targetCount && transactionPage <= maxTransactionPages) {
     const transactions = await client.transactions.search(
       undefined,
       undefined,
@@ -95,9 +87,7 @@ async function fetchSubscriptionsFromTransactions(
       transactionPage,
       50,
     );
-    const items =
-      (transactions as { items?: Array<{ subscription?: string }> }).items ||
-      [];
+    const items = (transactions as { items?: Array<{ subscription?: string }> }).items || [];
 
     if (items.length === 0) {
       noMoreTransactions = true;
@@ -126,9 +116,7 @@ async function fetchSubscriptionsFromTransactions(
   const batchSize = 10;
   for (let i = 0; i < subscriptionIdArray.length; i += batchSize) {
     const batch = subscriptionIdArray.slice(i, i + batchSize);
-    const results = await Promise.allSettled(
-      batch.map((id) => client.subscriptions.get(id)),
-    );
+    const results = await Promise.allSettled(batch.map((id) => client.subscriptions.get(id)));
 
     for (const result of results) {
       if (result.status === "fulfilled") {
@@ -224,18 +212,14 @@ function getSubscriptionDetailLines(sub: Subscription): string[] {
   lines.push(dl("Product ID", String(product?.id || sub.product)));
 
   if (product) {
-    lines.push(
-      dl("Price", output.formatCurrency(product.price, product.currency)),
-    );
+    lines.push(dl("Price", output.formatCurrency(product.price, product.currency)));
     if (product.billingPeriod) {
       lines.push(dl("Billing Period", product.billingPeriod));
     }
   }
 
   if (sub.currentPeriodStartDate) {
-    lines.push(
-      dl("Period Start", output.formatDate(sub.currentPeriodStartDate)),
-    );
+    lines.push(dl("Period Start", output.formatDate(sub.currentPeriodStartDate)));
   }
   if (sub.currentPeriodEndDate) {
     lines.push(dl("Period End", output.formatDate(sub.currentPeriodEndDate)));
@@ -261,25 +245,18 @@ function getSubscriptionsTuiDescriptor(): TuiModuleDescriptor<Subscription> {
       {
         header: "Customer",
         width: 28,
-        value: (s) =>
-          typeof s.customer === "object"
-            ? s.customer.email
-            : String(s.customer),
+        value: (s) => (typeof s.customer === "object" ? s.customer.email : String(s.customer)),
       },
       {
         header: "Product",
         width: 20,
-        value: (s) =>
-          typeof s.product === "object" ? s.product.name : String(s.product),
+        value: (s) => (typeof s.product === "object" ? s.product.name : String(s.product)),
       },
       { header: "Status", width: 12, value: (s) => formatStatus(s.status) },
       {
         header: "Next Billing",
         width: "auto",
-        value: (s) =>
-          s.nextTransactionDate
-            ? output.formatDate(s.nextTransactionDate)
-            : "-",
+        value: (s) => (s.nextTransactionDate ? output.formatDate(s.nextTransactionDate) : "-"),
       },
     ],
     fetchPage: (() => {
@@ -308,8 +285,7 @@ function getSubscriptionsTuiDescriptor(): TuiModuleDescriptor<Subscription> {
         // - Or we're on page 1 and API indicated more pages exist (for initial load indicator)
         // Don't use hasMorePages on pages > 1 as we only slice from cache at that point
         const hasMoreInCache = cachedSubscriptions.length > endIndex;
-        const mightHaveMoreFromApi =
-          page === 1 && hasMorePages && pageItems.length > 0;
+        const mightHaveMoreFromApi = page === 1 && hasMorePages && pageItems.length > 0;
 
         return {
           items: pageItems,
@@ -367,10 +343,8 @@ function getSubscriptionsTuiDescriptor(): TuiModuleDescriptor<Subscription> {
     ],
     searchFilter: (s, query) => {
       const q = query.toLowerCase();
-      const customer =
-        typeof s.customer === "object" ? s.customer.email : String(s.customer);
-      const product =
-        typeof s.product === "object" ? s.product.name : String(s.product);
+      const customer = typeof s.customer === "object" ? s.customer.email : String(s.customer);
+      const product = typeof s.product === "object" ? s.product.name : String(s.product);
       return (
         s.id.toLowerCase().includes(q) ||
         customer.toLowerCase().includes(q) ||
@@ -401,9 +375,7 @@ export function createSubscriptionsCommand(): Command {
 
       try {
         const client = getClient();
-        const result = (await client.subscriptions.get(
-          id,
-        )) as unknown as Subscription;
+        const result = (await client.subscriptions.get(id)) as unknown as Subscription;
 
         spinner.stop();
         formatSubscription(result, options.json);
@@ -418,57 +390,40 @@ export function createSubscriptionsCommand(): Command {
   command
     .command("cancel <id>")
     .description("Cancel a subscription")
-    .option(
-      "--mode <mode>",
-      "Cancellation mode: immediate or scheduled",
-      "immediate",
-    )
-    .option(
-      "--on-execute <action>",
-      "Action on scheduled cancel: cancel or pause",
-    )
+    .option("--mode <mode>", "Cancellation mode: immediate or scheduled", "immediate")
+    .option("--on-execute <action>", "Action on scheduled cancel: cancel or pause")
     .option("--json", "Output as JSON")
-    .action(
-      async (
-        id: string,
-        options: { mode?: string; onExecute?: string; json?: boolean },
-      ) => {
-        const spinner = ora("Canceling subscription...").start();
+    .action(async (id: string, options: { mode?: string; onExecute?: string; json?: boolean }) => {
+      const spinner = ora("Canceling subscription...").start();
 
-        try {
-          const client = getClient();
+      try {
+        const client = getClient();
 
-          // Cast to the expected SDK types
-          const params: {
-            mode?: "immediate" | "scheduled";
-            onExecute?: "cancel" | "pause";
-          } = {};
-          if (options.mode === "immediate" || options.mode === "scheduled") {
-            params.mode = options.mode;
-          }
-          if (options.onExecute === "cancel" || options.onExecute === "pause") {
-            params.onExecute = options.onExecute;
-          }
-
-          const result = (await client.subscriptions.cancel(
-            id,
-            params,
-          )) as unknown as Subscription;
-
-          spinner.succeed("Subscription canceled");
-          if (!shouldOutputJson(options.json)) {
-            output.newline();
-          }
-          formatSubscription(result, options.json);
-        } catch (error) {
-          spinner.fail("Failed to cancel subscription");
-          output.error(
-            error instanceof Error ? error.message : "Unknown error",
-          );
-          process.exit(1);
+        // Cast to the expected SDK types
+        const params: {
+          mode?: "immediate" | "scheduled";
+          onExecute?: "cancel" | "pause";
+        } = {};
+        if (options.mode === "immediate" || options.mode === "scheduled") {
+          params.mode = options.mode;
         }
-      },
-    );
+        if (options.onExecute === "cancel" || options.onExecute === "pause") {
+          params.onExecute = options.onExecute;
+        }
+
+        const result = (await client.subscriptions.cancel(id, params)) as unknown as Subscription;
+
+        spinner.succeed("Subscription canceled");
+        if (!shouldOutputJson(options.json)) {
+          output.newline();
+        }
+        formatSubscription(result, options.json);
+      } catch (error) {
+        spinner.fail("Failed to cancel subscription");
+        output.error(error instanceof Error ? error.message : "Unknown error");
+        process.exit(1);
+      }
+    });
 
   // Pause subscription
   command
@@ -480,9 +435,7 @@ export function createSubscriptionsCommand(): Command {
 
       try {
         const client = getClient();
-        const result = (await client.subscriptions.pause(
-          id,
-        )) as unknown as Subscription;
+        const result = (await client.subscriptions.pause(id)) as unknown as Subscription;
 
         spinner.succeed("Subscription paused");
         if (!shouldOutputJson(options.json)) {
@@ -506,9 +459,7 @@ export function createSubscriptionsCommand(): Command {
 
       try {
         const client = getClient();
-        const result = (await client.subscriptions.resume(
-          id,
-        )) as unknown as Subscription;
+        const result = (await client.subscriptions.resume(id)) as unknown as Subscription;
 
         spinner.succeed("Subscription resumed");
         if (!shouldOutputJson(options.json)) {
@@ -528,109 +479,82 @@ export function createSubscriptionsCommand(): Command {
     .description("List all subscriptions")
     .option("--page <number>", "Page number", "1")
     .option("--limit <number>", "Results per page", "10")
-    .option(
-      "--status <status>",
-      "Filter by status (active, paused, canceled, scheduled_cancel)",
-    )
+    .option("--status <status>", "Filter by status (active, paused, canceled, scheduled_cancel)")
     .option("--json", "Output as JSON")
-    .action(
-      async (options: {
-        page?: string;
-        limit?: string;
-        status?: string;
-        json?: boolean;
-      }) => {
-        const spinner = ora("Fetching subscriptions...").start();
+    .action(async (options: { page?: string; limit?: string; status?: string; json?: boolean }) => {
+      const spinner = ora("Fetching subscriptions...").start();
 
-        try {
-          const pageSize = Math.min(parseInt(options.limit || "10", 10), 50);
-          const statusFilter = options.status?.toLowerCase();
-          const requestedPage = parseInt(options.page || "1", 10);
+      try {
+        const pageSize = Math.min(parseInt(options.limit || "10", 10), 50);
+        const statusFilter = options.status?.toLowerCase();
+        const requestedPage = parseInt(options.page || "1", 10);
 
-          // Use shared helper to fetch subscriptions (avoids N+1 queries)
-          const targetCount = requestedPage * pageSize + 50; // Fetch extra to account for filtering
-          const result = await fetchSubscriptionsFromTransactions({
-            targetCount,
-            statusFilter,
-            onProgress: (msg) => {
-              spinner.text = msg;
-            },
-          });
+        // Use shared helper to fetch subscriptions (avoids N+1 queries)
+        const targetCount = requestedPage * pageSize + 50; // Fetch extra to account for filtering
+        const result = await fetchSubscriptionsFromTransactions({
+          targetCount,
+          statusFilter,
+          onProgress: (msg) => {
+            spinner.text = msg;
+          },
+        });
 
-          if (result.subscriptions.length === 0) {
-            spinner.stop();
-            output.info("No subscriptions found");
-            return;
-          }
-
-          // Apply pagination
-          const startIndex = (requestedPage - 1) * pageSize;
-          const subscriptions = result.subscriptions.slice(
-            startIndex,
-            startIndex + pageSize,
-          );
-
+        if (result.subscriptions.length === 0) {
           spinner.stop();
-
-          if (shouldOutputJson(options.json)) {
-            output.outputJson({
-              items: subscriptions,
-              total: result.subscriptions.length,
-              page: requestedPage,
-              pageSize: pageSize,
-              note: "Subscriptions derived from transaction history",
-            });
-            return;
-          }
-
-          if (subscriptions.length === 0) {
-            output.info("No subscriptions found");
-            return;
-          }
-
-          // Format as table
-          const headers = [
-            "ID",
-            "Customer",
-            "Product",
-            "Status",
-            "Next Billing",
-          ];
-          const rows = subscriptions.map((sub) => {
-            const customer =
-              typeof sub.customer === "object"
-                ? sub.customer.email
-                : sub.customer;
-            const product =
-              typeof sub.product === "object" ? sub.product.name : sub.product;
-            return [
-              sub.id,
-              customer,
-              product,
-              formatStatus(sub.status),
-              sub.nextTransactionDate
-                ? output.formatDate(sub.nextTransactionDate)
-                : "-",
-            ];
-          });
-
-          output.outputTable(headers, rows);
-          output.newline();
-          output.info(
-            `Showing ${subscriptions.length} of ${result.subscriptions.length} subscription(s) (page ${requestedPage})`,
-          );
-          if (statusFilter) {
-            output.info(`Filtered by status: ${statusFilter}`);
-          }
-        } catch (error) {
-          spinner.fail("Failed to fetch subscriptions");
-          output.error(
-            error instanceof Error ? error.message : "Unknown error",
-          );
-          process.exit(1);
+          output.info("No subscriptions found");
+          return;
         }
-      },
-    );
+
+        // Apply pagination
+        const startIndex = (requestedPage - 1) * pageSize;
+        const subscriptions = result.subscriptions.slice(startIndex, startIndex + pageSize);
+
+        spinner.stop();
+
+        if (shouldOutputJson(options.json)) {
+          output.outputJson({
+            items: subscriptions,
+            total: result.subscriptions.length,
+            page: requestedPage,
+            pageSize: pageSize,
+            note: "Subscriptions derived from transaction history",
+          });
+          return;
+        }
+
+        if (subscriptions.length === 0) {
+          output.info("No subscriptions found");
+          return;
+        }
+
+        // Format as table
+        const headers = ["ID", "Customer", "Product", "Status", "Next Billing"];
+        const rows = subscriptions.map((sub) => {
+          const customer = typeof sub.customer === "object" ? sub.customer.email : sub.customer;
+          const product = typeof sub.product === "object" ? sub.product.name : sub.product;
+          return [
+            sub.id,
+            customer,
+            product,
+            formatStatus(sub.status),
+            sub.nextTransactionDate ? output.formatDate(sub.nextTransactionDate) : "-",
+          ];
+        });
+
+        output.outputTable(headers, rows);
+        output.newline();
+        output.info(
+          `Showing ${subscriptions.length} of ${result.subscriptions.length} subscription(s) (page ${requestedPage})`,
+        );
+        if (statusFilter) {
+          output.info(`Filtered by status: ${statusFilter}`);
+        }
+      } catch (error) {
+        spinner.fail("Failed to fetch subscriptions");
+        output.error(error instanceof Error ? error.message : "Unknown error");
+        process.exit(1);
+      }
+    });
 
   return command;
 }

--- a/packages/cli/src/commands/transactions.ts
+++ b/packages/cli/src/commands/transactions.ts
@@ -161,27 +161,19 @@ function getTransactionDetailLines(txn: Transaction): string[] {
   lines.push(dl("Mode", txn.mode));
 
   if (txn.amountPaid != null) {
-    lines.push(
-      dl("Amount Paid", output.formatCurrency(txn.amountPaid, txn.currency)),
-    );
+    lines.push(dl("Amount Paid", output.formatCurrency(txn.amountPaid, txn.currency)));
   }
   if (txn.discountAmount != null) {
-    lines.push(
-      dl("Discount", output.formatCurrency(txn.discountAmount, txn.currency)),
-    );
+    lines.push(dl("Discount", output.formatCurrency(txn.discountAmount, txn.currency)));
   }
   if (txn.taxAmount != null) {
-    lines.push(
-      dl("Tax Amount", output.formatCurrency(txn.taxAmount, txn.currency)),
-    );
+    lines.push(dl("Tax Amount", output.formatCurrency(txn.taxAmount, txn.currency)));
   }
   if (txn.taxCountry) {
     lines.push(dl("Tax Country", txn.taxCountry));
   }
   if (txn.refundedAmount != null) {
-    lines.push(
-      dl("Refunded", output.formatCurrency(txn.refundedAmount, txn.currency)),
-    );
+    lines.push(dl("Refunded", output.formatCurrency(txn.refundedAmount, txn.currency)));
   }
   if (txn.order) {
     lines.push(dl("Order", txn.order));
@@ -353,11 +345,7 @@ export function createTransactionsCommand(): Command {
           output.newline();
         } catch (error) {
           spinner.stop();
-          output.error(
-            error instanceof Error
-              ? error.message
-              : "Failed to fetch transactions",
-          );
+          output.error(error instanceof Error ? error.message : "Failed to fetch transactions");
           process.exit(1);
         }
       },

--- a/packages/cli/src/lib/api.ts
+++ b/packages/cli/src/lib/api.ts
@@ -33,11 +33,7 @@ export function getClient(): Creem {
   const environment = getConfigValue("environment");
 
   // Recreate client if API key or environment changed
-  if (
-    !clientInstance ||
-    apiKey !== cachedApiKey ||
-    environment !== cachedEnvironment
-  ) {
+  if (!clientInstance || apiKey !== cachedApiKey || environment !== cachedEnvironment) {
     clientInstance = new Creem({
       apiKey,
       // 0 = live (api.creem.io), 1 = test (test-api.creem.io)

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -1,9 +1,4 @@
-import {
-  loadConfig,
-  saveConfig,
-  isAuthenticated,
-  getConfigValue,
-} from "./config";
+import { loadConfig, saveConfig, isAuthenticated, getConfigValue } from "./config";
 import { validateApiKey, resetClient } from "./api";
 
 export interface LoginResult {
@@ -51,8 +46,7 @@ export async function loginWithApiKey(apiKey: string): Promise<LoginResult> {
   } catch (error) {
     return {
       success: false,
-      message:
-        error instanceof Error ? error.message : "Invalid API key format",
+      message: error instanceof Error ? error.message : "Invalid API key format",
     };
   }
 

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -35,10 +35,7 @@ function validateConfig(config: Partial<CreemConfig>): CreemConfig {
   const validated: CreemConfig = { ...DEFAULT_CONFIG };
 
   // Validate environment
-  if (
-    config.environment &&
-    VALID_ENVIRONMENTS.includes(config.environment as "test" | "live")
-  ) {
+  if (config.environment && VALID_ENVIRONMENTS.includes(config.environment as "test" | "live")) {
     validated.environment = config.environment as "test" | "live";
   }
 
@@ -87,9 +84,7 @@ export function saveConfig(config: CreemConfig): void {
 /**
  * Gets a specific config value
  */
-export function getConfigValue<K extends keyof CreemConfig>(
-  key: K,
-): CreemConfig[K] {
+export function getConfigValue<K extends keyof CreemConfig>(key: K): CreemConfig[K] {
   const config = loadConfig();
   return config[key];
 }
@@ -97,10 +92,7 @@ export function getConfigValue<K extends keyof CreemConfig>(
 /**
  * Sets a specific config value
  */
-export function setConfigValue<K extends keyof CreemConfig>(
-  key: K,
-  value: CreemConfig[K],
-): void {
+export function setConfigValue<K extends keyof CreemConfig>(key: K, value: CreemConfig[K]): void {
   const config = loadConfig();
   config[key] = value;
   saveConfig(config);

--- a/packages/cli/src/tui/engine.ts
+++ b/packages/cli/src/tui/engine.ts
@@ -8,14 +8,10 @@ import { parseCommand } from "./command-bar";
 const PAGE_SIZE = 15;
 const STATUS_CLEAR_MS = 3000;
 
-export async function launchInteractiveMode<T>(
-  descriptor: TuiModuleDescriptor<T>,
-): Promise<void> {
+export async function launchInteractiveMode<T>(descriptor: TuiModuleDescriptor<T>): Promise<void> {
   // Non-TTY fallback
   if (!process.stdout.isTTY || !process.stdin.isTTY) {
-    console.error(
-      'Interactive mode requires a TTY. Use the "list" subcommand instead.',
-    );
+    console.error('Interactive mode requires a TTY. Use the "list" subcommand instead.');
     process.exit(1);
   }
 
@@ -48,10 +44,7 @@ export async function launchInteractiveMode<T>(
     process.stdin.pause();
   };
 
-  const setStatus = (
-    message: string,
-    type: "info" | "success" | "error",
-  ): void => {
+  const setStatus = (message: string, type: "info" | "success" | "error"): void => {
     state.statusMessage = message;
     state.statusType = type;
     if (statusTimer) clearTimeout(statusTimer);
@@ -70,17 +63,13 @@ export async function launchInteractiveMode<T>(
     doRender();
     try {
       const result = await descriptor.fetchPage(page, PAGE_SIZE);
-      state.items =
-        page === 1 ? result.items : [...state.items, ...result.items];
+      state.items = page === 1 ? result.items : [...state.items, ...result.items];
       state.hasMorePages = result.hasMore;
       state.currentPage = page;
       if (result.total !== undefined) state.totalItems = result.total;
       applySearchFilter();
     } catch (err) {
-      setStatus(
-        err instanceof Error ? err.message : "Failed to fetch data",
-        "error",
-      );
+      setStatus(err instanceof Error ? err.message : "Failed to fetch data", "error");
     } finally {
       state.isLoading = false;
       doRender();
@@ -108,10 +97,7 @@ export async function launchInteractiveMode<T>(
       state.scrollOffset = 0;
       return;
     }
-    state.cursorIndex = Math.max(
-      0,
-      Math.min(state.cursorIndex, items.length - 1),
-    );
+    state.cursorIndex = Math.max(0, Math.min(state.cursorIndex, items.length - 1));
     const visibleRows = getVisibleRows();
     if (state.cursorIndex < state.scrollOffset) {
       state.scrollOffset = state.cursorIndex;
@@ -126,19 +112,12 @@ export async function launchInteractiveMode<T>(
     // Wrap lines the same way the renderer does to get accurate line count
     const wrappedLines = wrapDetailLines(rawDetailLines, cols - 2);
     const maxScroll = Math.max(0, wrappedLines.length - detailVisibleRows);
-    state.detailScrollOffset = Math.max(
-      0,
-      Math.min(state.detailScrollOffset, maxScroll),
-    );
+    state.detailScrollOffset = Math.max(0, Math.min(state.detailScrollOffset, maxScroll));
   };
 
   const maybeFetchMore = async (): Promise<void> => {
     const items = getActiveItems();
-    if (
-      state.hasMorePages &&
-      !state.isLoading &&
-      state.cursorIndex >= items.length - 5
-    ) {
+    if (state.hasMorePages && !state.isLoading && state.cursorIndex >= items.length - 5) {
       await fetchPage(state.currentPage + 1);
     }
   };
@@ -192,14 +171,8 @@ export async function launchInteractiveMode<T>(
             const cols = process.stdout.columns || 80;
             const rawLines = descriptor.renderDetail(state.selectedItem);
             const wrappedLines = wrapDetailLines(rawLines, cols - 2);
-            const detailVisibleRows = Math.max(
-              1,
-              (process.stdout.rows || 24) - 3,
-            );
-            state.detailScrollOffset = Math.max(
-              0,
-              wrappedLines.length - detailVisibleRows,
-            );
+            const detailVisibleRows = Math.max(1, (process.stdout.rows || 24) - 3);
+            state.detailScrollOffset = Math.max(0, wrappedLines.length - detailVisibleRows);
           } else {
             state.cursorIndex = items.length - 1;
             clampCursor();
@@ -225,10 +198,7 @@ export async function launchInteractiveMode<T>(
         case "half_page_up": {
           const half = Math.floor(visibleRows / 2);
           if (state.mode === "detail") {
-            state.detailScrollOffset = Math.max(
-              0,
-              state.detailScrollOffset - half,
-            );
+            state.detailScrollOffset = Math.max(0, state.detailScrollOffset - half);
           } else {
             state.cursorIndex -= half;
             clampCursor();
@@ -324,9 +294,7 @@ export async function launchInteractiveMode<T>(
         case "confirm_yes": {
           if (state.mode === "confirm" && state.pendingCommand) {
             const cmd = state.pendingCommand;
-            const item =
-              state.selectedItem ||
-              (items.length > 0 ? items[state.cursorIndex] : null);
+            const item = state.selectedItem || (items.length > 0 ? items[state.cursorIndex] : null);
             state.pendingCommand = null;
             state.mode = state.selectedItem ? "detail" : "list";
             await runCommand(cmd, item);
@@ -364,10 +332,7 @@ export async function launchInteractiveMode<T>(
   };
 
   const executeCommand = async (): Promise<void> => {
-    const { parsed, error } = parseCommand(
-      state.commandInput,
-      descriptor.commands,
-    );
+    const { parsed, error } = parseCommand(state.commandInput, descriptor.commands);
     state.commandInput = "";
 
     if (error) {
@@ -382,9 +347,7 @@ export async function launchInteractiveMode<T>(
     }
 
     const items = getActiveItems();
-    const selectedItem =
-      state.selectedItem ||
-      (items.length > 0 ? items[state.cursorIndex] : null);
+    const selectedItem = state.selectedItem || (items.length > 0 ? items[state.cursorIndex] : null);
 
     if (parsed.command.requiresSelection && !selectedItem) {
       state.mode = "list";
@@ -452,18 +415,15 @@ export async function launchInteractiveMode<T>(
   // Keypress handler
   keymap.setPendingExpiredHandler(doRender);
 
-  process.stdin.on(
-    "keypress",
-    (str: string | undefined, key: readline.Key | undefined) => {
-      if (!running) return;
-      const action = keymap.resolve(str, key, state.mode);
-      // Handle async actions
-      handleAction(action).catch((err) => {
-        setStatus(err instanceof Error ? err.message : "Error", "error");
-        doRender();
-      });
-    },
-  );
+  process.stdin.on("keypress", (str: string | undefined, key: readline.Key | undefined) => {
+    if (!running) return;
+    const action = keymap.resolve(str, key, state.mode);
+    // Handle async actions
+    handleAction(action).catch((err) => {
+      setStatus(err instanceof Error ? err.message : "Error", "error");
+      doRender();
+    });
+  });
 
   // Fetch initial data
   await fetchPage(1);

--- a/packages/cli/src/tui/keymap.ts
+++ b/packages/cli/src/tui/keymap.ts
@@ -39,11 +39,7 @@ export class VimKeymap {
     this.onPendingExpired = handler;
   }
 
-  resolve(
-    str: string | undefined,
-    key: KeypressKey | undefined,
-    mode: TuiMode,
-  ): KeyAction {
+  resolve(str: string | undefined, key: KeypressKey | undefined, mode: TuiMode): KeyAction {
     if (mode === "confirm") {
       return this.resolveConfirmMode(str, key);
     }
@@ -64,22 +60,15 @@ export class VimKeymap {
     this.pendingKey = null;
   }
 
-  private resolveConfirmMode(
-    str: string | undefined,
-    key: KeypressKey | undefined,
-  ): KeyAction {
+  private resolveConfirmMode(str: string | undefined, key: KeypressKey | undefined): KeyAction {
     // Ctrl+C should quit (consistent with other modes)
     if (key?.ctrl && key?.name === "c") return "quit";
     if (str === "y" || str === "Y") return "confirm_yes";
-    if (str === "n" || str === "N" || key?.name === "escape")
-      return "confirm_no";
+    if (str === "n" || str === "N" || key?.name === "escape") return "confirm_no";
     return "none";
   }
 
-  private resolveInputMode(
-    str: string | undefined,
-    key: KeypressKey | undefined,
-  ): KeyAction {
+  private resolveInputMode(str: string | undefined, key: KeypressKey | undefined): KeyAction {
     if (key?.name === "escape") return "cancel_input";
     if (key?.name === "return") return "confirm_input";
     if (key?.name === "backspace") return "backspace_input";
@@ -95,19 +84,13 @@ export class VimKeymap {
     return "none";
   }
 
-  private resolveDetailMode(
-    str: string | undefined,
-    key: KeypressKey | undefined,
-  ): KeyAction {
+  private resolveDetailMode(str: string | undefined, key: KeypressKey | undefined): KeyAction {
     if (key?.ctrl && key?.name === "c") return this.clearPending("quit");
     if (str === "q" || key?.name === "escape") return this.clearPending("back");
-    if (str === "j" || key?.name === "down")
-      return this.clearPending("move_down");
+    if (str === "j" || key?.name === "down") return this.clearPending("move_down");
     if (str === "k" || key?.name === "up") return this.clearPending("move_up");
-    if (key?.ctrl && key?.name === "d")
-      return this.clearPending("half_page_down");
-    if (key?.ctrl && key?.name === "u")
-      return this.clearPending("half_page_up");
+    if (key?.ctrl && key?.name === "d") return this.clearPending("half_page_down");
+    if (key?.ctrl && key?.name === "u") return this.clearPending("half_page_up");
     if (str === ":") return this.clearPending("enter_command");
 
     // gg / G
@@ -118,21 +101,15 @@ export class VimKeymap {
     return "none";
   }
 
-  private resolveListMode(
-    str: string | undefined,
-    key: KeypressKey | undefined,
-  ): KeyAction {
+  private resolveListMode(str: string | undefined, key: KeypressKey | undefined): KeyAction {
     // Ctrl-c always quits
     if (key?.ctrl && key?.name === "c") return "quit";
 
     // Navigation
-    if (str === "j" || key?.name === "down")
-      return this.clearPending("move_down");
+    if (str === "j" || key?.name === "down") return this.clearPending("move_down");
     if (str === "k" || key?.name === "up") return this.clearPending("move_up");
-    if (key?.ctrl && key?.name === "d")
-      return this.clearPending("half_page_down");
-    if (key?.ctrl && key?.name === "u")
-      return this.clearPending("half_page_up");
+    if (key?.ctrl && key?.name === "d") return this.clearPending("half_page_down");
+    if (key?.ctrl && key?.name === "u") return this.clearPending("half_page_up");
 
     // G goes to bottom
     if (str === "G" && !key?.ctrl) return this.clearPending("goto_bottom");

--- a/packages/cli/src/tui/renderer.ts
+++ b/packages/cli/src/tui/renderer.ts
@@ -63,10 +63,7 @@ export function getVisibleRows(): number {
   return Math.max(1, (process.stdout.rows || 24) - HEADER_LINES - FOOTER_LINES);
 }
 
-export function render<T>(
-  descriptor: TuiModuleDescriptor<T>,
-  state: TuiState<T>,
-): void {
+export function render<T>(descriptor: TuiModuleDescriptor<T>, state: TuiState<T>): void {
   const cols = process.stdout.columns || 80;
   const rows = process.stdout.rows || 24;
 
@@ -112,9 +109,7 @@ function renderListView<T>(
   let headerLine = " ";
   for (let i = 0; i < descriptor.columns.length; i++) {
     const col = descriptor.columns[i];
-    headerLine += chalk.cyan(
-      padCell(col.header, columnWidths[i], col.align || "left"),
-    );
+    headerLine += chalk.cyan(padCell(col.header, columnWidths[i], col.align || "left"));
     if (i < descriptor.columns.length - 1) headerLine += "  ";
   }
   buffer += truncateAnsi(headerLine, cols) + "\n";
@@ -186,8 +181,7 @@ function renderDetailView<T>(
   const detailLines = wrapDetailLines(rawLines, cols - 2); // -2 for leading space + margin
 
   // Header
-  buffer +=
-    truncateAnsi(` ${chalk.bold(descriptor.name + " Details")}`, cols) + "\n";
+  buffer += truncateAnsi(` ${chalk.bold(descriptor.name + " Details")}`, cols) + "\n";
   buffer += chalk.dim(" " + "\u2500".repeat(Math.max(0, cols - 2))) + "\n";
 
   // Detail content with scroll
@@ -414,11 +408,7 @@ function computeColumnWidths(
   });
 }
 
-function padCell(
-  text: string,
-  width: number,
-  align: "left" | "right" | "center",
-): string {
+function padCell(text: string, width: number, align: "left" | "right" | "center"): string {
   const visLen = displayWidth(text);
 
   // Need to truncate — use truncateAnsi to preserve ANSI color codes

--- a/packages/cli/src/utils/output.ts
+++ b/packages/cli/src/utils/output.ts
@@ -39,9 +39,7 @@ export function outputTable(
   for (const row of rows) {
     for (let i = 0; i < colCount; i++) {
       const cell = row[i];
-      const len = stripAnsi(
-        cell === null || cell === undefined ? "-" : String(cell),
-      ).length;
+      const len = stripAnsi(cell === null || cell === undefined ? "-" : String(cell)).length;
       if (len > maxColWidths[i]) {
         maxColWidths[i] = len;
       }
@@ -49,8 +47,7 @@ export function outputTable(
   }
 
   // Each column needs at least its content width + 2 chars padding (cli-table3 default)
-  const naturalWidth =
-    maxColWidths.reduce((sum, w) => sum + w + 2, 0) + borderOverhead;
+  const naturalWidth = maxColWidths.reduce((sum, w) => sum + w + 2, 0) + borderOverhead;
 
   // If the table fits, render normally
   if (naturalWidth <= termWidth) {
@@ -59,11 +56,7 @@ export function outputTable(
       style: { head: [], border: [] },
     });
     rows.forEach((row) => {
-      table.push(
-        row.map((cell) =>
-          cell === null || cell === undefined ? "-" : String(cell),
-        ),
-      );
+      table.push(row.map((cell) => (cell === null || cell === undefined ? "-" : String(cell))));
     });
     console.log(table.toString());
     return;
@@ -112,9 +105,7 @@ function fitColumns(naturalWidths: number[], available: number): number[] {
   while (total > available) {
     const maxWidth = Math.max(...widths);
     // Find all columns at the maximum width
-    const maxIndices = widths
-      .map((w, i) => (w === maxWidth ? i : -1))
-      .filter((i) => i !== -1);
+    const maxIndices = widths.map((w, i) => (w === maxWidth ? i : -1)).filter((i) => i !== -1);
 
     // When multiple columns are tied at max width, shrink them all by 1
     if (maxIndices.length > 1) {
@@ -144,10 +135,7 @@ function fitColumns(naturalWidths: number[], available: number): number[] {
 /**
  * Outputs key-value pairs
  */
-export function outputKeyValue(
-  data: Record<string, unknown>,
-  options: OutputOptions = {},
-): void {
+export function outputKeyValue(data: Record<string, unknown>, options: OutputOptions = {}): void {
   if (options.json) {
     outputJson(data);
     return;
@@ -157,8 +145,7 @@ export function outputKeyValue(
 
   for (const [key, value] of Object.entries(data)) {
     const paddedKey = key.padEnd(maxKeyLength);
-    const displayValue =
-      value === null || value === undefined ? chalk.dim("-") : String(value);
+    const displayValue = value === null || value === undefined ? chalk.dim("-") : String(value);
     console.log(`${chalk.cyan(paddedKey)}  ${displayValue}`);
   }
 }

--- a/packages/convex/example-react/src/App.tsx
+++ b/packages/convex/example-react/src/App.tsx
@@ -153,7 +153,9 @@ export default function App() {
 
         {/* Test card info */}
         <div className="rounded-lg border border-surface-300-700 bg-surface-100-900 px-4 py-3 text-sm text-foreground-muted">
-          <span className="font-medium text-foreground-default">Test card:</span>
+          <span className="font-medium text-foreground-default">
+            Test card:
+          </span>
           <code className="ml-1 rounded bg-surface-200-800 px-1.5 py-0.5 font-mono text-xs">
             4242 4242 4242 4242
           </code>
@@ -178,8 +180,8 @@ export default function App() {
               </h2>
               <p className="body-l col-span-12 mt-6 text-center text-foreground-muted lg:col-start-4 lg:col-span-6">
                 Subscription plans with a free trial. Monthly, quarterly,
-                semi-annual, and annual billing cycles — the cycle toggle appears
-                automatically from the registered plans.
+                semi-annual, and annual billing cycles — the cycle toggle
+                appears automatically from the registered plans.
               </p>
             </div>
 
@@ -411,8 +413,8 @@ export default function App() {
                 Mutually Exclusive Product Group
               </h2>
               <p className="body-l col-span-12 mt-6 text-center text-foreground-muted lg:col-start-4 lg:col-span-6">
-                A group of products where owning one affects available actions on
-                others. Upgrade paths are defined via a transition graph —
+                A group of products where owning one affects available actions
+                on others. Upgrade paths are defined via a transition graph —
                 upgrading from Basic to Premium uses a dedicated delta product.
                 Product images are synced from Creem.
               </p>

--- a/packages/convex/example-react/vite.config.ts
+++ b/packages/convex/example-react/vite.config.ts
@@ -14,14 +14,8 @@ export default defineConfig({
         __dirname,
         "../src/react/index.tsx",
       ),
-      "@creem_io/convex/styles": path.resolve(
-        __dirname,
-        "../src/library.css",
-      ),
-      "@creem_io/convex": path.resolve(
-        __dirname,
-        "../src/client/index.ts",
-      ),
+      "@creem_io/convex/styles": path.resolve(__dirname, "../src/library.css"),
+      "@creem_io/convex": path.resolve(__dirname, "../src/client/index.ts"),
     },
   },
   optimizeDeps: {

--- a/packages/convex/example-svelte/vite.config.ts
+++ b/packages/convex/example-svelte/vite.config.ts
@@ -19,10 +19,7 @@ export default defineConfig({
         __dirname,
         "../src/react/index.tsx",
       ),
-      "@creem_io/convex/styles": path.resolve(
-        __dirname,
-        "../src/library.css",
-      ),
+      "@creem_io/convex/styles": path.resolve(__dirname, "../src/library.css"),
       "@creem_io/convex": path.resolve(__dirname, "../src/client/index.ts"),
     },
   },

--- a/packages/convex/src/core/markdown.test.ts
+++ b/packages/convex/src/core/markdown.test.ts
@@ -26,9 +26,7 @@ describe("renderMarkdown", () => {
   });
 
   it("renders GFM tables", () => {
-    const result = renderMarkdown(
-      "| col1 | col2 |\n| --- | --- |\n| a | b |",
-    );
+    const result = renderMarkdown("| col1 | col2 |\n| --- | --- |\n| a | b |");
     expect(result).toContain("<table>");
     expect(result).toContain("<th>");
     expect(result).toContain("<td>");

--- a/packages/convex/src/react/primitives/PricingCard.tsx
+++ b/packages/convex/src/react/primitives/PricingCard.tsx
@@ -231,7 +231,6 @@ export const PricingCard = ({
         ) : null}
       </div>
 
-
       <div
         className={`mb-4 mt-6 ${showSeatCheckoutControls ? "flex flex-col gap-2" : "flex min-h-8 items-start"}`}
       >
@@ -326,8 +325,9 @@ export const PricingCard = ({
               Cancel subscription
             </button>
           ) : isActiveProduct ||
-            isActiveFreePlan ? /* Keep CTA row height but intentionally empty when current plan has no action */
-          null : (isSiblingPlan || isActivePlanOtherCycle) && productId ? (
+            isActiveFreePlan /* Keep CTA row height but intentionally empty when current plan has no action */ ? null : (isSiblingPlan ||
+              isActivePlanOtherCycle) &&
+            productId ? (
             <CheckoutButton
               productId={productId}
               disabled={disableSwitch}

--- a/packages/docs/.agents/skills/remotion-best-practices/rules/assets/charts-bar-chart.tsx
+++ b/packages/docs/.agents/skills/remotion-best-practices/rules/assets/charts-bar-chart.tsx
@@ -1,173 +1,165 @@
-import {loadFont} from '@remotion/google-fonts/Inter';
-import {AbsoluteFill, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+import { loadFont } from "@remotion/google-fonts/Inter";
+import { AbsoluteFill, spring, useCurrentFrame, useVideoConfig } from "remotion";
 
-const {fontFamily} = loadFont();
+const { fontFamily } = loadFont();
 
-const COLOR_BAR = '#D4AF37';
-const COLOR_TEXT = '#ffffff';
-const COLOR_MUTED = '#888888';
-const COLOR_BG = '#0a0a0a';
-const COLOR_AXIS = '#333333';
+const COLOR_BAR = "#D4AF37";
+const COLOR_TEXT = "#ffffff";
+const COLOR_MUTED = "#888888";
+const COLOR_BG = "#0a0a0a";
+const COLOR_AXIS = "#333333";
 
 // Ideal composition size: 1280x720
 
-const Title: React.FC<{children: React.ReactNode}> = ({children}) => (
-	<div style={{textAlign: 'center', marginBottom: 40}}>
-		<div style={{color: COLOR_TEXT, fontSize: 48, fontWeight: 600}}>
-			{children}
-		</div>
-	</div>
+const Title: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div style={{ textAlign: "center", marginBottom: 40 }}>
+    <div style={{ color: COLOR_TEXT, fontSize: 48, fontWeight: 600 }}>{children}</div>
+  </div>
 );
 
-const YAxis: React.FC<{steps: number[]; height: number}> = ({
-	steps,
-	height,
-}) => (
-	<div
-		style={{
-			display: 'flex',
-			flexDirection: 'column',
-			justifyContent: 'space-between',
-			height,
-			paddingRight: 16,
-		}}
-	>
-		{steps
-			.slice()
-			.reverse()
-			.map((step) => (
-				<div
-					key={step}
-					style={{
-						color: COLOR_MUTED,
-						fontSize: 20,
-						textAlign: 'right',
-					}}
-				>
-					{step.toLocaleString()}
-				</div>
-			))}
-	</div>
+const YAxis: React.FC<{ steps: number[]; height: number }> = ({ steps, height }) => (
+  <div
+    style={{
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "space-between",
+      height,
+      paddingRight: 16,
+    }}
+  >
+    {steps
+      .slice()
+      .reverse()
+      .map((step) => (
+        <div
+          key={step}
+          style={{
+            color: COLOR_MUTED,
+            fontSize: 20,
+            textAlign: "right",
+          }}
+        >
+          {step.toLocaleString()}
+        </div>
+      ))}
+  </div>
 );
 
 const Bar: React.FC<{
-	height: number;
-	progress: number;
-}> = ({height, progress}) => (
-	<div
-		style={{
-			flex: 1,
-			display: 'flex',
-			flexDirection: 'column',
-			justifyContent: 'flex-end',
-		}}
-	>
-		<div
-			style={{
-				width: '100%',
-				height,
-				backgroundColor: COLOR_BAR,
-				borderRadius: '8px 8px 0 0',
-				opacity: progress,
-			}}
-		/>
-	</div>
+  height: number;
+  progress: number;
+}> = ({ height, progress }) => (
+  <div
+    style={{
+      flex: 1,
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "flex-end",
+    }}
+  >
+    <div
+      style={{
+        width: "100%",
+        height,
+        backgroundColor: COLOR_BAR,
+        borderRadius: "8px 8px 0 0",
+        opacity: progress,
+      }}
+    />
+  </div>
 );
 
 const XAxis: React.FC<{
-	children: React.ReactNode;
-	labels: string[];
-	height: number;
-}> = ({children, labels, height}) => (
-	<div style={{flex: 1, display: 'flex', flexDirection: 'column'}}>
-		<div
-			style={{
-				display: 'flex',
-				alignItems: 'flex-end',
-				gap: 16,
-				height,
-				borderLeft: `2px solid ${COLOR_AXIS}`,
-				borderBottom: `2px solid ${COLOR_AXIS}`,
-				paddingLeft: 16,
-			}}
-		>
-			{children}
-		</div>
-		<div
-			style={{
-				display: 'flex',
-				gap: 16,
-				paddingLeft: 16,
-				marginTop: 12,
-			}}
-		>
-			{labels.map((label) => (
-				<div
-					key={label}
-					style={{
-						flex: 1,
-						textAlign: 'center',
-						color: COLOR_MUTED,
-						fontSize: 20,
-					}}
-				>
-					{label}
-				</div>
-			))}
-		</div>
-	</div>
+  children: React.ReactNode;
+  labels: string[];
+  height: number;
+}> = ({ children, labels, height }) => (
+  <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+    <div
+      style={{
+        display: "flex",
+        alignItems: "flex-end",
+        gap: 16,
+        height,
+        borderLeft: `2px solid ${COLOR_AXIS}`,
+        borderBottom: `2px solid ${COLOR_AXIS}`,
+        paddingLeft: 16,
+      }}
+    >
+      {children}
+    </div>
+    <div
+      style={{
+        display: "flex",
+        gap: 16,
+        paddingLeft: 16,
+        marginTop: 12,
+      }}
+    >
+      {labels.map((label) => (
+        <div
+          key={label}
+          style={{
+            flex: 1,
+            textAlign: "center",
+            color: COLOR_MUTED,
+            fontSize: 20,
+          }}
+        >
+          {label}
+        </div>
+      ))}
+    </div>
+  </div>
 );
 
 export const MyAnimation = () => {
-	const frame = useCurrentFrame();
-	const {fps, height} = useVideoConfig();
+  const frame = useCurrentFrame();
+  const { fps, height } = useVideoConfig();
 
-	const data = [
-		{month: 'Jan', price: 2039},
-		{month: 'Mar', price: 2160},
-		{month: 'May', price: 2327},
-		{month: 'Jul', price: 2426},
-		{month: 'Sep', price: 2634},
-		{month: 'Nov', price: 2672},
-	];
+  const data = [
+    { month: "Jan", price: 2039 },
+    { month: "Mar", price: 2160 },
+    { month: "May", price: 2327 },
+    { month: "Jul", price: 2426 },
+    { month: "Sep", price: 2634 },
+    { month: "Nov", price: 2672 },
+  ];
 
-	const minPrice = 2000;
-	const maxPrice = 2800;
-	const priceRange = maxPrice - minPrice;
-	const chartHeight = height - 280;
-	const yAxisSteps = [2000, 2400, 2800];
+  const minPrice = 2000;
+  const maxPrice = 2800;
+  const priceRange = maxPrice - minPrice;
+  const chartHeight = height - 280;
+  const yAxisSteps = [2000, 2400, 2800];
 
-	return (
-		<AbsoluteFill
-			style={{
-				backgroundColor: COLOR_BG,
-				padding: 60,
-				display: 'flex',
-				flexDirection: 'column',
-				fontFamily,
-			}}
-		>
-			<Title>Gold Price 2024</Title>
+  return (
+    <AbsoluteFill
+      style={{
+        backgroundColor: COLOR_BG,
+        padding: 60,
+        display: "flex",
+        flexDirection: "column",
+        fontFamily,
+      }}
+    >
+      <Title>Gold Price 2024</Title>
 
-			<div style={{display: 'flex', flex: 1}}>
-				<YAxis steps={yAxisSteps} height={chartHeight} />
-				<XAxis height={chartHeight} labels={data.map((d) => d.month)}>
-					{data.map((item, i) => {
-						const progress = spring({
-							frame: frame - i * 5 - 10,
-							fps,
-							config: {damping: 18, stiffness: 80},
-						});
+      <div style={{ display: "flex", flex: 1 }}>
+        <YAxis steps={yAxisSteps} height={chartHeight} />
+        <XAxis height={chartHeight} labels={data.map((d) => d.month)}>
+          {data.map((item, i) => {
+            const progress = spring({
+              frame: frame - i * 5 - 10,
+              fps,
+              config: { damping: 18, stiffness: 80 },
+            });
 
-						const barHeight =
-							((item.price - minPrice) / priceRange) * chartHeight * progress;
+            const barHeight = ((item.price - minPrice) / priceRange) * chartHeight * progress;
 
-						return (
-							<Bar key={item.month} height={barHeight} progress={progress} />
-						);
-					})}
-				</XAxis>
-			</div>
-		</AbsoluteFill>
-	);
+            return <Bar key={item.month} height={barHeight} progress={progress} />;
+          })}
+        </XAxis>
+      </div>
+    </AbsoluteFill>
+  );
 };

--- a/packages/docs/.agents/skills/remotion-best-practices/rules/assets/text-animations-typewriter.tsx
+++ b/packages/docs/.agents/skills/remotion-best-practices/rules/assets/text-animations-typewriter.tsx
@@ -1,14 +1,9 @@
-import {
-	AbsoluteFill,
-	interpolate,
-	useCurrentFrame,
-	useVideoConfig,
-} from 'remotion';
+import { AbsoluteFill, interpolate, useCurrentFrame, useVideoConfig } from "remotion";
 
-const COLOR_BG = '#ffffff';
-const COLOR_TEXT = '#000000';
-const FULL_TEXT = 'From prompt to motion graphics. This is Remotion.';
-const PAUSE_AFTER = 'From prompt to motion graphics.';
+const COLOR_BG = "#ffffff";
+const COLOR_TEXT = "#000000";
+const FULL_TEXT = "From prompt to motion graphics. This is Remotion.";
+const PAUSE_AFTER = "From prompt to motion graphics.";
 const FONT_SIZE = 72;
 const FONT_WEIGHT = 700;
 const CHAR_FRAMES = 2;
@@ -18,83 +13,77 @@ const PAUSE_SECONDS = 1;
 // Ideal composition size: 1280x720
 
 const getTypedText = ({
-	frame,
-	fullText,
-	pauseAfter,
-	charFrames,
-	pauseFrames,
+  frame,
+  fullText,
+  pauseAfter,
+  charFrames,
+  pauseFrames,
 }: {
-	frame: number;
-	fullText: string;
-	pauseAfter: string;
-	charFrames: number;
-	pauseFrames: number;
+  frame: number;
+  fullText: string;
+  pauseAfter: string;
+  charFrames: number;
+  pauseFrames: number;
 }): string => {
-	const pauseIndex = fullText.indexOf(pauseAfter);
-	const preLen =
-		pauseIndex >= 0 ? pauseIndex + pauseAfter.length : fullText.length;
+  const pauseIndex = fullText.indexOf(pauseAfter);
+  const preLen = pauseIndex >= 0 ? pauseIndex + pauseAfter.length : fullText.length;
 
-	let typedChars = 0;
-	if (frame < preLen * charFrames) {
-		typedChars = Math.floor(frame / charFrames);
-	} else if (frame < preLen * charFrames + pauseFrames) {
-		typedChars = preLen;
-	} else {
-		const postPhase = frame - preLen * charFrames - pauseFrames;
-		typedChars = Math.min(
-			fullText.length,
-			preLen + Math.floor(postPhase / charFrames),
-		);
-	}
-	return fullText.slice(0, typedChars);
+  let typedChars = 0;
+  if (frame < preLen * charFrames) {
+    typedChars = Math.floor(frame / charFrames);
+  } else if (frame < preLen * charFrames + pauseFrames) {
+    typedChars = preLen;
+  } else {
+    const postPhase = frame - preLen * charFrames - pauseFrames;
+    typedChars = Math.min(fullText.length, preLen + Math.floor(postPhase / charFrames));
+  }
+  return fullText.slice(0, typedChars);
 };
 
 const Cursor: React.FC<{
-	frame: number;
-	blinkFrames: number;
-	symbol?: string;
-}> = ({frame, blinkFrames, symbol = '\u258C'}) => {
-	const opacity = interpolate(
-		frame % blinkFrames,
-		[0, blinkFrames / 2, blinkFrames],
-		[1, 0, 1],
-		{extrapolateLeft: 'clamp', extrapolateRight: 'clamp'},
-	);
+  frame: number;
+  blinkFrames: number;
+  symbol?: string;
+}> = ({ frame, blinkFrames, symbol = "\u258C" }) => {
+  const opacity = interpolate(frame % blinkFrames, [0, blinkFrames / 2, blinkFrames], [1, 0, 1], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+  });
 
-	return <span style={{opacity}}>{symbol}</span>;
+  return <span style={{ opacity }}>{symbol}</span>;
 };
 
 export const MyAnimation = () => {
-	const frame = useCurrentFrame();
-	const {fps} = useVideoConfig();
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
 
-	const pauseFrames = Math.round(fps * PAUSE_SECONDS);
+  const pauseFrames = Math.round(fps * PAUSE_SECONDS);
 
-	const typedText = getTypedText({
-		frame,
-		fullText: FULL_TEXT,
-		pauseAfter: PAUSE_AFTER,
-		charFrames: CHAR_FRAMES,
-		pauseFrames,
-	});
+  const typedText = getTypedText({
+    frame,
+    fullText: FULL_TEXT,
+    pauseAfter: PAUSE_AFTER,
+    charFrames: CHAR_FRAMES,
+    pauseFrames,
+  });
 
-	return (
-		<AbsoluteFill
-			style={{
-				backgroundColor: COLOR_BG,
-			}}
-		>
-			<div
-				style={{
-					color: COLOR_TEXT,
-					fontSize: FONT_SIZE,
-					fontWeight: FONT_WEIGHT,
-					fontFamily: 'sans-serif',
-				}}
-			>
-				<span>{typedText}</span>
-				<Cursor frame={frame} blinkFrames={CURSOR_BLINK_FRAMES} />
-			</div>
-		</AbsoluteFill>
-	);
+  return (
+    <AbsoluteFill
+      style={{
+        backgroundColor: COLOR_BG,
+      }}
+    >
+      <div
+        style={{
+          color: COLOR_TEXT,
+          fontSize: FONT_SIZE,
+          fontWeight: FONT_WEIGHT,
+          fontFamily: "sans-serif",
+        }}
+      >
+        <span>{typedText}</span>
+        <Cursor frame={frame} blinkFrames={CURSOR_BLINK_FRAMES} />
+      </div>
+    </AbsoluteFill>
+  );
 };

--- a/packages/docs/.agents/skills/remotion-best-practices/rules/assets/text-animations-word-highlight.tsx
+++ b/packages/docs/.agents/skills/remotion-best-practices/rules/assets/text-animations-word-highlight.tsx
@@ -1,11 +1,6 @@
-import {loadFont} from '@remotion/google-fonts/Inter';
-import React from 'react';
-import {
-	AbsoluteFill,
-	spring,
-	useCurrentFrame,
-	useVideoConfig,
-} from 'remotion';
+import { loadFont } from "@remotion/google-fonts/Inter";
+import React from "react";
+import { AbsoluteFill, spring, useCurrentFrame, useVideoConfig } from "remotion";
 
 /*
  * Highlight a word in a sentence with a spring-animated wipe effect.
@@ -13,96 +8,94 @@ import {
 
 // Ideal composition size: 1280x720
 
-const COLOR_BG = '#ffffff';
-const COLOR_TEXT = '#000000';
-const COLOR_HIGHLIGHT = '#A7C7E7';
-const FULL_TEXT = 'This is Remotion.';
-const HIGHLIGHT_WORD = 'Remotion';
+const COLOR_BG = "#ffffff";
+const COLOR_TEXT = "#000000";
+const COLOR_HIGHLIGHT = "#A7C7E7";
+const FULL_TEXT = "This is Remotion.";
+const HIGHLIGHT_WORD = "Remotion";
 const FONT_SIZE = 72;
 const FONT_WEIGHT = 700;
 const HIGHLIGHT_START_FRAME = 30;
 const HIGHLIGHT_WIPE_DURATION = 18;
 
-const {fontFamily} = loadFont();
+const { fontFamily } = loadFont();
 
 const Highlight: React.FC<{
-	word: string;
-	color: string;
-	delay: number;
-	durationInFrames: number;
-}> = ({word, color, delay, durationInFrames}) => {
-	const frame = useCurrentFrame();
-	const {fps} = useVideoConfig();
+  word: string;
+  color: string;
+  delay: number;
+  durationInFrames: number;
+}> = ({ word, color, delay, durationInFrames }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
 
-	const highlightProgress = spring({
-		fps,
-		frame,
-		config: {damping: 200},
-		delay,
-		durationInFrames,
-	});
-	const scaleX = Math.max(0, Math.min(1, highlightProgress));
+  const highlightProgress = spring({
+    fps,
+    frame,
+    config: { damping: 200 },
+    delay,
+    durationInFrames,
+  });
+  const scaleX = Math.max(0, Math.min(1, highlightProgress));
 
-	return (
-		<span style={{position: 'relative', display: 'inline-block'}}>
-			<span
-				style={{
-					position: 'absolute',
-					left: 0,
-					right: 0,
-					top: '50%',
-					height: '1.05em',
-					transform: `translateY(-50%) scaleX(${scaleX})`,
-					transformOrigin: 'left center',
-					backgroundColor: color,
-					borderRadius: '0.18em',
-					zIndex: 0,
-				}}
-			/>
-			<span style={{position: 'relative', zIndex: 1}}>{word}</span>
-		</span>
-	);
+  return (
+    <span style={{ position: "relative", display: "inline-block" }}>
+      <span
+        style={{
+          position: "absolute",
+          left: 0,
+          right: 0,
+          top: "50%",
+          height: "1.05em",
+          transform: `translateY(-50%) scaleX(${scaleX})`,
+          transformOrigin: "left center",
+          backgroundColor: color,
+          borderRadius: "0.18em",
+          zIndex: 0,
+        }}
+      />
+      <span style={{ position: "relative", zIndex: 1 }}>{word}</span>
+    </span>
+  );
 };
 
 export const MyAnimation = () => {
-	const highlightIndex = FULL_TEXT.indexOf(HIGHLIGHT_WORD);
-	const hasHighlight = highlightIndex >= 0;
-	const preText = hasHighlight ? FULL_TEXT.slice(0, highlightIndex) : FULL_TEXT;
-	const postText = hasHighlight
-		? FULL_TEXT.slice(highlightIndex + HIGHLIGHT_WORD.length)
-		: '';
+  const highlightIndex = FULL_TEXT.indexOf(HIGHLIGHT_WORD);
+  const hasHighlight = highlightIndex >= 0;
+  const preText = hasHighlight ? FULL_TEXT.slice(0, highlightIndex) : FULL_TEXT;
+  const postText = hasHighlight ? FULL_TEXT.slice(highlightIndex + HIGHLIGHT_WORD.length) : "";
 
-	return (
-		<AbsoluteFill
-			style={{
-				backgroundColor: COLOR_BG,
-				alignItems: 'center',
-				justifyContent: 'center',
-				fontFamily,
-			}}
-		>
-			<div
-				style={{
-					color: COLOR_TEXT,
-					fontSize: FONT_SIZE,
-					fontWeight: FONT_WEIGHT,
-				}}
-			>
-				{hasHighlight ? (
-					<>
-						<span>{preText}</span>
-						<Highlight
-							word={HIGHLIGHT_WORD}
-							color={COLOR_HIGHLIGHT}
-							delay={HIGHLIGHT_START_FRAME}
-							durationInFrames={HIGHLIGHT_WIPE_DURATION}
-						/>
-						<span>{postText}</span>
-					</>
-				) : (
-					<span>{FULL_TEXT}</span>
-				)}
-			</div>
-		</AbsoluteFill>
-	);
+  return (
+    <AbsoluteFill
+      style={{
+        backgroundColor: COLOR_BG,
+        alignItems: "center",
+        justifyContent: "center",
+        fontFamily,
+      }}
+    >
+      <div
+        style={{
+          color: COLOR_TEXT,
+          fontSize: FONT_SIZE,
+          fontWeight: FONT_WEIGHT,
+        }}
+      >
+        {hasHighlight ? (
+          <>
+            <span>{preText}</span>
+            <Highlight
+              word={HIGHLIGHT_WORD}
+              color={COLOR_HIGHLIGHT}
+              delay={HIGHLIGHT_START_FRAME}
+              durationInFrames={HIGHLIGHT_WIPE_DURATION}
+            />
+            <span>{postText}</span>
+          </>
+        ) : (
+          <span>{FULL_TEXT}</span>
+        )}
+      </div>
+    </AbsoluteFill>
+  );
 };

--- a/packages/docs/scripts/generate-api-docs.js
+++ b/packages/docs/scripts/generate-api-docs.js
@@ -2,13 +2,13 @@
 
 /**
  * OpenAPI to MDX Generator for Creem API Documentation
- * 
+ *
  * This script fetches the OpenAPI spec and generates MDX files for Mintlify docs.
  * It uses the OpenAPI `summary` and `description` fields when available.
- * 
+ *
  * Usage:
  *   node scripts/generate-api-docs.js [--url <openapi-url>] [--file <openapi-file>] [--dry-run]
- * 
+ *
  * Options:
  *   --url <url>     Fetch OpenAPI spec from URL (default: uses local file)
  *   --file <path>   Read OpenAPI spec from local file (default: api-reference/openapi.json)
@@ -16,34 +16,34 @@
  *   --update-spec   Update the local openapi.json from the remote URL
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
 // Filename overrides: operationId -> custom filename
 // Only needed when the auto-generated filename isn't what you want
 const FILENAME_OVERRIDES = {
-  retrieveProduct: 'get-product',
-  retrieveCustomer: 'get-customer',
-  retrieveSubscription: 'get-subscription',
-  retrieveCheckout: 'get-checkout',
-  retrieveDiscount: 'get-discount-code',
-  generateCustomerLinks: 'create-customer-billing',
-  getTransactionById: 'get-transaction',
-  searchTransactions: 'get-transactions',
-  searchProducts: 'search-products',
-  listCustomers: 'list-customers',
-  createDiscount: 'create-discount-code',
-  deleteDiscount: 'delete-discount-code',
-  activateLicense: 'activate-license',
-  deactivateLicense: 'deactivate-license',
-  validateLicense: 'validate-license',
-  cancelSubscription: 'cancel-subscription',
-  updateSubscription: 'update-subscription',
-  upgradeSubscription: 'upgrade-subscription',
-  pauseSubscription: 'pause-subscription',
-  resumeSubscription: 'resume-subscription',
-  createCheckout: 'create-checkout',
-  createProduct: 'create-product'
+  retrieveProduct: "get-product",
+  retrieveCustomer: "get-customer",
+  retrieveSubscription: "get-subscription",
+  retrieveCheckout: "get-checkout",
+  retrieveDiscount: "get-discount-code",
+  generateCustomerLinks: "create-customer-billing",
+  getTransactionById: "get-transaction",
+  searchTransactions: "get-transactions",
+  searchProducts: "search-products",
+  listCustomers: "list-customers",
+  createDiscount: "create-discount-code",
+  deleteDiscount: "delete-discount-code",
+  activateLicense: "activate-license",
+  deactivateLicense: "deactivate-license",
+  validateLicense: "validate-license",
+  cancelSubscription: "cancel-subscription",
+  updateSubscription: "update-subscription",
+  upgradeSubscription: "upgrade-subscription",
+  pauseSubscription: "pause-subscription",
+  resumeSubscription: "resume-subscription",
+  createCheckout: "create-checkout",
+  createProduct: "create-product",
 };
 
 // Fallback descriptions when not provided in OpenAPI spec
@@ -54,30 +54,30 @@ function parseArgs() {
   const args = process.argv.slice(2);
   const options = {
     url: null,
-    file: 'api-reference/openapi.json',
+    file: "api-reference/openapi.json",
     dryRun: false,
     updateSpec: false,
-    cleanup: false
+    cleanup: false,
   };
 
   for (let i = 0; i < args.length; i++) {
     switch (args[i]) {
-      case '--url':
+      case "--url":
         options.url = args[++i];
         break;
-      case '--file':
+      case "--file":
         options.file = args[++i];
         break;
-      case '--dry-run':
+      case "--dry-run":
         options.dryRun = true;
         break;
-      case '--update-spec':
+      case "--update-spec":
         options.updateSpec = true;
         break;
-      case '--cleanup':
+      case "--cleanup":
         options.cleanup = true;
         break;
-      case '--help':
+      case "--help":
         console.log(`
 OpenAPI to MDX Generator for Creem API Documentation
 
@@ -120,7 +120,7 @@ async function fetchOpenApiSpec(url) {
 // Read OpenAPI spec from file
 function readOpenApiSpec(filePath) {
   console.log(`Reading OpenAPI spec from: ${filePath}`);
-  const content = fs.readFileSync(filePath, 'utf-8');
+  const content = fs.readFileSync(filePath, "utf-8");
   return JSON.parse(content);
 }
 
@@ -128,13 +128,11 @@ function readOpenApiSpec(filePath) {
 function operationIdToFilename(operationId) {
   // Check for override first
   if (FILENAME_OVERRIDES[operationId]) {
-    return FILENAME_OVERRIDES[operationId] + '.mdx';
+    return FILENAME_OVERRIDES[operationId] + ".mdx";
   }
-  
+
   // Convert camelCase to kebab-case
-  return operationId
-    .replace(/([a-z])([A-Z])/g, '$1-$2')
-    .toLowerCase() + '.mdx';
+  return operationId.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase() + ".mdx";
 }
 
 // Get description from OpenAPI or fallback
@@ -143,9 +141,9 @@ function getDescription(operationId, operation) {
   if (operation.description) {
     return operation.description;
   }
-  
+
   // Use fallback
-  return DESCRIPTION_FALLBACKS[operationId] || operation.summary || 'API endpoint documentation.';
+  return DESCRIPTION_FALLBACKS[operationId] || operation.summary || "API endpoint documentation.";
 }
 
 // Get title from OpenAPI summary (used as-is from spec)
@@ -153,33 +151,31 @@ function getTitle(operationId, operation) {
   // Use summary directly as defined in the spec
   if (operation.summary) {
     // Only remove trailing period if present
-    return operation.summary.replace(/\.$/, '');
+    return operation.summary.replace(/\.$/, "");
   }
-  
+
   // Fallback: generate from operationId
-  return operationId
-    .replace(/([a-z])([A-Z])/g, '$1 $2')
-    .replace(/^./, str => str.toUpperCase());
+  return operationId.replace(/([a-z])([A-Z])/g, "$1 $2").replace(/^./, (str) => str.toUpperCase());
 }
 
 // Parse existing MDX file to extract frontmatter and content
 function parseExistingMdx(filePath) {
   if (!fs.existsSync(filePath)) {
-    return { frontmatter: null, content: '' };
+    return { frontmatter: null, content: "" };
   }
-  
-  const fileContent = fs.readFileSync(filePath, 'utf-8');
-  
+
+  const fileContent = fs.readFileSync(filePath, "utf-8");
+
   // Match frontmatter between --- markers
   const frontmatterMatch = fileContent.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
-  
+
   if (frontmatterMatch) {
     return {
       frontmatter: frontmatterMatch[1],
-      content: frontmatterMatch[2] || ''
+      content: frontmatterMatch[2] || "",
     };
   }
-  
+
   // No frontmatter found, treat entire file as content
   return { frontmatter: null, content: fileContent };
 }
@@ -189,7 +185,7 @@ function generateFrontmatter(operationId, method, apiPath, operation) {
   const title = getTitle(operationId, operation);
   const description = getDescription(operationId, operation);
   const openApiRef = `${method} ${apiPath}`;
-  
+
   return `title: '${title}'
 description: '${description}'
 openapi: ${openApiRef}`;
@@ -198,7 +194,7 @@ openapi: ${openApiRef}`;
 // Generate full MDX content, preserving existing content after frontmatter
 function generateMdxContent(operationId, method, apiPath, operation, existingContent) {
   const frontmatter = generateFrontmatter(operationId, method, apiPath, operation);
-  
+
   // If there's existing content, preserve it
   if (existingContent && existingContent.trim()) {
     return `---
@@ -206,7 +202,7 @@ ${frontmatter}
 ---
 ${existingContent}`;
   }
-  
+
   // New file, just frontmatter
   return `---
 ${frontmatter}
@@ -217,13 +213,13 @@ ${frontmatter}
 // Main function
 async function main() {
   const options = parseArgs();
-  const outputDir = path.join(process.cwd(), 'api-reference', 'endpoint');
+  const outputDir = path.join(process.cwd(), "api-reference", "endpoint");
 
   // Get the OpenAPI spec
   let spec;
   if (options.url) {
     spec = await fetchOpenApiSpec(options.url);
-    
+
     // Update local spec if requested
     if (options.updateSpec) {
       const specPath = path.join(process.cwd(), options.file);
@@ -248,7 +244,7 @@ async function main() {
           operationId: operation.operationId,
           method,
           path: apiPath,
-          operation
+          operation,
         });
       }
     }
@@ -257,23 +253,23 @@ async function main() {
   console.log(`\nFound ${operations.length} operations in OpenAPI spec\n`);
 
   // Check for operations without descriptions
-  const missingDescriptions = operations.filter(op => 
-    !op.operation.description && !DESCRIPTION_FALLBACKS[op.operationId]
+  const missingDescriptions = operations.filter(
+    (op) => !op.operation.description && !DESCRIPTION_FALLBACKS[op.operationId],
   );
 
   if (missingDescriptions.length > 0) {
-    console.log('⚠️  Operations without description (add in NestJS @ApiOperation):');
-    missingDescriptions.forEach(op => console.log(`   - ${op.operationId}`));
-    console.log('');
+    console.log("⚠️  Operations without description (add in NestJS @ApiOperation):");
+    missingDescriptions.forEach((op) => console.log(`   - ${op.operationId}`));
+    console.log("");
   }
 
   // Generate MDX files
-  console.log('Generating MDX files:\n');
-  
+  console.log("Generating MDX files:\n");
+
   let created = 0;
   let updated = 0;
   let unchanged = 0;
-  
+
   // Track generated filenames to detect orphans
   const generatedFiles = new Set();
 
@@ -281,53 +277,55 @@ async function main() {
     const filename = operationIdToFilename(operationId);
     generatedFiles.add(filename);
     const filePath = path.join(outputDir, filename);
-    
+
     // Parse existing file to preserve content below frontmatter
     const { content: existingContent } = parseExistingMdx(filePath);
-    
+
     // Generate new MDX with updated frontmatter but preserved content
     const mdxContent = generateMdxContent(operationId, method, apiPath, operation, existingContent);
 
     // Check if file exists and compare content
     let status;
     let hasCustomContent = existingContent && existingContent.trim().length > 0;
-    
+
     if (fs.existsSync(filePath)) {
-      const currentFileContent = fs.readFileSync(filePath, 'utf-8');
+      const currentFileContent = fs.readFileSync(filePath, "utf-8");
       if (currentFileContent === mdxContent) {
-        status = 'unchanged';
+        status = "unchanged";
         unchanged++;
       } else {
-        status = 'updated';
+        status = "updated";
         updated++;
       }
     } else {
-      status = 'created';
+      status = "created";
       created++;
     }
 
     const statusIcon = {
-      created: '✨',
-      updated: '📝',
-      unchanged: '✓'
+      created: "✨",
+      updated: "📝",
+      unchanged: "✓",
     }[status];
 
-    const hasOpenApiDesc = operation.description ? '✓' : '○';
-    const customContentIndicator = hasCustomContent ? ' [+content]' : '';
-    console.log(`${statusIcon} ${filename} [desc: ${hasOpenApiDesc}]${customContentIndicator} (${status})`);
+    const hasOpenApiDesc = operation.description ? "✓" : "○";
+    const customContentIndicator = hasCustomContent ? " [+content]" : "";
+    console.log(
+      `${statusIcon} ${filename} [desc: ${hasOpenApiDesc}]${customContentIndicator} (${status})`,
+    );
 
-    if (!options.dryRun && status !== 'unchanged') {
+    if (!options.dryRun && status !== "unchanged") {
       fs.writeFileSync(filePath, mdxContent);
     }
   }
 
   // Detect orphaned MDX files (exist but not in spec)
-  const existingFiles = fs.readdirSync(outputDir).filter(f => f.endsWith('.mdx'));
-  const orphanedFiles = existingFiles.filter(f => !generatedFiles.has(f));
+  const existingFiles = fs.readdirSync(outputDir).filter((f) => f.endsWith(".mdx"));
+  const orphanedFiles = existingFiles.filter((f) => !generatedFiles.has(f));
   let deleted = 0;
 
   if (orphanedFiles.length > 0) {
-    console.log('\n⚠️  Orphaned files (not in OpenAPI spec):\n');
+    console.log("\n⚠️  Orphaned files (not in OpenAPI spec):\n");
     for (const filename of orphanedFiles) {
       const filePath = path.join(outputDir, filename);
       if (options.cleanup) {
@@ -341,7 +339,7 @@ async function main() {
       }
     }
     if (!options.cleanup) {
-      console.log('\n   Run with --cleanup to delete these files');
+      console.log("\n   Run with --cleanup to delete these files");
     }
   }
 
@@ -350,7 +348,9 @@ async function main() {
   console.log(`  Updated: ${updated}`);
   console.log(`  Unchanged: ${unchanged}`);
   if (orphanedFiles.length > 0) {
-    console.log(`  Orphaned: ${orphanedFiles.length}${options.cleanup ? ` (${deleted} deleted)` : ''}`);
+    console.log(
+      `  Orphaned: ${orphanedFiles.length}${options.cleanup ? ` (${deleted} deleted)` : ""}`,
+    );
   }
   console.log(`\nLegend:`);
   console.log(`  [desc: ✓] = has OpenAPI description`);
@@ -358,13 +358,13 @@ async function main() {
   console.log(`  [+content] = has custom content below frontmatter (preserved)`);
 
   if (options.dryRun) {
-    console.log('\n[DRY RUN] No files were modified');
+    console.log("\n[DRY RUN] No files were modified");
   }
 
   // Print NestJS decorator example for missing descriptions
   if (missingDescriptions.length > 0) {
-    console.log('\n--- NestJS Example ---');
-    console.log('Add descriptions to your controllers:\n');
+    console.log("\n--- NestJS Example ---");
+    console.log("Add descriptions to your controllers:\n");
     console.log(`@ApiOperation({
   summary: 'Your Summary Here',
   description: 'Your detailed description here.'
@@ -374,7 +374,7 @@ yourMethod() { ... }`);
   }
 }
 
-main().catch(err => {
-  console.error('Error:', err.message);
+main().catch((err) => {
+  console.error("Error:", err.message);
   process.exit(1);
 });

--- a/packages/nextjs/example/app/layout.tsx
+++ b/packages/nextjs/example/app/layout.tsx
@@ -24,11 +24,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
-      </body>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
     </html>
   );
 }

--- a/packages/nextjs/server/checkout.ts
+++ b/packages/nextjs/server/checkout.ts
@@ -27,16 +27,13 @@ export const Checkout = ({
     const customFieldsParam = req.nextUrl.searchParams.get("customFields");
     const successUrl = resolveSuccessUrl(
       req.nextUrl.searchParams.get("successUrl") ?? defaultSuccessUrl,
-      req
+      req,
     );
     const metadataParam = req.nextUrl.searchParams.get("metadata");
     const referenceId = req.nextUrl.searchParams.get("referenceId");
 
     if (!productId) {
-      return NextResponse.json(
-        { error: "Product ID is required" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "Product ID is required" }, { status: 400 });
     }
 
     // Parse units to number
@@ -47,10 +44,7 @@ export const Checkout = ({
     try {
       customer = customerParam ? JSON.parse(customerParam) : undefined;
     } catch {
-      return NextResponse.json(
-        { error: "Invalid customer JSON" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "Invalid customer JSON" }, { status: 400 });
     }
 
     // Parse metadata JSON if provided
@@ -58,10 +52,7 @@ export const Checkout = ({
     try {
       metadata = metadataParam ? JSON.parse(metadataParam) : undefined;
     } catch {
-      return NextResponse.json(
-        { error: "Invalid metadata JSON" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "Invalid metadata JSON" }, { status: 400 });
     }
 
     // Parse customFields JSON if provided
@@ -69,10 +60,7 @@ export const Checkout = ({
     try {
       customFields = customFieldsParam ? JSON.parse(customFieldsParam) : undefined;
     } catch {
-      return NextResponse.json(
-        { error: "Invalid customFields JSON" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "Invalid customFields JSON" }, { status: 400 });
     }
 
     try {
@@ -91,25 +79,21 @@ export const Checkout = ({
 
       // Redirect to the checkout URL
       if (!checkout.checkoutUrl) {
-        return NextResponse.json(
-          { error: "Checkout URL not available" },
-          { status: 500 }
-        );
+        return NextResponse.json({ error: "Checkout URL not available" }, { status: 500 });
       }
 
       return NextResponse.redirect(checkout.checkoutUrl);
     } catch (error) {
       console.error("Checkout creation failed:", error);
 
-      const errorMessage =
-        error instanceof Error ? error.message : "An unexpected error occurred";
+      const errorMessage = error instanceof Error ? error.message : "An unexpected error occurred";
 
       return NextResponse.json(
         {
           error: "Failed to create checkout",
           details: errorMessage,
         },
-        { status: 500 }
+        { status: 500 },
       );
     }
   };

--- a/packages/nextjs/server/portal.ts
+++ b/packages/nextjs/server/portal.ts
@@ -17,10 +17,7 @@ export const Portal = ({ apiKey, testMode = false }: PortalRouteInstance) => {
     const customerId = req.nextUrl.searchParams.get("customerId");
 
     if (!customerId) {
-      return NextResponse.json(
-        { error: "Customer ID is required" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "Customer ID is required" }, { status: 400 });
     }
 
     try {
@@ -30,25 +27,21 @@ export const Portal = ({ apiKey, testMode = false }: PortalRouteInstance) => {
 
       // Redirect to the portal URL
       if (!portal.customerPortalLink) {
-        return NextResponse.json(
-          { error: "Portal URL not available" },
-          { status: 500 }
-        );
+        return NextResponse.json({ error: "Portal URL not available" }, { status: 500 });
       }
 
       return NextResponse.redirect(portal.customerPortalLink);
     } catch (error) {
       console.error("Portal creation failed:", error);
 
-      const errorMessage =
-        error instanceof Error ? error.message : "An unexpected error occurred";
+      const errorMessage = error instanceof Error ? error.message : "An unexpected error occurred";
 
       return NextResponse.json(
         {
           error: "Failed to create portal",
           details: errorMessage,
         },
-        { status: 500 }
+        { status: 500 },
       );
     }
   };

--- a/packages/nextjs/server/utils.ts
+++ b/packages/nextjs/server/utils.ts
@@ -9,7 +9,7 @@ export { generateSignature, parseWebhookEvent };
  */
 export function resolveSuccessUrl(
   url: string | undefined | null,
-  req: NextRequest
+  req: NextRequest,
 ): string | undefined {
   if (!url) return undefined;
 

--- a/packages/nextjs/server/webhook.ts
+++ b/packages/nextjs/server/webhook.ts
@@ -37,15 +37,9 @@ export const Webhook = (options: WebhookOptions) => {
 
       // Verify the webhook signature
       const computedSignature = await generateSignature(body, options.webhookSecret);
-      if (
-        !signature ||
-        computedSignature !== signature
-      ) {
+      if (!signature || computedSignature !== signature) {
         console.error("Creem webhook: Invalid signature");
-        return NextResponse.json(
-          { error: "Invalid signature" },
-          { status: 400 }
-        );
+        return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
       }
 
       // Parse the webhook event
@@ -195,19 +189,13 @@ export const Webhook = (options: WebhookOptions) => {
 
         default:
           console.error("Unknown event type", event);
-          return NextResponse.json(
-            { error: "Unknown event type" },
-            { status: 400 }
-          );
+          return NextResponse.json({ error: "Unknown event type" }, { status: 400 });
       }
 
       return NextResponse.json({ message: "Webhook received" });
     } catch (error) {
       console.error("Creem webhook error:", error);
-      return NextResponse.json(
-        { error: "Failed to process webhook" },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: "Failed to process webhook" }, { status: 500 });
     }
   };
 };

--- a/packages/nextjs/types.ts
+++ b/packages/nextjs/types.ts
@@ -221,63 +221,61 @@ export interface WebhookOptions {
    * }
    */
   onSubscriptionActive?: (
-    data: FlatSubscriptionEvent<"subscription.active">
+    data: FlatSubscriptionEvent<"subscription.active">,
   ) => void | Promise<void>;
 
   /**
    * Called when a subscription is in trialing state.
    */
   onSubscriptionTrialing?: (
-    data: FlatSubscriptionEvent<"subscription.trialing">
+    data: FlatSubscriptionEvent<"subscription.trialing">,
   ) => void | Promise<void>;
 
   /**
    * Called when a subscription is canceled.
    */
   onSubscriptionCanceled?: (
-    data: FlatSubscriptionEvent<"subscription.canceled">
+    data: FlatSubscriptionEvent<"subscription.canceled">,
   ) => void | Promise<void>;
 
   /**
    * Called when a subscription is paid.
    */
-  onSubscriptionPaid?: (
-    data: FlatSubscriptionEvent<"subscription.paid">
-  ) => void | Promise<void>;
+  onSubscriptionPaid?: (data: FlatSubscriptionEvent<"subscription.paid">) => void | Promise<void>;
 
   /**
    * Called when a subscription has expired.
    */
   onSubscriptionExpired?: (
-    data: FlatSubscriptionEvent<"subscription.expired">
+    data: FlatSubscriptionEvent<"subscription.expired">,
   ) => void | Promise<void>;
 
   /**
    * Called when a subscription is unpaid.
    */
   onSubscriptionUnpaid?: (
-    data: FlatSubscriptionEvent<"subscription.unpaid">
+    data: FlatSubscriptionEvent<"subscription.unpaid">,
   ) => void | Promise<void>;
 
   /**
    * Called when a subscription is updated.
    */
   onSubscriptionUpdate?: (
-    data: FlatSubscriptionEvent<"subscription.update">
+    data: FlatSubscriptionEvent<"subscription.update">,
   ) => void | Promise<void>;
 
   /**
    * Called when a subscription is past due.
    */
   onSubscriptionPastDue?: (
-    data: FlatSubscriptionEvent<"subscription.past_due">
+    data: FlatSubscriptionEvent<"subscription.past_due">,
   ) => void | Promise<void>;
 
   /**
    * Called when a subscription is paused.
    */
   onSubscriptionPaused?: (
-    data: FlatSubscriptionEvent<"subscription.paused">
+    data: FlatSubscriptionEvent<"subscription.paused">,
   ) => void | Promise<void>;
 
   /**

--- a/packages/webhook-types/src/type-guards.ts
+++ b/packages/webhook-types/src/type-guards.ts
@@ -54,37 +54,61 @@ export function isWebhookEventEntity(obj: unknown): obj is WebhookEventEntity {
 }
 
 export function isCheckoutEntity(obj: unknown): obj is CheckoutEntity {
-  return obj !== null && typeof obj === "object" && "object" in obj && (obj as any).object === "checkout";
+  return (
+    obj !== null && typeof obj === "object" && "object" in obj && (obj as any).object === "checkout"
+  );
 }
 
 export function isCustomerEntity(obj: unknown): obj is CustomerEntity {
-  return obj !== null && typeof obj === "object" && "object" in obj && (obj as any).object === "customer";
+  return (
+    obj !== null && typeof obj === "object" && "object" in obj && (obj as any).object === "customer"
+  );
 }
 
 export function isOrderEntity(obj: unknown): obj is OrderEntity {
-  return obj !== null && typeof obj === "object" && "object" in obj && (obj as any).object === "order";
+  return (
+    obj !== null && typeof obj === "object" && "object" in obj && (obj as any).object === "order"
+  );
 }
 
 export function isProductEntity(obj: unknown): obj is ProductEntity {
-  return obj !== null && typeof obj === "object" && "object" in obj && (obj as any).object === "product";
+  return (
+    obj !== null && typeof obj === "object" && "object" in obj && (obj as any).object === "product"
+  );
 }
 
 export function isSubscriptionEntity(obj: unknown): obj is SubscriptionEntity {
-  return obj !== null && typeof obj === "object" && "object" in obj && (obj as any).object === "subscription";
+  return (
+    obj !== null &&
+    typeof obj === "object" &&
+    "object" in obj &&
+    (obj as any).object === "subscription"
+  );
 }
 
 export function isRefundEntity(obj: unknown): obj is RefundEntity {
-  return obj !== null && typeof obj === "object" && "object" in obj && (obj as any).object === "refund";
+  return (
+    obj !== null && typeof obj === "object" && "object" in obj && (obj as any).object === "refund"
+  );
 }
 
 export function isDisputeEntity(obj: unknown): obj is DisputeEntity {
-  return obj !== null && typeof obj === "object" && "object" in obj && (obj as any).object === "dispute";
+  return (
+    obj !== null && typeof obj === "object" && "object" in obj && (obj as any).object === "dispute"
+  );
 }
 
 export function isTransactionEntity(obj: unknown): obj is TransactionEntity {
-  return obj !== null && typeof obj === "object" && "object" in obj && (obj as any).object === "transaction";
+  return (
+    obj !== null &&
+    typeof obj === "object" &&
+    "object" in obj &&
+    (obj as any).object === "transaction"
+  );
 }
 
 export function isDiscountEntity(obj: unknown): obj is DiscountEntity {
-  return obj !== null && typeof obj === "object" && "object" in obj && (obj as any).object === "discount";
+  return (
+    obj !== null && typeof obj === "object" && "object" in obj && (obj as any).object === "discount"
+  );
 }


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                                                                                                                                            
                                                         
  - Stop Speakeasy-generated SDK files from triggering 168 prettier diffs on every regen (added to `.prettierignore`)                                                                                                                                                                                                                                                                                                   
  - Reformat the 53 hand-written files that drifted from `.prettierrc` since `printWidth` changed in #35, so `pnpm format:check` is green
  - Gate CI on `format:check` so the repo can't drift again                                                                                                                                                                                                                                                                                                                                                             
  - Skip Speakeasy's npm-based compile step (`speakeasy run` was failing in this pnpm monorepo because its post-generation `npm install` collides with pnpm's esbuild layout — the binary shim ends up as a Mach-O instead of JS, the install crashes, and a stray `packages/creem-sdk/package-lock.json` is left behind)
                                                                                                                                                                                                                                                                                                                                                                                                                        
  After this PR a one-line change produces a one-line diff, and `pnpm gen:sdk` (or the SDK generation workflow) regenerates without blowing up the local install.                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                        
  ## Test plan                                                                                                                                                                                                                                                                                                                                                                                                          
                                                         
  - [x] `pnpm format:check` passes on this branch
  - [x] `pnpm gen:sdk` runs end-to-end locally
  - [ ] CI: `Format check` step passes                                                                                                                                                                                                                                                                                                                                                                                  
  - [ ] After merge, manually trigger `Speakeasy SDK Generation` workflow and confirm the PR it opens has only intentional SDK diffs (no styling churn, no `package-lock.json`)
