### PR TITLE
fix(ci): remove skip_compile from speakeasy generation workflow

### DIFF
--- a/.github/workflows/sdk-generation.yml
+++ b/.github/workflows/sdk-generation.yml
@@ -20,10 +20,6 @@ jobs:
       speakeasy_version: latest
       working_directory: packages/creem-sdk
       mode: pr
-      # Speakeasy's compile step runs `npm install`, which collides with this
-      # repo's pnpm-managed node_modules and corrupts esbuild's binary. The
-      # monorepo's own `pnpm turbo build` covers compile/typecheck.
-      skip_compile: "true"
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}


### PR DESCRIPTION
The skip_compile flag was added (PR #48) to work around a local-only issue: when running `speakeasy run` against this pnpm-managed repo, the generator's `npm install` collides with the symlinked esbuild binary in pnpm's node_modules layout. In CI the Speakeasy reusable workflow runs in an isolated runner with no pre-existing pnpm node_modules, so npm install behaves normally and we get the full compile validation that flag was disabling.

Also fixes the validation error on main:

  Invalid workflow file: .github/workflows/sdk-generation.yml#L26
  Unexpected value 'true'

(speakeasy declares skip_compile as type: boolean, so the quoted string "true" was rejected.) For local runs use `pnpm gen:sdk` which still passes --skip-compile via the npm script.