### PR TITLE
chore: [ENG-757] add changeset for embed creem_ref persistence + captureAffiliateRef

### DIFF
--- a/.changeset/eng-757-creem-ref-persistence.md
+++ b/.changeset/eng-757-creem-ref-persistence.md
@@ -1,0 +1,8 @@
+---
+"@creem_io/embed": patch
+"@creem_io/react": patch
+"@creem_io/vue": patch
+"@creem_io/svelte": patch
+---
+
+Persist the affiliate `creem_ref` token in first-party localStorage so embedded-checkout attribution survives internal navigation (e.g. `/` → `/pricing`) before checkout opens. Adds a `captureAffiliateRef()` helper to capture it on the landing page (re-exported from react/vue/svelte). The newer token by `iat` always wins, so a stale URL token can't clobber a fresher stored ref.


### PR DESCRIPTION
Adds the changeset that was missing from #115 (which merged without one, so no Version Packages PR / publish was triggered).

Bumps **patch** for the packages touched in #115:
- `@creem_io/embed` — localStorage persistence + `captureAffiliateRef()` + newer-token-by-`iat` ordering
- `@creem_io/react`, `@creem_io/vue`, `@creem_io/svelte` — re-export `captureAffiliateRef`

Once this merges, the changesets bot opens the **Version Packages** PR; merging that publishes the four packages.