### PR TITLE
fix(cli): correct outdated API key dashboard URL

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -65,7 +65,7 @@ This guide equips agents with everything needed to help a human integrate Creem 
 
 ### Authentication
 
-All API calls require the `x-api-key` header. Keys are available at [Dashboard > API Keys](https://creem.io/dashboard/api-keys).
+All API calls require the `x-api-key` header. Keys are available at [Dashboard > API Keys](https://creem.io/dashboard/developers).
 
 | Environment           | Key prefix    | API base                    |
 | --------------------- | ------------- | --------------------------- |
@@ -818,7 +818,7 @@ The environment switches automatically based on the key prefix. For SDKs, change
 | ---------------------- | --------------------------------------------------- |
 | Creem                  | <https://creem.io>                                    |
 | Dashboard              | <https://creem.io/dashboard>                          |
-| API keys               | <https://creem.io/dashboard/api-keys>                 |
+| API keys               | <https://creem.io/dashboard/developers>               |
 | Documentation          | <https://docs.creem.io>                               |
 | API Reference          | <https://docs.creem.io/api-reference>                 |
 | Webhooks               | <https://docs.creem.io/code/webhooks>                 |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -38,7 +38,7 @@ creem whoami
 creem config set environment live
 ```
 
-Get your API key from the [Creem Dashboard](https://creem.io/dashboard/api-keys).
+Get your API key from the [Creem Dashboard](https://creem.io/dashboard/developers).
 
 - Test keys start with `creem_test_`
 - Live keys start with `creem_`

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -34,7 +34,7 @@ export function createLoginCommand(): Command {
         if (!apiKey) {
           output.newline();
           output.info("Enter your API key from the Creem dashboard.");
-          output.dim("Get your API key at: https://creem.io/dashboard/api-keys");
+          output.dim("Get your API key at: https://creem.io/dashboard/developers");
           output.newline();
 
           apiKey = await password({

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -57,7 +57,7 @@ ${chalk.dim("Agents:")}
   Creem Skills:      https://github.com/armitage-labs/creem-skills
 
 ${chalk.dim("Documentation:")}  https://docs.creem.io
-${chalk.dim("API keys:")}       https://creem.io/dashboard/api-keys
+${chalk.dim("API keys:")}       https://creem.io/dashboard/developers
 `;
 
 const program = new Command();

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -21,7 +21,7 @@ export function detectEnvironment(apiKey: string): "test" | "live" {
   }
   throw new Error(
     'Invalid API key format. Key must start with "creem_test_" or "creem_live_" (or "creem_" for live). ' +
-      "Get your API key from https://creem.io/dashboard/api-keys",
+      "Get your API key from https://creem.io/dashboard/developers",
   );
 }
 


### PR DESCRIPTION
`creem login` — plus the CLI help banner, the auth-error hint, the package README, and AGENTS.md — pointed users to `https://creem.io/dashboard/api-keys`, which now **404s** (the API-keys page moved under the Developers section). Updates all 6 occurrences in `packages/cli` to `https://creem.io/dashboard/developers`.

Fixes ENG-730