### PR TITLE
docs: deprecate creem_io wrapper SDK in favor of core SDK

### DIFF
--- a/packages/docs/ai/for-agents/skill-files.mdx
+++ b/packages/docs/ai/for-agents/skill-files.mdx
@@ -37,8 +37,7 @@ This is the main skill file. It contains everything needed to integrate Creem:
   </Accordion>
 
   <Accordion title="SDKs">
-    - TypeScript Core (`creem`)
-    - TypeScript Wrapper (`creem_io`)
+    - TypeScript SDK (`creem`)
     - Next.js Adapter (`@creem_io/nextjs`)
     - Better Auth Plugin (`@creem_io/better-auth`)
   </Accordion>

--- a/packages/docs/api-reference/error-codes.mdx
+++ b/packages/docs/api-reference/error-codes.mdx
@@ -128,9 +128,9 @@ Returned when trying to create a resource that already exists.
 ### TypeScript SDK
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({ apiKey: process.env.CREEM_API_KEY! });
+const creem = new Creem({ apiKey: process.env.CREEM_API_KEY! });
 
 try {
   const checkout = await creem.checkouts.create({

--- a/packages/docs/api-reference/introduction.mdx
+++ b/packages/docs/api-reference/introduction.mdx
@@ -76,11 +76,11 @@ curl -X POST https://test-api.creem.io/v1/checkouts \
 ```
 
 ```typescript TypeScript SDK
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: process.env.NODE_ENV !== 'production',
+  serverIdx: process.env.NODE_ENV === 'production' ? 0 : 1,
 });
 
 const checkout = await creem.checkouts.create({
@@ -164,7 +164,7 @@ Every error response includes a `trace_id` you can share with support for faster
 ## SDKs & Libraries
 
 <CardGroup cols={2}>
-  <Card title="TypeScript SDK" icon="js" href="/code/sdks/typescript-core">
+  <Card title="TypeScript SDK" icon="js" href="/code/sdks/typescript">
     Core SDK for Node.js and TypeScript projects
   </Card>
   <Card title="Next.js Adapter" icon="react" href="/code/sdks/nextjs">

--- a/packages/docs/code/cli.mdx
+++ b/packages/docs/code/cli.mdx
@@ -370,7 +370,7 @@ The CLI automatically switches to the production API based on the key prefix.
   <Card title="Webhooks" icon="webhook" href="/code/webhooks">
     Handle real-time payment events in your application
   </Card>
-  <Card title="SDKs" icon="code" href="/code/sdks/typescript-core">
+  <Card title="SDKs" icon="code" href="/code/sdks/typescript">
     Integrate Creem programmatically with TypeScript, Next.js, or Better Auth
   </Card>
   <Card title="API Reference" icon="book" href="/api-reference/introduction">

--- a/packages/docs/code/sdks/typescript-wrapper.mdx
+++ b/packages/docs/code/sdks/typescript-wrapper.mdx
@@ -1,30 +1,32 @@
 ---
-title: SDK Wrapper (creem_io)
-description: A convenience wrapper SDK with helper functions for webhooks, access management, and simplified API interactions. Ideal for quick integrations with less boilerplate.
+title: SDK Wrapper (creem_io, deprecated)
+description: Deprecated convenience wrapper SDK with helper functions for webhooks, access management, and simplified API interactions. Use the Core SDK (creem) for new integrations.
 ---
 
-<Info>
-  This is the **creem_io** wrapper package, which provides convenience methods and webhook helpers for common use cases.
+<Warning>
+**Deprecation Notice:** The `creem_io` wrapper package is deprecated. Existing integrations will continue to work, but new integrations should use the [TypeScript SDK (creem)](/code/sdks/typescript).
+</Warning>
 
-  For full API access with all endpoints and maximum flexibility, see the [Core SDK (creem)](/code/sdks/typescript-core).
+<Info>
+  This page is kept as a reference for existing `creem_io` integrations.
 </Info>
 
 ## Overview
 
-The `creem_io` package is a convenience wrapper around the Creem API that provides:
+The deprecated `creem_io` package is a convenience wrapper around the Creem API that provides:
 
 - **Simplified webhook handling** with `onGrantAccess` and `onRevokeAccess` callbacks
 - **Automatic signature verification** for webhook events
 - **Type-safe event handlers** for all webhook events
 - **Framework-agnostic** webhook processing
 
-This wrapper is ideal if you want to get started quickly with minimal configuration, especially for handling subscription access management.
+For new projects, use the [TypeScript SDK (creem)](/code/sdks/typescript), which is the recommended SDK with full API coverage and active support.
 
 ---
 
 ## Installation
 
-Install with your preferred package manager:
+For existing `creem_io` integrations, install with your preferred package manager:
 
 <CodeGroup>
 

--- a/packages/docs/code/sdks/typescript.mdx
+++ b/packages/docs/code/sdks/typescript.mdx
@@ -1,13 +1,10 @@
 ---
-title: Core SDK (creem)
+title: TypeScript
 description: The official Creem TypeScript SDK with full API access, all endpoints, and maximum flexibility for advanced integrations.
 ---
 
 <Info>
   This is the **creem** core package with full API access and advanced configuration options.
-
-For a simpler integration with webhook helpers, see the [SDK Wrapper (creem_io)](/code/sdks/typescript-wrapper).
-
 </Info>
 
 ## Overview

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -127,13 +127,7 @@
               {
                 "group": "SDKs",
                 "pages": [
-                  {
-                    "group": "TypeScript",
-                    "pages": [
-                      "code/sdks/typescript-core",
-                      "code/sdks/typescript-wrapper"
-                    ]
-                  },
+                  "code/sdks/typescript",
                   "code/sdks/nextjs",
                   "code/sdks/better-auth",
                   "code/sdks/templates",

--- a/packages/docs/features/addons/licenses.mdx
+++ b/packages/docs/features/addons/licenses.mdx
@@ -142,11 +142,11 @@ Here's how a typical activation flow works:
 <CodeGroup>
 
 ```ts TypeScript SDK
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: true,
+  serverIdx: 1,
 });
 
 const license = await creem.licenses.activate({
@@ -289,11 +289,11 @@ Here's how the validation process typically works:
 <CodeGroup>
 
 ```ts TypeScript SDK
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: true,
+  serverIdx: 1,
 });
 
 const validatedLicense = await creem.licenses.validate({
@@ -444,11 +444,11 @@ Here's how the deactivation process typically works:
 <CodeGroup>
 
 ```ts TypeScript SDK
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: true,
+  serverIdx: 1,
 });
 
 const deactivatedLicense = await creem.licenses.deactivate({

--- a/packages/docs/features/checkout/checkout-api.mdx
+++ b/packages/docs/features/checkout/checkout-api.mdx
@@ -104,19 +104,19 @@ The `CreemCheckout` component automatically handles the checkout session creatio
 <CodeGroup>
 
 ```bash npm
-npm install creem_io
+npm install creem
 ```
 
 ```bash yarn
-yarn add creem_io
+yarn add creem
 ```
 
 ```bash pnpm
-pnpm install creem_io
+pnpm install creem
 ```
 
 ```bash bun
-bun install creem_io
+bun install creem
 ```
 
 </CodeGroup>
@@ -124,11 +124,11 @@ bun install creem_io
 ### Create a checkout session
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: process.env.NODE_ENV !== 'production',
+  serverIdx: process.env.NODE_ENV === 'production' ? 0 : 1,
 });
 
 // Create a checkout session
@@ -142,8 +142,8 @@ const checkout = await creem.checkouts.create({
 });
 
 // Redirect to the checkout URL
-console.log(checkout.checkout_url);
-// In the browser: window.location.href = checkout.checkout_url;
+console.log(checkout.checkoutUrl);
+// In the browser: window.location.href = checkout.checkoutUrl;
 ```
 
 <Card

--- a/packages/docs/features/customer-portal.mdx
+++ b/packages/docs/features/customer-portal.mdx
@@ -107,15 +107,15 @@ export function ManageSubscriptionButton({
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: process.env.NODE_ENV !== 'production',
+  serverIdx: process.env.NODE_ENV === 'production' ? 0 : 1,
 });
 
 // Create customer portal link
-const portal = await creem.customers.createPortal({
+const portal = await creem.customers.generateBillingLinks({
   customerId: 'cust_abc123',
 });
 
@@ -128,12 +128,10 @@ You can also retrieve the customer ID by email:
 
 ```typescript
 // Get customer by email first
-const customer = await creem.customers.get({
-  email: 'customer@example.com',
-});
+const customer = await creem.customers.retrieve(undefined, 'customer@example.com');
 
 // Then create portal link
-const portal = await creem.customers.createPortal({
+const portal = await creem.customers.generateBillingLinks({
   customerId: customer.id,
 });
 

--- a/packages/docs/features/discounts.mdx
+++ b/packages/docs/features/discounts.mdx
@@ -30,11 +30,11 @@ You can also create discounts programmatically using the API.
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: process.env.NODE_ENV !== 'production',
+  serverIdx: process.env.NODE_ENV === 'production' ? 0 : 1,
 });
 
 // Create a percentage discount
@@ -45,6 +45,7 @@ const percentageDiscount = await creem.discounts.create({
   type: 'percentage',
   percentage: 10,
   duration: 'forever',
+  appliesToProducts: ['prod_YOUR_PRODUCT_ID'],
 });
 
 // Create a fixed amount discount
@@ -55,6 +56,7 @@ const fixedDiscount = await creem.discounts.create({
   currency: 'USD',
   type: 'fixed',
   duration: 'forever',
+  appliesToProducts: ['prod_YOUR_PRODUCT_ID'],
 });
 ```
 
@@ -220,7 +222,7 @@ const checkout = await creem.checkouts.create({
 });
 
 // Redirect to checkout with discount pre-applied
-window.location.href = checkout.checkout_url;
+window.location.href = checkout.checkoutUrl;
 ```
 
   </Tab>

--- a/packages/docs/features/one-time-payment.mdx
+++ b/packages/docs/features/one-time-payment.mdx
@@ -61,11 +61,11 @@ export function BuyButton() {
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: process.env.NODE_ENV !== 'production',
+  serverIdx: process.env.NODE_ENV === 'production' ? 0 : 1,
 });
 
 // Create a one-time payment checkout session
@@ -79,7 +79,7 @@ const checkout = await creem.checkouts.create({
 });
 
 // Redirect to the checkout URL
-console.log(checkout.checkout_url);
+console.log(checkout.checkoutUrl);
 ```
 
 <Card

--- a/packages/docs/features/seat-based-billing.mdx
+++ b/packages/docs/features/seat-based-billing.mdx
@@ -57,11 +57,11 @@ export function SeatBasedCheckout({ seatCount }: { seatCount: number }) {
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: process.env.NODE_ENV !== 'production',
+  serverIdx: process.env.NODE_ENV === 'production' ? 0 : 1,
 });
 
 // Create a checkout session with multiple seats
@@ -72,7 +72,7 @@ const checkout = await creem.checkouts.create({
 });
 
 // Redirect to the checkout URL
-console.log(checkout.checkout_url);
+console.log(checkout.checkoutUrl);
 ```
 
 <Card
@@ -188,17 +188,15 @@ First, retrieve the subscription to get the subscription item ID:
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: process.env.NODE_ENV !== 'production',
+  serverIdx: process.env.NODE_ENV === 'production' ? 0 : 1,
 });
 
 // Get subscription details
-const subscription = await creem.subscriptions.get({
-  subscriptionId: 'sub_YOUR_SUBSCRIPTION_ID',
-});
+const subscription = await creem.subscriptions.get('sub_YOUR_SUBSCRIPTION_ID');
 
 // Extract the subscription item ID
 const itemId = subscription.items[0].id;
@@ -252,17 +250,19 @@ Use the subscription item ID to update the number of seats:
 
 ```typescript
 // Update the subscription to 15 seats
-const updated = await creem.subscriptions.update({
-  subscriptionId: 'sub_YOUR_SUBSCRIPTION_ID',
-  items: [
-    {
-      id: 'sitem_3l8jhRR2jWWhIBbJrKLwPT', // Item ID from step 1
-      price_id: 'pprice_YOUR_PRICE_ID', // Price ID for validation
-      units: 5, // New seat count
-    },
-  ],
-  updateBehavior: 'proration-charge-immediately', // Optional
-});
+const updated = await creem.subscriptions.update(
+  'sub_YOUR_SUBSCRIPTION_ID',
+  {
+    items: [
+      {
+        id: 'sitem_3l8jhRR2jWWhIBbJrKLwPT', // Item ID from step 1
+        priceId: 'pprice_YOUR_PRICE_ID', // Price ID for validation
+        units: 15, // New seat count
+      },
+    ],
+    updateBehavior: 'proration-charge-immediately', // Optional
+  }
+);
 
 console.log('Subscription updated:', updated);
 ```

--- a/packages/docs/features/subscriptions/introduction.mdx
+++ b/packages/docs/features/subscriptions/introduction.mdx
@@ -91,11 +91,11 @@ export function SubscribeButton() {
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: process.env.NODE_ENV !== 'production',
+  serverIdx: process.env.NODE_ENV === 'production' ? 0 : 1,
 });
 
 // Create a subscription checkout session
@@ -112,7 +112,7 @@ const checkout = await creem.checkouts.create({
 });
 
 // Redirect to the checkout URL
-console.log(checkout.checkout_url);
+console.log(checkout.checkoutUrl);
 ```
 
 <Card

--- a/packages/docs/features/subscriptions/managing.mdx
+++ b/packages/docs/features/subscriptions/managing.mdx
@@ -31,15 +31,15 @@ export function ManageBillingButton({ customerId }: { customerId: string }) {
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: process.env.NODE_ENV !== 'production',
+  serverIdx: process.env.NODE_ENV === 'production' ? 0 : 1,
 });
 
 // Create customer portal link
-const portal = await creem.customers.createPortal({
+const portal = await creem.customers.generateBillingLinks({
   customerId: 'cust_YOUR_CUSTOMER_ID',
 });
 
@@ -109,19 +109,21 @@ Upgrade or downgrade a subscription to a different product using the subscriptio
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: process.env.NODE_ENV !== 'production',
+  serverIdx: process.env.NODE_ENV === 'production' ? 0 : 1,
 });
 
 // Upgrade subscription to a different product
-const upgraded = await creem.subscriptions.upgrade({
-  subscriptionId: 'sub_YOUR_SUBSCRIPTION_ID',
-  productId: 'prod_PREMIUM_PLAN', // New product ID
-  updateBehavior: 'proration-charge-immediately',
-});
+const upgraded = await creem.subscriptions.upgrade(
+  'sub_YOUR_SUBSCRIPTION_ID',
+  {
+    productId: 'prod_PREMIUM_PLAN', // New product ID
+    updateBehavior: 'proration-charge-immediately',
+  }
+);
 
 console.log('Subscription upgraded:', upgraded);
 ```
@@ -191,31 +193,31 @@ For seat-based subscriptions, you can update the number of seats:
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: process.env.NODE_ENV !== 'production',
+  serverIdx: process.env.NODE_ENV === 'production' ? 0 : 1,
 });
 
 // First, get the subscription to retrieve the item ID
-const subscription = await creem.subscriptions.get({
-  subscriptionId: 'sub_YOUR_SUBSCRIPTION_ID',
-});
+const subscription = await creem.subscriptions.get('sub_YOUR_SUBSCRIPTION_ID');
 
 const itemId = subscription.items[0].id;
 
 // Update the seat count
-const updated = await creem.subscriptions.update({
-  subscriptionId: 'sub_YOUR_SUBSCRIPTION_ID',
-  items: [
-    {
-      id: itemId,
-      units: 10, // New seat count
-    },
-  ],
-  updateBehavior: 'proration-charge-immediately',
-});
+const updated = await creem.subscriptions.update(
+  'sub_YOUR_SUBSCRIPTION_ID',
+  {
+    items: [
+      {
+        id: itemId,
+        units: 10, // New seat count
+      },
+    ],
+    updateBehavior: 'proration-charge-immediately',
+  }
+);
 ```
 
   </Tab>

--- a/packages/docs/features/subscriptions/refunds-and-cancellations.mdx
+++ b/packages/docs/features/subscriptions/refunds-and-cancellations.mdx
@@ -22,16 +22,16 @@ Cancel subscriptions programmatically using the API:
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: process.env.NODE_ENV !== 'production',
+  serverIdx: process.env.NODE_ENV === 'production' ? 0 : 1,
 });
 
 // Cancel subscription
-const canceled = await creem.subscriptions.cancel({
-  subscriptionId: 'sub_YOUR_SUBSCRIPTION_ID',
+const canceled = await creem.subscriptions.cancel('sub_YOUR_SUBSCRIPTION_ID', {
+  mode: 'immediate',
 });
 
 console.log('Subscription canceled:', canceled);
@@ -137,7 +137,7 @@ export function ManageSubscriptionButton({
 
 ```typescript
 // Create customer portal link
-const portal = await creem.customers.createPortal({
+const portal = await creem.customers.generateBillingLinks({
   customerId: 'cust_YOUR_CUSTOMER_ID',
 });
 
@@ -247,9 +247,9 @@ When you process a refund:
 ### Cancellation Flow Example
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
 });
 
@@ -259,12 +259,14 @@ async function handleCancellation(subscriptionId: string, reason?: string) {
     console.log(`Canceling subscription: ${subscriptionId}`, { reason });
 
     // Cancel the subscription
-    const canceled = await creem.subscriptions.cancel({
-      subscriptionId,
+    const canceled = await creem.subscriptions.cancel(subscriptionId, {
+      mode: 'immediate',
     });
 
-    // Send cancellation email to customer
-    await sendCancellationEmail(canceled.customer.email);
+    // Send cancellation email to customer when the response includes expanded customer data
+    if (typeof canceled.customer !== 'string') {
+      await sendCancellationEmail(canceled.customer.email);
+    }
 
     // Update internal database
     await db.subscription.update({

--- a/packages/docs/getting-started/introduction.mdx
+++ b/packages/docs/getting-started/introduction.mdx
@@ -81,7 +81,7 @@ We are the legal seller of record. We collect and remit VAT, GST, and sales tax 
 ## Developer Tools
 
 <CardGroup cols={3}>
-  <Card title="TypeScript SDK" icon="code" href="/code/sdks/typescript-core">
+  <Card title="TypeScript SDK" icon="code" href="/code/sdks/typescript">
     Type-safe SDK for Node.js, Deno, and Bun. Full API coverage with auto-generated types.
   </Card>
   <Card title="Next.js Adapter" icon="react" href="/code/sdks/nextjs">
@@ -203,7 +203,7 @@ Creem has a one-command migration tool to bring your products over.
   <Card title="Checkout API" icon="code" href="/api-reference/introduction">
     Programmatically create checkout sessions for custom flows.
   </Card>
-  <Card title="TypeScript SDK" icon="code" href="/code/sdks/typescript-core">
+  <Card title="TypeScript SDK" icon="code" href="/code/sdks/typescript">
     Full API coverage with type safety and auto-generated types.
   </Card>
   <Card title="Next.js Adapter" icon="react" href="/code/sdks/nextjs">

--- a/packages/docs/getting-started/quickstart.mdx
+++ b/packages/docs/getting-started/quickstart.mdx
@@ -102,19 +102,19 @@ export default function Page() {
 <CodeGroup>
 
 ```bash npm
-npm install creem_io
+npm install creem
 ```
 
 ```bash yarn
-yarn add creem_io
+yarn add creem
 ```
 
 ```bash pnpm
-pnpm install creem_io
+pnpm install creem
 ```
 
 ```bash bun
-bun install creem_io
+bun install creem
 ```
 
 </CodeGroup>
@@ -133,11 +133,11 @@ CREEM_API_KEY=your_api_key_here
 Create a checkout session:
 
 ```ts
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: true, // Set to false for production
+  serverIdx: 1, // Use 0 for production
 });
 
 const checkout = await creem.checkouts.create({
@@ -145,8 +145,8 @@ const checkout = await creem.checkouts.create({
   successUrl: 'https://yoursite.com/success',
 });
 
-// Redirect to checkout.checkout_url
-console.log(checkout.checkout_url);
+// Redirect to checkout.checkoutUrl
+console.log(checkout.checkoutUrl);
 ```
 
 <Card title="TypeScript SDK Docs" icon="code" href="/code/sdks/typescript">
@@ -315,11 +315,11 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 ```typescript
 // lib/creem.ts
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-export const creem = createCreem({
+export const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: true, // Set to false for production
+  serverIdx: 1, // Use 0 for production
 });
 ```
 
@@ -340,7 +340,7 @@ export async function POST(request: NextRequest) {
     });
     
     return NextResponse.json({ 
-      checkoutUrl: checkout.checkout_url 
+      checkoutUrl: checkout.checkoutUrl
     });
   } catch (error) {
     console.error('Checkout error:', error);
@@ -502,7 +502,7 @@ export default function SuccessPage({
 
 1. Install dependencies:
 ```bash
-npm install creem_io
+npm install creem
 ```
 
 2. Create a product in the [Creem dashboard](https://creem.io/dashboard/products)

--- a/packages/docs/getting-started/test-mode.mdx
+++ b/packages/docs/getting-started/test-mode.mdx
@@ -55,11 +55,11 @@ export const GET = Checkout({
     Enable test mode when initializing the SDK:
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: true, // Enable test mode
+  serverIdx: 1, // Enable test mode
 });
 
 const checkout = await creem.checkouts.create({
@@ -71,9 +71,9 @@ const checkout = await creem.checkouts.create({
 Use environment-based configuration:
 
 ```typescript
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  testMode: process.env.NODE_ENV !== 'production',
+  serverIdx: process.env.NODE_ENV === 'production' ? 0 : 1,
 });
 ```
 

--- a/packages/docs/skills/README.md
+++ b/packages/docs/skills/README.md
@@ -152,7 +152,7 @@ skills/
 
 This skill focuses on the CREEM REST API. It does not cover:
 
-- **TypeScript SDK** (`creem_io`) - See [TypeScript SDK docs](https://docs.creem.io/code/sdks/typescript)
+- **TypeScript SDK** (`creem`) - See [TypeScript SDK docs](https://docs.creem.io/code/sdks/typescript)
 - **Next.js SDK** (`@creem_io/nextjs`) - See [Next.js SDK docs](https://docs.creem.io/code/sdks/nextjs)
 - **Better Auth Plugin** (`@creem_io/better-auth`) - See [Better Auth docs](https://docs.creem.io/code/sdks/better-auth)
 


### PR DESCRIPTION
Rewrites the documentation to use the `creem` SDK.

There are two files left to be migrated
- [subscriptions/introductions](https://github.com/armitage-labs/creem/blob/main/packages/docs/features/subscriptions/introduction.mdx?plain=1#L299)
- [subscriptions/refunds-and-cancellations](https://github.com/armitage-labs/creem/blob/main/packages/docs/features/subscriptions/refunds-and-cancellations.mdx?plain=1#L321)

They include signature verification, event routing, and onGrantAccess/onRevokeAccess which are not 1:1 migratable to `creem` SDK. I'm checking this as part of the task to bring some of the convenience from `creem_io` into `creem` SDK. 