### PR TITLE
fix: remove the invalid link to the removed salesnip guide

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -156,10 +156,6 @@
               {
                 "group": "CMS",
                 "pages": ["integrations/strapi"]
-              },
-              {
-                "group": "AI Chatbot",
-                "pages": ["integrations/ai-negotiation-bot"]
               }
             ]
           },


### PR DESCRIPTION
A follow up on https://github.com/armitage-labs/creem/pull/97