### PR TITLE
ci: Node 22 across all workflows + npm upgrade for OIDC trusted publishing

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,13 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
+
+      # OIDC trusted publishing requires npm >= 11.5.1; Node 22 ships an older npm.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/sdk-cascade.yml
+++ b/.github/workflows/sdk-cascade.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - name: Get new SDK version

--- a/.github/workflows/sdk-regen-lockfile.yml
+++ b/.github/workflows/sdk-regen-lockfile.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - name: Refresh pnpm-lock.yaml


### PR DESCRIPTION
## Problem

The `Release` workflow fails at the publish step with a misleading error for every package:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@creem_io%2fsvelte - Not found
'@creem_io/svelte@0.2.1' is not in this registry.
```

(failing run: https://github.com/armitage-labs/creem/actions/runs/27757121622)

## Root cause

We publish via **npm OIDC trusted publishing** (`id-token: write` set, `NPM_TOKEN` intentionally commented out). But the runner ran **npm 10.8.2** (bundled with Node 20), which has **no OIDC trusted-publishing support** — that requires **npm >= 11.5.1**.

With no token and an OIDC-incapable npm, the publish goes out anonymous and the registry returns a misleading `E404 - PUT ... Not found` instead of 401/403.

## Changes

1. **release.yml**: Node 20 → 22, plus `npm install -g npm@latest` so `changeset publish` uses an OIDC-capable npm.
2. **All other workflows** (`ci.yml`, `changeset-check.yml`, `sdk-cascade.yml`, `sdk-regen-lockfile.yml`): Node 20 → 22 for consistency — so we don't test on 20 while releasing on 22.

## Before merge — verify on npmjs.org

Each package (`creem-cli`, `@creem_io/embed`, `@creem_io/react`, `@creem_io/svelte`, `@creem_io/vue`) must have a **Trusted Publisher** configured: org `armitage-labs`, repo `creem`, workflow `release.yml`, environment `release`. Note: `creem-cli` exists but has no published versions yet.