### PR TITLE
docs: migrate SDK examples from deprecated creem_io to creem

### DIFF
--- a/packages/docs/api-reference/error-codes.mdx
+++ b/packages/docs/api-reference/error-codes.mdx
@@ -128,9 +128,9 @@ Returned when trying to create a resource that already exists.
 ### TypeScript SDK
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({ apiKey: process.env.CREEM_API_KEY! });
+const creem = new Creem({ apiKey: process.env.CREEM_API_KEY! });
 
 try {
   const checkout = await creem.checkouts.create({

--- a/packages/docs/api-reference/introduction.mdx
+++ b/packages/docs/api-reference/introduction.mdx
@@ -76,9 +76,9 @@ curl -X POST https://test-api.creem.io/v1/checkouts \
 ```
 
 ```typescript TypeScript SDK
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: process.env.NODE_ENV !== 'production',
 });

--- a/packages/docs/code/sdks/typescript-wrapper.mdx
+++ b/packages/docs/code/sdks/typescript-wrapper.mdx
@@ -1,13 +1,17 @@
 ---
-title: SDK Wrapper (creem_io)
-description: A convenience wrapper SDK with helper functions for webhooks, access management, and simplified API interactions. Ideal for quick integrations with less boilerplate.
+title: SDK Wrapper (creem_io) — Deprecated
+description: The standalone creem_io wrapper SDK is deprecated. Use the core creem SDK for API calls, and the @creem_io/nextjs or @creem_io/better-auth adapters for onGrantAccess / onRevokeAccess callbacks.
 ---
 
-<Info>
-  This is the **creem_io** wrapper package, which provides convenience methods and webhook helpers for common use cases.
+<Warning>
+  **The standalone `creem_io` wrapper package is deprecated** and shows a deprecation notice on npm and GitHub. This page is kept for reference only.
 
-  For full API access with all endpoints and maximum flexibility, see the [Core SDK (creem)](/code/sdks/typescript-core).
-</Info>
+  Use these actively maintained packages instead:
+
+  - **API calls** → the core SDK [`creem`](/code/sdks/typescript-core)
+  - **`onGrantAccess` / `onRevokeAccess` callbacks** → the framework adapters [`@creem_io/nextjs`](/code/sdks/nextjs) or [`@creem_io/better-auth`](/code/sdks/better-auth)
+  - **Handling webhooks yourself** → verify the `creem-signature` header manually (see the [Webhook Guide](/code/webhooks))
+</Warning>
 
 ## Overview
 

--- a/packages/docs/features/addons/licenses.mdx
+++ b/packages/docs/features/addons/licenses.mdx
@@ -142,9 +142,9 @@ Here's how a typical activation flow works:
 <CodeGroup>
 
 ```ts TypeScript SDK
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: true,
 });
@@ -289,9 +289,9 @@ Here's how the validation process typically works:
 <CodeGroup>
 
 ```ts TypeScript SDK
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: true,
 });
@@ -444,9 +444,9 @@ Here's how the deactivation process typically works:
 <CodeGroup>
 
 ```ts TypeScript SDK
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: true,
 });

--- a/packages/docs/features/checkout/checkout-api.mdx
+++ b/packages/docs/features/checkout/checkout-api.mdx
@@ -104,19 +104,19 @@ The `CreemCheckout` component automatically handles the checkout session creatio
 <CodeGroup>
 
 ```bash npm
-npm install creem_io
+npm install creem
 ```
 
 ```bash yarn
-yarn add creem_io
+yarn add creem
 ```
 
 ```bash pnpm
-pnpm install creem_io
+pnpm install creem
 ```
 
 ```bash bun
-bun install creem_io
+bun install creem
 ```
 
 </CodeGroup>
@@ -124,9 +124,9 @@ bun install creem_io
 ### Create a checkout session
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: process.env.NODE_ENV !== 'production',
 });

--- a/packages/docs/features/checkout/embedded-checkout.mdx
+++ b/packages/docs/features/checkout/embedded-checkout.mdx
@@ -29,9 +29,9 @@ Every embed needs a **checkout URL**, created on your server with your secret AP
 
 ```ts
 // Server-side only — keep CREEM_API_KEY secret
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({ apiKey: process.env.CREEM_API_KEY! });
+const creem = new Creem({ apiKey: process.env.CREEM_API_KEY! });
 
 const checkout = await creem.checkouts.create({
   productId: 'prod_YOUR_PRODUCT_ID',

--- a/packages/docs/features/customer-portal.mdx
+++ b/packages/docs/features/customer-portal.mdx
@@ -107,15 +107,15 @@ export function ManageSubscriptionButton({
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: process.env.NODE_ENV !== 'production',
 });
 
 // Create customer portal link
-const portal = await creem.customers.createPortal({
+const portal = await creem.customers.generateBillingLinks({
   customerId: 'cust_abc123',
 });
 
@@ -128,12 +128,13 @@ You can also retrieve the customer ID by email:
 
 ```typescript
 // Get customer by email first
-const customer = await creem.customers.get({
-  email: 'customer@example.com',
-});
+const customer = await creem.customers.retrieve(
+  undefined,
+  'customer@example.com',
+);
 
 // Then create portal link
-const portal = await creem.customers.createPortal({
+const portal = await creem.customers.generateBillingLinks({
   customerId: customer.id,
 });
 

--- a/packages/docs/features/discounts.mdx
+++ b/packages/docs/features/discounts.mdx
@@ -30,9 +30,9 @@ You can also create discounts programmatically using the API.
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: process.env.NODE_ENV !== 'production',
 });

--- a/packages/docs/features/one-time-payment.mdx
+++ b/packages/docs/features/one-time-payment.mdx
@@ -61,9 +61,9 @@ export function BuyButton() {
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: process.env.NODE_ENV !== 'production',
 });

--- a/packages/docs/features/seat-based-billing.mdx
+++ b/packages/docs/features/seat-based-billing.mdx
@@ -57,9 +57,9 @@ export function SeatBasedCheckout({ seatCount }: { seatCount: number }) {
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: process.env.NODE_ENV !== 'production',
 });
@@ -188,9 +188,9 @@ First, retrieve the subscription to get the subscription item ID:
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: process.env.NODE_ENV !== 'production',
 });

--- a/packages/docs/features/subscriptions/introduction.mdx
+++ b/packages/docs/features/subscriptions/introduction.mdx
@@ -91,9 +91,9 @@ export function SubscribeButton() {
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: process.env.NODE_ENV !== 'production',
 });
@@ -288,69 +288,6 @@ export const POST = Webhook({
   href="/code/sdks/nextjs"
 >
   Learn more about webhook handling and server functions.
-</Card>
-
-  </Tab>
-
-  <Tab title="TypeScript SDK">
-
-```typescript
-// app/api/webhook/route.ts
-import { createCreem } from 'creem_io';
-
-const creem = createCreem({
-  apiKey: process.env.CREEM_API_KEY!,
-  webhookSecret: process.env.CREEM_WEBHOOK_SECRET!,
-});
-
-app.post('/webhook', async (req, res) => {
-  try {
-    await creem.webhooks.handleEvents(
-      req.body,
-      req.headers['creem-signature'],
-      {
-        onGrantAccess: async ({ reason, customer, product, metadata }) => {
-          // Called for: subscription.active, subscription.trialing, subscription.paid
-          const userId = metadata?.userId as string;
-
-          await db.user.update({
-            where: { id: userId },
-            data: {
-              subscriptionActive: true,
-              subscriptionTier: product.name,
-            },
-          });
-
-          console.log(`Granted ${reason} to ${customer.email}`);
-        },
-
-        onRevokeAccess: async ({ reason, customer, metadata }) => {
-          // Called for: subscription.paused, subscription.expired
-          const userId = metadata?.userId as string;
-
-          await db.user.update({
-            where: { id: userId },
-            data: { subscriptionActive: false },
-          });
-
-          console.log(`Revoked access (${reason}) from ${customer.email}`);
-        },
-      }
-    );
-
-    res.status(200).send('OK');
-  } catch (error) {
-    res.status(400).send('Invalid signature');
-  }
-});
-```
-
-<Card
-  title="TypeScript SDK Documentation"
-  icon="code"
-  href="/code/sdks/typescript-core"
->
-  View the complete webhook API and all available events.
 </Card>
 
   </Tab>

--- a/packages/docs/features/subscriptions/managing.mdx
+++ b/packages/docs/features/subscriptions/managing.mdx
@@ -31,15 +31,15 @@ export function ManageBillingButton({ customerId }: { customerId: string }) {
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: process.env.NODE_ENV !== 'production',
 });
 
 // Create customer portal link
-const portal = await creem.customers.createPortal({
+const portal = await creem.customers.generateBillingLinks({
   customerId: 'cust_YOUR_CUSTOMER_ID',
 });
 
@@ -109,9 +109,9 @@ Upgrade or downgrade a subscription to a different product using the subscriptio
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: process.env.NODE_ENV !== 'production',
 });
@@ -191,9 +191,9 @@ For seat-based subscriptions, you can update the number of seats:
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: process.env.NODE_ENV !== 'production',
 });

--- a/packages/docs/features/subscriptions/refunds-and-cancellations.mdx
+++ b/packages/docs/features/subscriptions/refunds-and-cancellations.mdx
@@ -22,9 +22,9 @@ Cancel subscriptions programmatically using the API:
   <Tab title="TypeScript SDK">
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: process.env.NODE_ENV !== 'production',
 });
@@ -137,7 +137,7 @@ export function ManageSubscriptionButton({
 
 ```typescript
 // Create customer portal link
-const portal = await creem.customers.createPortal({
+const portal = await creem.customers.generateBillingLinks({
   customerId: 'cust_YOUR_CUSTOMER_ID',
 });
 
@@ -247,9 +247,9 @@ When you process a refund:
 ### Cancellation Flow Example
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
 });
 
@@ -313,40 +313,42 @@ export const POST = Webhook({
 
   </Tab>
 
-  <Tab title="TypeScript SDK">
+  <Tab title="Manual Webhook">
 
 ```typescript
-import { createCreem } from 'creem_io';
-
-const creem = createCreem({
-  apiKey: process.env.CREEM_API_KEY!,
-  webhookSecret: process.env.CREEM_WEBHOOK_SECRET!,
-});
-
 // In your webhook endpoint
-await creem.webhooks.handleEvents(
-  request.body,
-  request.headers['creem-signature'],
-  {
-    onSubscriptionCanceled: async (data) => {
-      const { subscription, customer } = data;
+import crypto from 'crypto';
 
-      console.log(`Subscription ${subscription.id} canceled`);
+function verifySignature(payload: string, signature: string) {
+  const computed = crypto
+    .createHmac('sha256', process.env.CREEM_WEBHOOK_SECRET!)
+    .update(payload)
+    .digest('hex');
+  return computed === signature;
+}
 
-      // Revoke access
-      await revokeAccess(customer.email);
-    },
+app.post('/webhook', async (req, res) => {
+  const signature = req.headers['creem-signature'];
+  const payload = JSON.stringify(req.body);
 
-    onRevokeAccess: async (context) => {
-      // Simplified access management
-      const userId = context.metadata?.userId;
-      await db.user.update({
-        where: { id: userId },
-        data: { subscriptionActive: false },
-      });
-    },
+  if (!verifySignature(payload, signature)) {
+    return res.status(401).send('Invalid signature');
   }
-);
+
+  const { eventType, object } = req.body;
+
+  // Revoke access when a subscription is canceled
+  if (eventType === 'subscription.canceled') {
+    const customer = object.customer;
+
+    console.log(`Subscription ${object.id} canceled`);
+
+    // Revoke access
+    await revokeAccess(customer.email);
+  }
+
+  res.status(200).send('OK');
+});
 ```
 
   </Tab>
@@ -374,29 +376,46 @@ When a subscription payment fails:
 
 ```typescript
 // Handle failed payment webhook
-await creem.webhooks.handleEvents(
-  request.body,
-  request.headers['creem-signature'],
-  {
-    onSubscriptionPastDue: async (data) => {
-      const { subscription, customer } = data;
+import crypto from 'crypto';
 
-      // Notify customer to update payment method
-      await sendPaymentFailedEmail(customer.email, {
-        portalLink: `https://yoursite.com/portal?customer=${customer.id}`,
-      });
+function verifySignature(payload: string, signature: string) {
+  const computed = crypto
+    .createHmac('sha256', process.env.CREEM_WEBHOOK_SECRET!)
+    .update(payload)
+    .digest('hex');
+  return computed === signature;
+}
 
-      // Optionally restrict access or show warning
-      await showPaymentWarning(customer.email);
-    },
+app.post('/webhook', async (req, res) => {
+  const signature = req.headers['creem-signature'];
+  const payload = JSON.stringify(req.body);
 
-    onSubscriptionCanceled: async (data) => {
-      // After all retries failed
-      await revokeAccess(data.customer.email);
-      await sendSubscriptionEndedEmail(data.customer.email);
-    },
+  if (!verifySignature(payload, signature)) {
+    return res.status(401).send('Invalid signature');
   }
-);
+
+  const { eventType, object } = req.body;
+  const customer = object.customer;
+
+  // Payment failed — subscription is past due
+  if (eventType === 'subscription.past_due') {
+    // Notify customer to update payment method
+    await sendPaymentFailedEmail(customer.email, {
+      portalLink: `https://yoursite.com/portal?customer=${customer.id}`,
+    });
+
+    // Optionally restrict access or show warning
+    await showPaymentWarning(customer.email);
+  }
+
+  // After all retries failed
+  if (eventType === 'subscription.canceled') {
+    await revokeAccess(customer.email);
+    await sendSubscriptionEndedEmail(customer.email);
+  }
+
+  res.status(200).send('OK');
+});
 ```
 
 ---

--- a/packages/docs/getting-started/quickstart.mdx
+++ b/packages/docs/getting-started/quickstart.mdx
@@ -102,19 +102,19 @@ export default function Page() {
 <CodeGroup>
 
 ```bash npm
-npm install creem_io
+npm install creem
 ```
 
 ```bash yarn
-yarn add creem_io
+yarn add creem
 ```
 
 ```bash pnpm
-pnpm install creem_io
+pnpm install creem
 ```
 
 ```bash bun
-bun install creem_io
+bun install creem
 ```
 
 </CodeGroup>
@@ -133,9 +133,9 @@ CREEM_API_KEY=your_api_key_here
 Create a checkout session:
 
 ```ts
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: true, // Set to false for production
 });
@@ -315,9 +315,9 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 ```typescript
 // lib/creem.ts
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-export const creem = createCreem({
+export const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: true, // Set to false for production
 });
@@ -502,7 +502,7 @@ export default function SuccessPage({
 
 1. Install dependencies:
 ```bash
-npm install creem_io
+npm install creem
 ```
 
 2. Create a product in the [Creem dashboard](https://creem.io/dashboard/products)

--- a/packages/docs/getting-started/test-mode.mdx
+++ b/packages/docs/getting-started/test-mode.mdx
@@ -55,9 +55,9 @@ export const GET = Checkout({
     Enable test mode when initializing the SDK:
 
 ```typescript
-import { createCreem } from 'creem_io';
+import { Creem } from 'creem';
 
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: true, // Enable test mode
 });
@@ -71,7 +71,7 @@ const checkout = await creem.checkouts.create({
 Use environment-based configuration:
 
 ```typescript
-const creem = createCreem({
+const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
   testMode: process.env.NODE_ENV !== 'production',
 });


### PR DESCRIPTION
The standalone creem_io wrapper is deprecated on npm/GitHub, but the docs still recommended it (reported via Featurebase). Migrate all customer-facing examples to the active packages.

- 14 pages: creem_io wrapper to creem core SDK (import/init/install), fixing diverged methods (customers.get to retrieve, createPortal to generateBillingLinks)

- Replace wrapper-only webhook examples (creem.webhooks.handleEvents, which has no core equivalent) with manual signature verification; onGrantAccess/onRevokeAccess paths now point to @creem_io/nextjs and @creem_io/better-auth

- Add a deprecation banner to the typescript-wrapper page

- https://creem.featurebase.app/dashboard/inbox/team/6947065c5731aa69f4b3d501/conversation/17779