### PR TITLE
docs: Fix Test Mode toggle location

### DIFF
--- a/packages/docs/api-reference/introduction.mdx
+++ b/packages/docs/api-reference/introduction.mdx
@@ -47,7 +47,7 @@ Test mode gives you a full sandbox environment to build and test your integratio
 | **Payments** | Real charges                         | Simulated with test cards             |
 | **Data**     | Live data                            | Isolated sandbox data                 |
 
-To activate test mode, toggle **Test Mode** in the top navbar of your [dashboard](https://creem.io/dashboard).
+To activate test mode, toggle **Test Mode** in the bottom of the left sidebar of your [dashboard](https://creem.io/dashboard).
 
 ### Test Cards
 

--- a/packages/docs/getting-started/test-mode.mdx
+++ b/packages/docs/getting-started/test-mode.mdx
@@ -13,11 +13,11 @@ Test Mode allows you to build and test your Creem integration in a completely is
 
 ## Activating Test Mode
 
-To switch to the test environment, click the **Test Mode** toggle on the top navbar of your dashboard.
+To switch to the test environment, click the **Test Mode** toggle at the bottom of the left sidebar.
 
 <img
-  style={{ borderRadius: '0.5rem' }}
-  src="https://nucn5fajkcc6sgrd.public.blob.vercel-storage.com/test-mode-uVKSqW0Pcc9Mbu6MN82q3PrEDQUEbm.png"
+  style={{ borderRadius: '0.5rem', maxWidth: '450px' }}
+  src="https://nucn5fajkcc6sgrd.public.blob.vercel-storage.com/test-mode-BMpcC8LrMTvzYQerR0pSe55z3gWLD3"
 />
 
 ## Using Test Mode in Code
@@ -147,7 +147,7 @@ Creem uses separate API endpoints for test and production environments:
 
 ## API Keys
 
-Test and production environments use different API keys. You can find both keys in the [Developers section](https://creem.io/dashboard/developers). Make sure to toggle Test Mode in the navigation bar.
+Test and production environments use different API keys. You can find both keys in the [Developers section](https://creem.io/dashboard/developers). Make sure to toggle Test Mode in the bottom of the left sidebar.
 
 <Tip>
   Store your API keys as environment variables and never commit them to version


### PR DESCRIPTION
Fixes docs references to the Test Mode toggle, which was moved from top navbar to the bottom of the left sidebar.