### PR TITLE
docs(checkout): add embedded checkout screenshot

### DIFF
--- a/packages/docs/features/checkout/embedded-checkout.mdx
+++ b/packages/docs/features/checkout/embedded-checkout.mdx
@@ -5,6 +5,14 @@ description: 'Embed Creem checkout directly in your site — as a modal overlay 
 
 Embedded checkout runs the entire Creem payment flow **inside your own site** instead of sending customers to a hosted page. Drop in a small script, open checkout as a modal or inline iframe, and get a callback when payment completes.
 
+<Frame caption="Creem embedded checkout shown as a modal overlay on a merchant's site">
+  <img
+    style={{ borderRadius: '0.5rem' }}
+    src="https://nucn5fajkcc6sgrd.public.blob.vercel-storage.com/embed-checkout-4sSl5sCtTb30kDoLuhCZHtZaW1qPp4.png"
+    alt="Creem embedded checkout as a modal overlay on a merchant's site"
+  />
+</Frame>
+
 ## How it works
 
 1. Create a **checkout session** on your server with your secret API key (see [Checkout API](/features/checkout/checkout-api)) and read its `checkoutUrl`.


### PR DESCRIPTION
## What

Adds a screenshot to the [Embedded Checkout](https://docs.creem.io/features/checkout/embedded-checkout) docs page, showing the embedded checkout as a modal overlay on a merchant's site.

## Details

- Placed a `<Frame>` + `<img>` block right after the intro paragraph (hero shot), matching how sibling feature pages (`affiliate-program`, `split-payments`, `product-bundles`) open with a screenshot.
- Image is hosted on Vercel Blob storage (`vercel-storage.com`) — the established convention for feature/checkout doc screenshots, so nothing is checked into the repo.
- Uses `caption` on `<Frame>` for the visible label and `alt` on `<img>` for accessibility.

## Notes

- Minimal diff (8 lines added, no reformatting) — kept the file's existing single-quote style.
- Docs auto-deploy via the Mintlify GitHub App on merge to `main`; the PR gets a Mintlify preview build.