### PR TITLE
docs: add API resellers to restricted products

### DIFF
--- a/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
+++ b/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
@@ -136,6 +136,7 @@ We review accounts to ensure stores are legitimate and in compliance with our te
   - Services of any kind, including marketing, design, web development, consulting, and similar work
   - Job boards
   - Advertising in newsletters, on websites, or in social media posts
+  - API resellers. We can only support established resellers, who must provide their previous payment processor, chargeback rate (with screenshots of the rate and transaction volume), and reason for moving to Creem.
 </Accordion>
 
 If you are unsure whether your content is prohibited, contact Creem support with a description or example before you start selling.


### PR DESCRIPTION
Adds API resellers to the **Restricted products** (strict due diligence) list in the Account Reviews docs, matching the approach we already take in onboarding flags.

**Disclaimer:** due to the nature of the business we can only support *established* API resellers, and they must provide the docs we ask for in the API reseller flags:
- previous payment processor
- chargeback rate (with screenshots showing rate + transaction volume)
- reason for moving to Creem

Kept concise and in line with how the other restricted entries read.