### PR TITLE
fix(docs): correct broken TypeScript SDK and API Keys links

### DIFF
--- a/packages/docs/code/community/community-resources.mdx
+++ b/packages/docs/code/community/community-resources.mdx
@@ -72,7 +72,7 @@ Community-maintained SDKs and adapters for various frameworks and languages. The
 
 <Note>
   Looking for official SDKs? Check out our{' '}
-  <a href="/code/sdks/typescript">TypeScript SDK</a> and{' '}
+  <a href="/code/sdks/typescript-core">TypeScript SDK</a> and{' '}
   <a href="/code/sdks/nextjs">Next.js adapter</a>.
 </Note>
 
@@ -163,7 +163,7 @@ We love seeing what our community builds! If you've created an SDK, template, bo
   >
     Connect with other developers and get help from the community.
   </Card>
-  <Card title="Official SDKs" icon="code" href="/code/sdks/typescript">
+  <Card title="Official SDKs" icon="code" href="/code/sdks/typescript-core">
     Check out our official TypeScript SDK and framework adapters.
   </Card>
   <Card title="API Reference" icon="book" href="/api-reference/introduction">

--- a/packages/docs/code/community/community-resources/boilerplates/saaskit.mdx
+++ b/packages/docs/code/community/community-resources/boilerplates/saaskit.mdx
@@ -32,7 +32,7 @@ SaaSKit includes Creem payment integration out of the box, allowing you to accep
   >
     Visit the official SaaSKit website for documentation and setup instructions.
   </Card>
-  <Card title="Creem TypeScript SDK" icon="code" href="/code/sdks/typescript">
+  <Card title="Creem TypeScript SDK" icon="code" href="/code/sdks/typescript-core">
     Learn about the Creem SDK used in SaaSKit.
   </Card>
 </CardGroup>

--- a/packages/docs/code/community/creem-checkout-nextjs-demo.mdx
+++ b/packages/docs/code/community/creem-checkout-nextjs-demo.mdx
@@ -39,7 +39,7 @@ A Next.js demo application that demonstrates how to integrate Creem checkout flo
   <Card
     title="Creem Integration"
     icon="credit-card"
-    href="/code/sdks/typescript"
+    href="/code/sdks/typescript-core"
   >
     Learn about Creem's payment integration.
   </Card>

--- a/packages/docs/code/community/krema.mdx
+++ b/packages/docs/code/community/krema.mdx
@@ -36,7 +36,7 @@ Krema is an unofficial TypeScript SDK for the Creem API that provides type-safe 
   <Card
     title="Creem Integration"
     icon="credit-card"
-    href="/code/sdks/typescript"
+    href="/code/sdks/typescript-core"
   >
     Learn about Creem's payment integration.
   </Card>

--- a/packages/docs/code/community/nuxt-creem.mdx
+++ b/packages/docs/code/community/nuxt-creem.mdx
@@ -43,7 +43,7 @@ Nuxt Creem is a Nuxt module that provides an easy way to integrate Creem payment
   <Card
     title="Creem Integration"
     icon="credit-card"
-    href="/code/sdks/typescript"
+    href="/code/sdks/typescript-core"
   >
     Learn about Creem's payment integration.
   </Card>

--- a/packages/docs/code/community/saaskit.mdx
+++ b/packages/docs/code/community/saaskit.mdx
@@ -40,7 +40,7 @@ SaaSKit is a modular TanStack Start boilerplate that includes Creem payment inte
   <Card
     title="Creem Integration"
     icon="credit-card"
-    href="/code/sdks/typescript"
+    href="/code/sdks/typescript-core"
   >
     Learn about Creem's payment integration.
   </Card>

--- a/packages/docs/code/community/supastarter.mdx
+++ b/packages/docs/code/community/supastarter.mdx
@@ -42,7 +42,7 @@ Supastarter is a production-ready Next.js SaaS starter kit that includes Creem p
   <Card
     title="Creem Integration"
     icon="credit-card"
-    href="/code/sdks/typescript"
+    href="/code/sdks/typescript-core"
   >
     Learn about Creem's payment integration.
   </Card>

--- a/packages/docs/code/sdks/ai-agents.mdx
+++ b/packages/docs/code/sdks/ai-agents.mdx
@@ -479,7 +479,7 @@ The Creem skill is designed for **direct API integration** and complements our S
 
 <Note>
   The skill focuses on the REST API. For SDK-specific help, see our [TypeScript
-  SDK](/code/sdks/typescript), [Next.js SDK](/code/sdks/nextjs), or [Better
+  SDK](/code/sdks/typescript-core), [Next.js SDK](/code/sdks/nextjs), or [Better
   Auth](/code/sdks/better-auth) documentation.
 </Note>
 

--- a/packages/docs/code/sdks/templates.mdx
+++ b/packages/docs/code/sdks/templates.mdx
@@ -230,7 +230,7 @@ yarn dev
   >
     View the source code, open issues, or contribute.
   </Card>
-  <Card title="Creem SDK Docs" icon="book" href="/code/sdks/typescript">
+  <Card title="Creem SDK Docs" icon="book" href="/code/sdks/typescript-core">
     Learn more about the Creem TypeScript SDK.
   </Card>
   <Card

--- a/packages/docs/features/addons/licenses.mdx
+++ b/packages/docs/features/addons/licenses.mdx
@@ -561,7 +561,7 @@ For detailed API documentation, visit:
 <Card
   title="TypeScript SDK Documentation"
   icon="code"
-  href="/code/sdks/typescript"
+  href="/code/sdks/typescript-core"
 >
   View the complete TypeScript SDK documentation with examples for licenses,
   subscriptions, and more.

--- a/packages/docs/features/checkout/checkout-api.mdx
+++ b/packages/docs/features/checkout/checkout-api.mdx
@@ -149,7 +149,7 @@ console.log(checkout.checkout_url);
 <Card
   title="TypeScript SDK Documentation"
   icon="code"
-  href="/code/sdks/typescript"
+  href="/code/sdks/typescript-core"
 >
   View the full SDK API reference and advanced usage examples.
 </Card>

--- a/packages/docs/features/customer-portal.mdx
+++ b/packages/docs/features/customer-portal.mdx
@@ -144,7 +144,7 @@ window.location.href = portal.customerPortalLink;
 <Card
   title="TypeScript SDK Documentation"
   icon="code"
-  href="/code/sdks/typescript"
+  href="/code/sdks/typescript-core"
 >
   View the complete customer management API reference.
 </Card>

--- a/packages/docs/features/one-time-payment.mdx
+++ b/packages/docs/features/one-time-payment.mdx
@@ -85,7 +85,7 @@ console.log(checkout.checkout_url);
 <Card
   title="TypeScript SDK Documentation"
   icon="code"
-  href="/code/sdks/typescript"
+  href="/code/sdks/typescript-core"
 >
   View the full SDK API reference and advanced usage examples.
 </Card>

--- a/packages/docs/features/seat-based-billing.mdx
+++ b/packages/docs/features/seat-based-billing.mdx
@@ -78,7 +78,7 @@ console.log(checkout.checkout_url);
 <Card
   title="TypeScript SDK Documentation"
   icon="code"
-  href="/code/sdks/typescript"
+  href="/code/sdks/typescript-core"
 >
   View the full SDK API reference and advanced usage examples.
 </Card>

--- a/packages/docs/features/subscriptions/introduction.mdx
+++ b/packages/docs/features/subscriptions/introduction.mdx
@@ -118,7 +118,7 @@ console.log(checkout.checkout_url);
 <Card
   title="TypeScript SDK Documentation"
   icon="code"
-  href="/code/sdks/typescript"
+  href="/code/sdks/typescript-core"
 >
   View the full SDK API reference and advanced usage examples.
 </Card>
@@ -348,7 +348,7 @@ app.post('/webhook', async (req, res) => {
 <Card
   title="TypeScript SDK Documentation"
   icon="code"
-  href="/code/sdks/typescript"
+  href="/code/sdks/typescript-core"
 >
   View the complete webhook API and all available events.
 </Card>

--- a/packages/docs/getting-started/quickstart.mdx
+++ b/packages/docs/getting-started/quickstart.mdx
@@ -127,7 +127,7 @@ CREEM_API_KEY=your_api_key_here
 ```
 
 <Tip>
-  See the [API Keys](/getting-started/api-keys) page for more information.
+  See the [API Keys](/getting-started/dashboard-overview#finding-your-api-keys) page for more information.
 </Tip>
 
 Create a checkout session:
@@ -149,7 +149,7 @@ const checkout = await creem.checkouts.create({
 console.log(checkout.checkout_url);
 ```
 
-<Card title="TypeScript SDK Docs" icon="code" href="/code/sdks/typescript">
+<Card title="TypeScript SDK Docs" icon="code" href="/code/sdks/typescript-core">
   Explore the full SDK API reference and advanced usage.
 </Card>
 
@@ -170,7 +170,7 @@ CREEM_API_KEY=your_api_key_here
 ```
 
 <Tip>
-  See the [API Keys](/getting-started/api-keys) page for more information.
+  See the [API Keys](/getting-started/dashboard-overview#finding-your-api-keys) page for more information.
 </Tip>
 
 Configure Better Auth with the Creem plugin:

--- a/packages/docs/guides/create-checkout-session.mdx
+++ b/packages/docs/guides/create-checkout-session.mdx
@@ -53,7 +53,7 @@ Choose your preferred integration method:
   <Card title="Next.js" icon="react" href="/code/sdks/nextjs">
     Use the Next.js adapter for seamless integration
   </Card>
-  <Card title="TypeScript SDK" icon="code" href="/code/sdks/typescript">
+  <Card title="TypeScript SDK" icon="code" href="/code/sdks/typescript-core">
     Full type-safety for any JavaScript framework
   </Card>
   <Card title="Better Auth" icon="lock" href="/code/sdks/better-auth">


### PR DESCRIPTION
Closes #80

## What changed

Two internal doc links in `packages/docs` returned 404 on docs.creem.io. Both are path corrections only — no content changes.

| Broken target | Corrected to | Refs |
|---|---|---|
| `/code/sdks/typescript` | `/code/sdks/typescript-core` | 19 (16 files) |
| `/getting-started/api-keys` | `/getting-started/dashboard-overview#finding-your-api-keys` | 2 (quickstart) |

The `api-keys` link had no destination page; the canonical "Finding Your API Keys" section already lives in `dashboard-overview`.

## Why

The quickstart TypeScript SDK flow linked to two dead pages, breaking onboarding. The `/code/sdks/typescript` link was dead in every place it appeared (16 files), not just the quickstart.

## Verification

- Confirmed `code/sdks/typescript-core.mdx` and `getting-started/dashboard-overview.mdx` (with `## Finding Your API Keys` heading → `#finding-your-api-keys` anchor) exist.
- Regex used a negative lookahead so `typescript-core` / `typescript-wrapper` links were untouched; verified zero `typescript-core-core` corruption and zero remaining bare `/code/sdks/typescript` or `/getting-started/api-keys` references.

## Scope

Limited to the two reported broken links. Orphaned Mintlify template files (`essentials/*` → `/writing-content/*`, `/api-playground/demo`) were found during the scan but are intentionally out of scope here.