### PR TITLE
feat: [ENG-757] forward creem_ref affiliate token into the checkout iframe (embed SDK)

### DIFF
--- a/.changeset/eng-757-creem-ref-forwarding.md
+++ b/.changeset/eng-757-creem-ref-forwarding.md
@@ -1,0 +1,5 @@
+---
+"@creem_io/embed": minor
+---
+
+Forward the `creem_ref` affiliate token from the merchant page into the checkout iframe URL. Embedded checkout (`openCheckout` / `mount`, and the React/Vue/Svelte wrappers) now attributes the affiliate in every browser — including Safari (ITP), Firefox (TCP), and Chrome incognito, where the third-party affiliate cookie is dropped inside the iframe. The token is read from the merchant page's `?creem_ref=` query param and appended to the checkout URL. No public API change.

--- a/packages/embed/index.ts
+++ b/packages/embed/index.ts
@@ -51,15 +51,36 @@ export interface CreemCheckoutInlineHandle {
   destroy: () => void;
 }
 
-// Append the merchant-controlled presentation params (`theme`, `locale`) to the
-// checkout URL. Both are optional; the checkout page falls back to its defaults
-// (browser language, light theme) when absent.
+// Read the affiliate ref token (`creem_ref`) from the MERCHANT page URL. The
+// /affiliate redirect lands the visitor on the merchant's own site with
+// `?creem_ref=<signed token>` — first-party to the visitor, so it's readable
+// here even in browsers that drop our third-party cookie (Safari ITP,
+// Firefox TCP). Returns null when absent or the URL can't be parsed.
+function readAffiliateRef(): string | null {
+  try {
+    return new URLSearchParams(window.location.search).get("creem_ref");
+  } catch {
+    return null;
+  }
+}
+
+// Append the merchant-controlled presentation params (`theme`, `locale`) and the
+// affiliate ref token (`creem_ref`) to the checkout URL. Presentation params are
+// optional; the checkout page falls back to its defaults (browser language,
+// light theme) when absent. Forwarding `creem_ref` into the iframe URL is what
+// carries affiliate attribution across the third-party boundary (ENG-757), so it
+// survives in browsers that drop the cookie.
 function withParams(url: string, options: CreemCheckoutOptions): string {
-  if (!options.theme && !options.locale) return url;
+  const ref = readAffiliateRef();
+  if (!options.theme && !options.locale && !ref) return url;
   try {
     const parsed = new URL(url);
     if (options.theme) parsed.searchParams.set("theme", options.theme);
     if (options.locale) parsed.searchParams.set("locale", options.locale);
+    // Don't clobber a creem_ref the merchant already put on the checkout URL.
+    if (ref && !parsed.searchParams.has("creem_ref")) {
+      parsed.searchParams.set("creem_ref", ref);
+    }
     return parsed.toString();
   } catch {
     return url;


### PR DESCRIPTION
## What

Mirror the ENG-757 `creem_ref` affiliate-token forwarding into the SDK embed core (`@creem_io/embed`), so embedded checkout attributes the affiliate in **every browser** (Safari / Firefox / Chrome-incognito) — not just the hosted `creem.io/embed.js` path.

## Why

`@creem_io/embed` is a separate copy of the embed loader (used by `@creem_io/react`, `/vue`, `/svelte`). The monorepo's `public/embed.js` got this forwarding in ENG-757 (armitage-labs/pugpay-monorepo#2252), but this SDK loader didn't — so merchants embedding via the npm SDK wouldn't get affiliate attribution where the third-party cookie is dropped in the iframe.

## What changed (`packages/embed/index.ts`)

- `readAffiliateRef()` — reads `creem_ref` from the merchant page URL (first-party to the visitor).
- `withParams()` — forwards `creem_ref` into the checkout iframe URL (fixes the early-return guard, doesn't clobber a `creem_ref` the merchant already set).

The `/affiliate` redirect lands the visitor on the merchant page with `?creem_ref=<signed token>`; the SDK appends it to the iframe URL; the checkout resolves it server-side → same affiliate attribution, **no cookie**. Same mechanism as the hosted loader.

No protocol change — `CREEM_EMBED_PROTOCOL_VERSION` stays `1`. One change covers all framework wrappers (they re-export this core). `tsc --noEmit` passes.

## Follow-up

After merge, **publish a new release** (npm version bump of `@creem_io/embed` + the wrappers) so SDK-based merchants pick up the forwarding.
