### PR TITLE
fix(docs): correct outdated API key dashboard URL

### DIFF
--- a/packages/docs/ai/for-humans/getting-started.mdx
+++ b/packages/docs/ai/for-humans/getting-started.mdx
@@ -166,7 +166,7 @@ The one-prompt approach works for most integrations. For the full technical refe
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Get Your API Key" icon="key" href="https://creem.io/dashboard/api-keys">
+  <Card title="Get Your API Key" icon="key" href="https://creem.io/dashboard/developers">
     You'll need a Creem API key for your AI to use
   </Card>
   <Card title="Creem CLI" icon="terminal" href="/ai/for-humans/cli">


### PR DESCRIPTION
## What

The `https://creem.io/dashboard/api-keys` link in the AI getting-started guide (`packages/docs/ai/for-humans/getting-started.mdx`) returns a **404** — that page moved under the Developers section. This points it to `https://creem.io/dashboard/developers`, keeping the apex domain to match the other dashboard links in the docs.

## Scope

- Single occurrence under `packages/docs/`; confirmed none remain via `grep -rn "dashboard/api-keys" packages/docs/`.

## Related

Same fix already shipped for the CLI in #77 (Linear ENG-730).