### PR TITLE
fix: [ENG-803] embed onComplete+close() cancels the post-payment redirect + docs

### DIFF
--- a/.changeset/embed-close-cancels-redirect.md
+++ b/.changeset/embed-close-cancels-redirect.md
@@ -1,0 +1,9 @@
+---
+"@creem_io/embed": patch
+---
+
+Embedded checkout: calling `close()` inside `onComplete` now cancels the post-payment redirect.
+
+The completion handler previously scheduled the ~3s top-window redirect *after* invoking `onComplete`, so a merchant calling `checkout.close()` inside `onComplete` hit the timer cleanup before the timer existed (a no-op) and the redirect fired anyway — navigating a customer who had explicitly closed the modal. The redirect timer is now scheduled *before* `onComplete`, so `close()`'s cleanup cancels a live timer. Default behavior (no `close()` → redirect to the product Return URL after ~3s) is unchanged.
+
+Re-exported by `@creem_io/react`, `@creem_io/vue`, and `@creem_io/svelte`, which pick up the fix on their next release.

--- a/packages/docs/features/checkout/embedded-checkout.mdx
+++ b/packages/docs/features/checkout/embedded-checkout.mdx
@@ -172,7 +172,30 @@ First-class packages for **React (≥18), Vue (≥3), and Svelte (≥4)** with t
   </Tab>
 </Tabs>
 
-Every SDK takes the same options as the loader below (`theme`, `locale`) and emits the same `ready` + `completed` events. On completion, if the product has a **Return URL**, the page navigates there automatically (after a short confirmation screen) — handle `onComplete` for custom behavior.
+Every SDK takes the same options as the loader below (`theme`, `locale`) and emits the same `ready` + `completed` events.
+
+On completion the embed behaves exactly like the hosted checkout's return page:
+
+- **Product has a Return URL** → a short confirmation screen, then the top window navigates there (~3s).
+- **No Return URL** → a "View order" button; the embed stays open until the customer closes it.
+
+To keep customers fully inline, call `close()` inside `onComplete` — it dismisses the embed **and cancels the pending redirect**. Cancelling the redirect from `close()` requires `@creem_io/embed` ≥ 0.3.3 (or `@creem_io/react` / `/vue` / `/svelte` ≥ 0.2.3); on older versions `close()` dismisses the modal but the redirect still fires.
+
+<Frame caption="Product has a Return URL — a confirmation screen with a 'Returning to Merchant' countdown, then the redirect.">
+  <img
+    style={{ borderRadius: '0.5rem' }}
+    src="https://nucn5fajkcc6sgrd.public.blob.vercel-storage.com/embed-completion-return-url.png"
+    alt="Embedded checkout success screen: 'Thank you for your payment' with a 'Returning to Merchant in 2s' countdown button"
+  />
+</Frame>
+
+<Frame caption="No Return URL — a 'View order' button; the embed stays open until the customer closes it (or you call close() in onComplete).">
+  <img
+    style={{ borderRadius: '0.5rem' }}
+    src="https://nucn5fajkcc6sgrd.public.blob.vercel-storage.com/embed-completion-view-order.png"
+    alt="Embedded checkout success screen: 'Thank you for your payment' with a 'View Order' button"
+  />
+</Frame>
 
 #### Open on click (dynamic sessions)
 
@@ -231,7 +254,7 @@ For non-framework apps, or when you want a global `Creem` object. No build step 
   </Step>
 </Steps>
 
-The overlay shows the confirmation screen on success; call `Creem.close()` from `onComplete` if you want it to dismiss automatically.
+The overlay shows the confirmation screen on success; call `Creem.close()` from `onComplete` to dismiss it — this also **cancels the pending redirect** to the Return URL, keeping the customer on your page.
 
 #### Inline
 

--- a/packages/embed/index.ts
+++ b/packages/embed/index.ts
@@ -224,18 +224,24 @@ function subscribe(checkoutUrl: string, options: CreemCheckoutOptions): () => vo
         redirect: data.redirect,
         redirectUrl: data.redirectUrl,
       };
-      options.onComplete?.(detail);
       // Single-event model: no separate "redirect" event. The checkout shows a
       // ~3s "Returning to merchant" confirmation in-iframe; we mirror that delay
       // here, then navigate the top window (a cross-origin iframe can't move it
-      // itself). Cancelled on close/unsubscribe below, so a checkout the
-      // customer closed never navigates the merchant.
+      // itself).
+      //
+      // Order matters: the timer is scheduled BEFORE onComplete. A merchant that
+      // calls handle.close() inside onComplete triggers unsubscribe() ->
+      // clearTimeout below, which must find a LIVE timer to cancel. If we
+      // scheduled after onComplete, close()'s clearTimeout would run against a
+      // still-null timer and the redirect would fire anyway — navigating a
+      // customer who explicitly closed the modal.
       if (detail.redirectUrl) {
         const url = detail.redirectUrl;
         redirectTimer = setTimeout(() => {
           window.location.href = url;
         }, 3000);
       }
+      options.onComplete?.(detail);
     }
   }
   window.addEventListener("message", handler);


### PR DESCRIPTION
fix: [ENG-803] embed onComplete+close() cancels the post-payment redirect + docs