### PR TITLE
fix: [ENG-721] remove prepublishOnly to fix SDK publish build race

### DIFF
--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -19,7 +19,6 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "prepublishOnly": "npm run build",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,7 +19,6 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "prepublishOnly": "npm run build",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -24,7 +24,6 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "prepublishOnly": "npm run build",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -19,7 +19,6 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "prepublishOnly": "npm run build",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [


### PR DESCRIPTION
## What
Removes the redundant `prepublishOnly: npm run build` from the 4 embedded-checkout SDK packages (`@creem_io/embed`, `react`, `vue`, `svelte`).

## Why
The release script is `turbo run build && changeset publish`. `turbo run build` already builds every package in dependency order (`build.dependsOn: ["^build"]`) and the packages ship `dist` via their `files` field — so the build is already done before publish.

But `changeset publish` then runs each package's `prepublishOnly` → `tsup` (with `clean: true`) **again**, concurrently. `@creem_io/embed`'s rebuild wipes its `dist` while the wrappers' DTS build tries to resolve it, so the wrapper build fails:

```
index.ts: TS2307: Cannot find module '@creem_io/embed' or its type declarations
index.ts: TS7006: Parameter 'detail' implicitly has an 'any' type
DTS Build error → publish fails (ELIFECYCLE)
```

Verified locally: build `embed` then `vue` → succeeds. The failure only happens during the racey publish-time rebuild.

## Effect
Removes the build race so `changeset publish` publishes the already-`turbo`-built dist. No API change → no changeset needed.

## Note
This isolates the variable: after merge, the only remaining failure in the release run should be the `E404 on PUT` (npm auth/permission to publish these new packages) — which confirms the publish blocker is the token, not the build.