### PR TITLE
fix: [ENG-757] make embed affiliate attribution survive internal navigation (SDK + docs)

### DIFF
--- a/packages/docs/features/affiliate-program.mdx
+++ b/packages/docs/features/affiliate-program.mdx
@@ -24,7 +24,7 @@ The Creem Affiliate Platform is a complete affiliate marketing solution that ena
     Join programs, get unique referral links, track earnings in real-time, and request payouts
   </Card>
   <Card title="Automated Tracking" icon="chart-line">
-    Cookie-based attribution automatically credits affiliates for referred sales
+    Attribution automatically credits affiliates for referred sales
   </Card>
   <Card title="Compliant Payouts" icon="building-columns">
     Built-in KYC verification and multiple payout methods (bank transfer, crypto)
@@ -345,6 +345,9 @@ If you're an affiliate for multiple merchants, you can switch between programs u
   </Accordion>
   <Accordion title="How is my referral tracked?">
     When someone clicks your affiliate link, a cookie is stored in their browser. This cookie attributes any purchases to you within the cookie duration period.
+  </Accordion>
+  <Accordion title="Does attribution work with embedded checkout?">
+    Yes. When a merchant embeds the Creem checkout in their own site, the affiliate cookie isn't available inside the cross-site iframe (no browser sends it there) — so Creem carries attribution as a signed URL token (`creem_ref`) that the embed forwards automatically. Merchants don't need to wire anything for the common case. See [Embedded checkout → Affiliate attribution](/features/checkout/embedded-checkout#affiliate-attribution).
   </Accordion>
   <Accordion title="Can I see which products are selling?">
     Yes, your dashboard shows conversion data. Merchants may also provide additional reporting on which products drive the most affiliate sales.

--- a/packages/docs/features/checkout/embedded-checkout.mdx
+++ b/packages/docs/features/checkout/embedded-checkout.mdx
@@ -301,6 +301,58 @@ Creem.openCheckout({
 
 By default the checkout follows the customer's **browser language**. Pass `locale` to force a specific one (e.g. to match your own site's language). Unsupported locales fall back to English. See the [supported languages](/features/checkout/checkout-api) for the full list.
 
+## Affiliate attribution
+
+If you run the Creem [Affiliate Program](/features/affiliate-program), embedded checkout still credits referred sales to the right affiliate — and the SDKs and script loader handle it for you. Here's what happens, and the one edge case worth knowing.
+
+**How it works**
+
+- An affiliate link (`creem.io/affiliate?code=…`) sends the visitor to your site and appends a `creem_ref` token to the landing URL.
+- On the **hosted** checkout, attribution rides a first-party cookie on Creem's domain — nothing to do.
+- Inside the **embed**, the checkout runs in a cross-site iframe, so the browser doesn't send that cookie there — in any browser. Attribution instead rides the token: the SDK/loader reads `creem_ref` from your page, **persists it in your site's own first-party storage**, and forwards it into the checkout iframe, so it works uniformly everywhere. No code needed for the common case.
+
+<Note>
+  `creem_ref` is an **opaque, signed token** — it identifies the click, not the affiliate. Don't try to parse an affiliate code out of it, and you don't need to read or forward it yourself: the SDKs and loader do it automatically. (It mirrors `client_reference_id` in Stripe-based tools like Rewardful and Tolt.)
+</Note>
+
+**Edge case: separate landing and checkout pages**
+
+The token arrives on whatever page the affiliate link points to. The SDK captures it automatically when it runs on that page. But if a visitor lands on `/?creem_ref=…`, then **navigates** to another page (say `/pricing`) before opening checkout, and your app drops the query string on that navigation, the token is no longer on the URL. If it wasn't captured before that navigation, attribution is lost — in every browser, since the embed relies on the token, not the cookie.
+
+To cover this, call `captureAffiliateRef()` once early in your app (e.g. a root layout) so the token is captured on the landing page and stored for later:
+
+```tsx
+// Root layout / top-level component — runs on every page
+'use client';
+import { useEffect } from 'react';
+import { captureAffiliateRef } from '@creem_io/react'; // also in /vue, /svelte, /embed
+
+export function AffiliateRefCapture() {
+  useEffect(() => { captureAffiliateRef(); }, []);
+  return null;
+}
+```
+
+<Tip>
+  The **script loader** (`creem.io/embed.js`) captures the token automatically on every page it loads on — so if you include the `<script>` site-wide (not just on the checkout page), there's nothing to add.
+</Tip>
+
+**Manage it yourself (optional)**
+
+We persist `creem_ref` in `localStorage` by default. Prefer your own storage — `sessionStorage`, your own cookie, or server-side? Read the value off the landing URL, store it however you like, and append it to the `checkoutUrl` you pass to the SDK. The SDK **won't overwrite a `creem_ref` you've already set on the URL**, so your value wins:
+
+```ts
+// On your affiliate landing page — capture into your own store
+const ref = new URLSearchParams(location.search).get('creem_ref');
+if (ref) sessionStorage.setItem('creem_ref', ref);
+
+// When you open checkout — put it back on the checkout URL yourself
+const stored = sessionStorage.getItem('creem_ref');
+const url = new URL(checkoutUrl);
+if (stored) url.searchParams.set('creem_ref', stored);
+openCheckout({ checkoutUrl: url.toString() });
+```
+
 ## API reference
 
 The framework SDKs (`@creem_io/react`, `/vue`, `/svelte`) accept these same options — as props/args, with `onComplete`/`onClose` surfaced as the `complete`/`close` events where idiomatic.
@@ -343,6 +395,12 @@ Mounts checkout inline. Same options as `openCheckout`, plus:
 ### `Creem.close()`
 
 Programmatically closes the overlay.
+
+### `captureAffiliateRef()`
+
+An SDK export (`@creem_io/embed`, `/react`, `/vue`, `/svelte`) — not a method on the loader, which captures automatically. Reads the affiliate `creem_ref` token from the current URL, persists it to your site's first-party storage, and returns the active token (from the URL, or a previously stored one), or `null`. `openCheckout`/`mount` already do this; call it directly only to capture on a **landing page** the visitor reaches before opening checkout (see [Affiliate attribution](#affiliate-attribution)). Safe anywhere — a no-op during SSR and when no token is present.
+
+**Returns** `string | null`.
 
 ## Events
 

--- a/packages/docs/skills/creem-api/WORKFLOWS.md
+++ b/packages/docs/skills/creem-api/WORKFLOWS.md
@@ -913,6 +913,11 @@ export function UpgradePrompt({
 
 Track conversions from marketing campaigns or affiliates.
 
+**Two different things — pick the right one:**
+
+- **Creem Affiliate Program (managed).** If you use Creem's built-in [Affiliate Program](https://docs.creem.io/features/affiliate-program), tracking and attribution are automatic. An affiliate link (`creem.io/affiliate?code=…`) redirects the visitor to your site and appends an opaque, signed **`creem_ref`** token. Creem attributes the sale via its own cookie (hosted checkout) or by forwarding `creem_ref` into the iframe (embedded checkout). You do **not** parse `creem_ref` or pass it to the checkout API — it identifies the click, not the affiliate, and seeing `?creem_ref=` on your site after an affiliate link is expected. See [Embedded checkout → Affiliate attribution](https://docs.creem.io/features/checkout/embedded-checkout#affiliate-attribution).
+- **Custom tracking (the pattern below).** Use this only to roll your own campaign/affiliate tracking with your own `?ref=` / `?aff=` / `utm_*` params — stored in your own cookie and passed as checkout `metadata`. It's independent of the managed Affiliate Program above.
+
 ### Step 1: Pass Tracking Data
 
 ```typescript

--- a/packages/embed/index.ts
+++ b/packages/embed/index.ts
@@ -51,17 +51,69 @@ export interface CreemCheckoutInlineHandle {
   destroy: () => void;
 }
 
-// Read the affiliate ref token (`creem_ref`) from the MERCHANT page URL. The
-// /affiliate redirect lands the visitor on the merchant's own site with
-// `?creem_ref=<signed token>` — first-party to the visitor, so it's readable
-// here even in browsers that drop our third-party cookie (Safari ITP,
-// Firefox TCP). Returns null when absent or the URL can't be parsed.
-function readAffiliateRef(): string | null {
+// Storage key for the affiliate ref token, persisted first-party on the
+// merchant's own origin (not our partitioned third-party context) so it survives
+// internal navigation away from the /affiliate landing URL (e.g. `/` ->
+// `/pricing`) before the embed opens.
+const REF_STORAGE_KEY = "creem_ref";
+
+function readRefFromUrl(): string | null {
   try {
     return new URLSearchParams(window.location.search).get("creem_ref");
   } catch {
     return null;
   }
+}
+
+function storeRef(token: string): void {
+  try {
+    window.localStorage.setItem(REF_STORAGE_KEY, token);
+  } catch {
+    /* localStorage unavailable (private mode / disabled) — best-effort. */
+  }
+}
+
+function readStoredRef(): string | null {
+  try {
+    return window.localStorage.getItem(REF_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+// Read the affiliate ref token (`creem_ref`). The /affiliate redirect lands the
+// visitor on the merchant's own site with `?creem_ref=<signed token>` —
+// first-party to the visitor, so it's readable here even though the cross-site
+// checkout iframe receives no cookie in any browser. The URL wins (a fresh
+// affiliate link overwrites the stored value), and we persist it
+// to first-party storage so it survives internal navigation that drops the param
+// before the embed opens; we fall back to that stored value when the URL has none
+// (ENG-757). A stale/expired token is rejected server-side (HMAC + TTL) and the
+// cookie wins anyway, so a leftover stored value is inert.
+function readAffiliateRef(): string | null {
+  if (typeof window === "undefined") return null;
+  const fromUrl = readRefFromUrl();
+  if (fromUrl) {
+    storeRef(fromUrl);
+    return fromUrl;
+  }
+  return readStoredRef();
+}
+
+/**
+ * Capture the affiliate ref token (`creem_ref`) from the current URL into
+ * first-party storage. `openCheckout`/`mount` already do this, but only when the
+ * visitor opens the checkout — if your affiliate landing page and your checkout
+ * page differ (the visitor lands on `/?creem_ref=…`, then navigates to
+ * `/pricing` before buying), the param is gone from the URL by the time checkout
+ * opens, and since the embed relies on the token (the cross-site iframe gets no
+ * cookie in any browser), attribution is then lost. Call this once early in your app — e.g. a root
+ * layout effect — so the token is captured on the landing page and stays
+ * available later. Safe anywhere: a no-op on the server and when no token is
+ * present. Returns the active token (URL or previously stored), or null.
+ */
+export function captureAffiliateRef(): string | null {
+  return readAffiliateRef();
 }
 
 // Append the merchant-controlled presentation params (`theme`, `locale`) and the

--- a/packages/embed/index.ts
+++ b/packages/embed/index.ts
@@ -84,20 +84,37 @@ function readStoredRef(): string | null {
 // Read the affiliate ref token (`creem_ref`). The /affiliate redirect lands the
 // visitor on the merchant's own site with `?creem_ref=<signed token>` —
 // first-party to the visitor, so it's readable here even though the cross-site
-// checkout iframe receives no cookie in any browser. The URL wins (a fresh
-// affiliate link overwrites the stored value), and we persist it
-// to first-party storage so it survives internal navigation that drops the param
-// before the embed opens; we fall back to that stored value when the URL has none
-// (ENG-757). A stale/expired token is rejected server-side (HMAC + TTL) and the
-// cookie wins anyway, so a leftover stored value is inert.
+// checkout iframe receives no cookie in any browser. We persist it to first-party
+// storage so it survives internal navigation that drops the param before the embed
+// opens, and fall back to that stored value when the URL has none (ENG-757). See
+// readAffiliateRef below for the newer-token-wins ordering.
+// Mint time (`iat`, ms epoch) of a signed token, read from its base64url JSON
+// payload (no signature check — that's the server's job). Returns 0 when it can't
+// be parsed, so a malformed token always loses the freshness comparison.
+function tokenIat(token: string): number {
+  try {
+    let b64 = token.split(".")[0].replace(/-/g, "+").replace(/_/g, "/");
+    while (b64.length % 4) b64 += "=";
+    const payload = JSON.parse(atob(b64)) as { iat?: number };
+    return typeof payload.iat === "number" ? payload.iat : 0;
+  } catch {
+    return 0;
+  }
+}
+
 function readAffiliateRef(): string | null {
   if (typeof window === "undefined") return null;
   const fromUrl = readRefFromUrl();
-  if (fromUrl) {
+  const stored = readStoredRef();
+  // Keep the NEWER of the two by mint time (`iat`, server-stamped → immune to
+  // client clock skew): a fresh affiliate click wins and is persisted; a stale
+  // URL token (old bookmark / email link) can't clobber a newer stored ref. The
+  // server still enforces the signature + `exp`, so an expired token is rejected.
+  if (fromUrl && (!stored || tokenIat(fromUrl) >= tokenIat(stored))) {
     storeRef(fromUrl);
     return fromUrl;
   }
-  return readStoredRef();
+  return stored || fromUrl || null;
 }
 
 /**

--- a/packages/react/index.tsx
+++ b/packages/react/index.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import {
   openCheckout,
   mount,
+  captureAffiliateRef,
   CreemEmbedCheckout,
   type CreemCheckoutCompleted,
   type CreemCheckoutOptions,
@@ -15,6 +16,7 @@ import {
 
 export {
   openCheckout,
+  captureAffiliateRef,
   CreemEmbedCheckout,
   type CreemCheckoutCompleted,
   type CreemCheckoutOptions,

--- a/packages/svelte/index.ts
+++ b/packages/svelte/index.ts
@@ -1,6 +1,7 @@
 import {
   openCheckout,
   mount,
+  captureAffiliateRef,
   CreemEmbedCheckout,
   type CreemCheckoutCompleted,
   type CreemCheckoutOptions,
@@ -14,6 +15,7 @@ import {
 export {
   openCheckout,
   mount,
+  captureAffiliateRef,
   CreemEmbedCheckout,
   type CreemCheckoutCompleted,
   type CreemCheckoutOptions,

--- a/packages/vue/index.ts
+++ b/packages/vue/index.ts
@@ -2,6 +2,7 @@ import { defineComponent, h, onBeforeUnmount, onMounted, ref, type PropType } fr
 import {
   openCheckout,
   mount,
+  captureAffiliateRef,
   CreemEmbedCheckout,
   type CreemCheckoutCompleted,
   type CreemCheckoutOptions,
@@ -13,6 +14,7 @@ import {
 
 export {
   openCheckout,
+  captureAffiliateRef,
   CreemEmbedCheckout,
   type CreemCheckoutCompleted,
   type CreemCheckoutOptions,


### PR DESCRIPTION
ENG-757 follow-up — SDK + docs counterpart of monorepo PR armitage-labs/pugpay-monorepo#2282.

## Why
Embedded checkout attribution rides the `creem_ref` URL token, which was read only from `window.location.search`. If a visitor lands on `/?creem_ref=…` then navigates internally (e.g. `/pricing`) before the embed opens, the param is dropped and attribution was lost — the cross-site iframe gets no cookie in any browser.

## SDK (`@creem_io/embed` + react/vue/svelte)
- Persist `creem_ref` in the merchant's first-party `localStorage` (URL-first, storage-fallback) so it survives internal navigation; the token still resolves server-side to the same cookieId.
- New exported `captureAffiliateRef()` for SPA merchants to call early (e.g. a root layout) so the token is captured on the landing page. Re-exported from react/vue/svelte.

## Docs
- New "Affiliate attribution" section in embedded-checkout: how it works, `creem_ref` is opaque (don't parse, it's automatic), the navigation edge case + `captureAffiliateRef`, and a DIY/sessionStorage override (SDK won't clobber a `creem_ref` you set yourself).
- WORKFLOWS#6 callout distinguishing the managed `creem_ref` program from the DIY `?ref=`/`?aff=`/`utm_*` + `metadata` pattern (the source of a merchant's confusion).
- Affiliate-program FAQ entry for embedded checkout.

## Notes
- `dist/` is gitignored (built in CI on publish). After merge, republish `@creem_io/embed` + react/vue/svelte.
- Verified E2E on staging (incognito, no cookie): the token survives navigation and attribution is created off the token alone.