### PR TITLE
chore(sdk): restore stable Speakeasy name overrides

### DIFF
--- a/packages/creem-sdk/.speakeasy/speakeasy-modifications-overlay.yaml
+++ b/packages/creem-sdk/.speakeasy/speakeasy-modifications-overlay.yaml
@@ -2,92 +2,53 @@ overlay: 1.0.0
 x-speakeasy-jsonpath: rfc9535
 info:
   title: Speakeasy Modifications
-  version: 0.0.5
+  version: 0.0.8
   x-speakeasy-metadata:
     after: ""
     before: ""
     type: speakeasy-modifications
 actions:
+  # --- Existing endpoints (kept stable from 0.0.5) ---
   - target: $["paths"]["/v1/discounts"]["get"]
     update:
       x-speakeasy-group: discounts
       x-speakeasy-name-override: get
-  - target: $["paths"]["/v1/discounts/{id}/delete"]["delete"]
-    update:
-      x-speakeasy-group: discounts
-      x-speakeasy-name-override: delete
-  - target: $["paths"]["/v1/customers/billing"]["post"]
-    update:
-      x-speakeasy-group: customers
-      x-speakeasy-name-override: generateBillingLinks
-  - target: $["paths"]["/v1/subscriptions"]["get"]
-    update:
-      x-speakeasy-group: subscriptions
-      x-speakeasy-name-override: get
-  - target: $["paths"]["/v1/subscriptions/{id}/upgrade"]["post"]
-    update:
-      x-speakeasy-group: subscriptions
-      x-speakeasy-name-override: upgrade
-  - target: $["paths"]["/v1/customers"]["get"]
-    update:
-      x-speakeasy-group: customers
-      x-speakeasy-name-override: retrieve
-  - target: $["paths"]["/v1/products"]["post"]
-    update:
-      x-speakeasy-group: products
-      x-speakeasy-name-override: create
-  - target: $["paths"]["/v1/products/search"]["get"]
-    update:
-      x-speakeasy-group: products
-      x-speakeasy-name-override: search
-  - target: $["paths"]["/v1/checkouts"]["post"]
-    update:
-      x-speakeasy-group: checkouts
-      x-speakeasy-name-override: create
-  - target: $["paths"]["/v1/licenses/activate"]["post"]
-    update:
-      x-speakeasy-group: licenses
-      x-speakeasy-name-override: activate
-  - target: $["paths"]["/v1/checkouts"]["get"]
-    update:
-      x-speakeasy-group: checkouts
-      x-speakeasy-name-override: retrieve
-  - target: $["paths"]["/v1/products"]["get"]
-    update:
-      x-speakeasy-group: products
-      x-speakeasy-name-override: get
-  - target: $["paths"]["/v1/licenses/deactivate"]["post"]
-    update:
-      x-speakeasy-group: licenses
-      x-speakeasy-name-override: deactivate
-  - target: $["paths"]["/v1/transactions/search"]["get"]
-    update:
-      x-speakeasy-group: transactions
-      x-speakeasy-name-override: search
-  - target: $["paths"]["/v1/subscriptions/{id}/cancel"]["post"]
-    update:
-      x-speakeasy-group: subscriptions
-      x-speakeasy-name-override: cancel
-  - target: $["paths"]["/v1/subscriptions/{id}"]["post"]
-    update:
-      x-speakeasy-group: subscriptions
-      x-speakeasy-name-override: update
-  - target: $["paths"]["/v1/transactions"]["get"]
-    update:
-      x-speakeasy-group: transactions
-      x-speakeasy-name-override: getById
   - target: $["paths"]["/v1/discounts"]["post"]
     update:
       x-speakeasy-group: discounts
       x-speakeasy-name-override: create
+  - target: $["paths"]["/v1/discounts/{id}/delete"]["delete"]
+    update:
+      x-speakeasy-group: discounts
+      x-speakeasy-name-override: delete
+  - target: $["paths"]["/v1/customers"]["get"]
+    update:
+      x-speakeasy-group: customers
+      x-speakeasy-name-override: retrieve
+  - target: $["paths"]["/v1/customers/billing"]["post"]
+    update:
+      x-speakeasy-group: customers
+      x-speakeasy-name-override: generateBillingLinks
   - target: $["paths"]["/v1/customers/list"]["get"]
     update:
       x-speakeasy-group: customers
       x-speakeasy-name-override: list
-  - target: $["paths"]["/v1/licenses/validate"]["post"]
+  - target: $["paths"]["/v1/subscriptions"]["get"]
     update:
-      x-speakeasy-group: licenses
-      x-speakeasy-name-override: validate
+      x-speakeasy-group: subscriptions
+      x-speakeasy-name-override: get
+  - target: $["paths"]["/v1/subscriptions/{id}"]["post"]
+    update:
+      x-speakeasy-group: subscriptions
+      x-speakeasy-name-override: update
+  - target: $["paths"]["/v1/subscriptions/{id}/cancel"]["post"]
+    update:
+      x-speakeasy-group: subscriptions
+      x-speakeasy-name-override: cancel
+  - target: $["paths"]["/v1/subscriptions/{id}/upgrade"]["post"]
+    update:
+      x-speakeasy-group: subscriptions
+      x-speakeasy-name-override: upgrade
   - target: $["paths"]["/v1/subscriptions/{id}/pause"]["post"]
     update:
       x-speakeasy-group: subscriptions
@@ -96,3 +57,125 @@ actions:
     update:
       x-speakeasy-group: subscriptions
       x-speakeasy-name-override: resume
+  - target: $["paths"]["/v1/products"]["get"]
+    update:
+      x-speakeasy-group: products
+      x-speakeasy-name-override: get
+  - target: $["paths"]["/v1/products"]["post"]
+    update:
+      x-speakeasy-group: products
+      x-speakeasy-name-override: create
+  - target: $["paths"]["/v1/products/search"]["get"]
+    update:
+      x-speakeasy-group: products
+      x-speakeasy-name-override: search
+  - target: $["paths"]["/v1/checkouts"]["get"]
+    update:
+      x-speakeasy-group: checkouts
+      x-speakeasy-name-override: retrieve
+  - target: $["paths"]["/v1/checkouts"]["post"]
+    update:
+      x-speakeasy-group: checkouts
+      x-speakeasy-name-override: create
+  - target: $["paths"]["/v1/licenses/activate"]["post"]
+    update:
+      x-speakeasy-group: licenses
+      x-speakeasy-name-override: activate
+  - target: $["paths"]["/v1/licenses/deactivate"]["post"]
+    update:
+      x-speakeasy-group: licenses
+      x-speakeasy-name-override: deactivate
+  - target: $["paths"]["/v1/licenses/validate"]["post"]
+    update:
+      x-speakeasy-group: licenses
+      x-speakeasy-name-override: validate
+  - target: $["paths"]["/v1/transactions"]["get"]
+    update:
+      x-speakeasy-group: transactions
+      x-speakeasy-name-override: getById
+  - target: $["paths"]["/v1/transactions/search"]["get"]
+    update:
+      x-speakeasy-group: transactions
+      x-speakeasy-name-override: search
+
+  # --- New endpoints (added in 0.0.8) ---
+  - target: $["paths"]["/v1/customers"]["post"]
+    update:
+      x-speakeasy-group: customers
+      x-speakeasy-name-override: create
+  - target: $["paths"]["/v1/customers"]["patch"]
+    update:
+      x-speakeasy-group: customers
+      x-speakeasy-name-override: update
+  - target: $["paths"]["/v1/customers/{id}/orders"]["get"]
+    update:
+      x-speakeasy-group: customers
+      x-speakeasy-name-override: getOrders
+  - target: $["paths"]["/v1/customers/{id}/subscriptions"]["get"]
+    update:
+      x-speakeasy-group: customers
+      x-speakeasy-name-override: listSubscriptions
+  - target: $["paths"]["/v1/customers/{id}/licenses"]["get"]
+    update:
+      x-speakeasy-group: customers
+      x-speakeasy-name-override: listLicenses
+  - target: $["paths"]["/v1/subscriptions/search"]["get"]
+    update:
+      x-speakeasy-group: subscriptions
+      x-speakeasy-name-override: search
+  - target: $["paths"]["/v1/discounts/search"]["get"]
+    update:
+      x-speakeasy-group: discounts
+      x-speakeasy-name-override: search
+  - target: $["paths"]["/v1/stats/summary"]["get"]
+    update:
+      x-speakeasy-group: stats
+      x-speakeasy-name-override: getSummary
+  - target: $["paths"]["/v1/moderation/prompt"]["post"]
+    update:
+      x-speakeasy-group: moderation
+      x-speakeasy-name-override: screenPrompt
+  - target: $["paths"]["/v1/customer-credits/accounts"]["post"]
+    update:
+      x-speakeasy-group: customerCredits
+      x-speakeasy-name-override: createAccount
+  - target: $["paths"]["/v1/customer-credits/accounts"]["get"]
+    update:
+      x-speakeasy-group: customerCredits
+      x-speakeasy-name-override: listAccounts
+  - target: $["paths"]["/v1/customer-credits/accounts/{id}"]["get"]
+    update:
+      x-speakeasy-group: customerCredits
+      x-speakeasy-name-override: getAccount
+  - target: $["paths"]["/v1/customer-credits/accounts/{id}/balance"]["get"]
+    update:
+      x-speakeasy-group: customerCredits
+      x-speakeasy-name-override: getAccountBalance
+  - target: $["paths"]["/v1/customer-credits/accounts/{id}/entries"]["get"]
+    update:
+      x-speakeasy-group: customerCredits
+      x-speakeasy-name-override: listEntries
+  - target: $["paths"]["/v1/customer-credits/accounts/{id}/freeze"]["post"]
+    update:
+      x-speakeasy-group: customerCredits
+      x-speakeasy-name-override: freezeAccount
+  - target: $["paths"]["/v1/customer-credits/accounts/{id}/unfreeze"]["post"]
+    update:
+      x-speakeasy-group: customerCredits
+      x-speakeasy-name-override: unfreezeAccount
+  - target: $["paths"]["/v1/customer-credits/accounts/{id}/credit"]["post"]
+    update:
+      x-speakeasy-group: customerCredits
+      x-speakeasy-name-override: creditAccount
+  - target: $["paths"]["/v1/customer-credits/accounts/{id}/debit"]["post"]
+    update:
+      x-speakeasy-group: customerCredits
+      x-speakeasy-name-override: debitAccount
+  - target: $["paths"]["/v1/customer-credits/accounts/{id}/reverse"]["post"]
+    update:
+      x-speakeasy-group: customerCredits
+      x-speakeasy-name-override: reverseTransaction
+  - target: $["paths"]["/v1/customer-credits/accounts/{id}/close"]["post"]
+    update:
+      x-speakeasy-group: customerCredits
+      x-speakeasy-name-override: closeAccount


### PR DESCRIPTION
## Summary

  Restore the explicit `x-speakeasy-name-override` rules that were silently dropped from the overlay (0.0.5 → 0.0.7), and add rules for endpoints that weren't covered before.

  Without these overrides Speakeasy falls back to the operationId, producing renames like `productsGet → productsList`, `subscriptionsCancel → subscriptionsCancelSubscription`, `customersList → customersListCustomers`, and `customerCreditsCloseAccount → customerCreditsAccountsExperimentalCloseCustomerCreditsAccount`. Every consumer of those methods (CLI, convex, better-auth) would break.

  The overlay now has 42 rules: the 22 from 0.0.5 verbatim, plus 20 new ones covering customer-credits, moderation, customers sub-resources, and the search/summary endpoints.