### PR TITLE
docs: update remaining test card numbers to match test mode

### DIFF
--- a/packages/better-auth/test/nextjs-app/QUICK_START.md
+++ b/packages/better-auth/test/nextjs-app/QUICK_START.md
@@ -107,7 +107,7 @@ The app will start at http://localhost:3000
 2. **View Pricing**: Navigate to /pricing
 3. **Subscribe**: Click "Subscribe" (you'll be redirected to Creem)
 4. **Use Test Card**: 
-   - Card: `4242 4242 4242 4242`
+   - Card: `4111 1111 1111 1111`
    - Expiry: Any future date
    - CVC: `123`
 5. **Complete Payment**: You'll be redirected back

--- a/packages/better-auth/test/nextjs-app/TESTING_GUIDE.md
+++ b/packages/better-auth/test/nextjs-app/TESTING_GUIDE.md
@@ -51,7 +51,7 @@ This guide walks you through testing all features of the Creem Better-Auth plugi
 #### Test Completing Checkout
 
 1. On Creem checkout page, use test card:
-   - Card: `4242 4242 4242 4242`
+   - Card: `4111 1111 1111 1111`
    - Expiry: Any future date
    - CVC: Any 3 digits
 2. Complete payment

--- a/packages/convex/example-react/src/App.tsx
+++ b/packages/convex/example-react/src/App.tsx
@@ -157,7 +157,7 @@ export default function App() {
             Test card:
           </span>
           <code className="ml-1 rounded bg-surface-200-800 px-1.5 py-0.5 font-mono text-xs">
-            4242 4242 4242 4242
+            4111 1111 1111 1111
           </code>
           <span className="ml-2 text-foreground-placeholder">
             — any future expiry, any CVC, any cardholder name

--- a/packages/docs/api-reference/introduction.mdx
+++ b/packages/docs/api-reference/introduction.mdx
@@ -58,7 +58,6 @@ Use these card numbers to simulate different payment scenarios. All cards work w
 | `4507 9900 0000 0028` | Card declined      |
 | `4507 9900 0000 0010` | Insufficient funds |
 | `4507 9900 0000 0044` | Incorrect CVC      |
-| `4000 0000 0000 3220` | 3DS Challenge      |
 
 ### Using Test Mode in Code
 

--- a/packages/docs/getting-started/quickstart.mdx
+++ b/packages/docs/getting-started/quickstart.mdx
@@ -498,7 +498,7 @@ npm run dev
 6. Visit `http://localhost:3000` and click "Buy Now"
 
 <Note>
-  In test mode, use test card number `4242 4242 4242 4242` with any future expiry date and any CVC.
+  In test mode, use test card number `4111 1111 1111 1111` with any future expiry date and any CVC.
 </Note>
 
 ---

--- a/packages/docs/getting-started/test-mode.mdx
+++ b/packages/docs/getting-started/test-mode.mdx
@@ -167,7 +167,6 @@ Use these test card numbers to simulate different payment scenarios:
 | `4507 9900 0000 0028` | Card declined      |
 | `4507 9900 0000 0010` | Insufficient funds |
 | `4507 9900 0000 0044` | Incorrect CVC      |
-| `4000 0000 0000 3220` | 3DS Challenge      |
 
 ## Webhook Testing
 

--- a/packages/docs/getting-started/test-mode.mdx
+++ b/packages/docs/getting-started/test-mode.mdx
@@ -163,11 +163,11 @@ Use these test card numbers to simulate different payment scenarios:
 
 | Card Number           | Behavior           |
 | --------------------- | ------------------ |
-| `4242 4242 4242 4242` | Successful payment |
-| `4000 0000 0000 0002` | Card declined      |
-| `4000 0000 0000 9995` | Insufficient funds |
-| `4000 0000 0000 0127` | Incorrect CVC      |
-| `4000 0000 0000 0069` | Expired card       |
+| `4111 1111 1111 1111` | Successful payment |
+| `4507 9900 0000 0028` | Card declined      |
+| `4507 9900 0000 0010` | Insufficient funds |
+| `4507 9900 0000 0044` | Incorrect CVC      |
+| `4000 0000 0000 3220` | 3DS Challenge      |
 
 ## Webhook Testing
 

--- a/packages/docs/skills/creem-api/Skill.md
+++ b/packages/docs/skills/creem-api/Skill.md
@@ -343,9 +343,9 @@ Always develop in test mode first:
 1. Use `https://test-api.creem.io` as base URL
 2. Use test API key from dashboard
 3. Test cards:
-   - `4242 4242 4242 4242` - Success
-   - `4000 0000 0000 0002` - Declined
-   - `4000 0000 0000 9995` - Insufficient funds
+   - `4111 1111 1111 1111` - Success
+   - `4507 9900 0000 0028` - Declined
+   - `4507 9900 0000 0010` - Insufficient funds
 
 ## Common Integration Checklist
 


### PR DESCRIPTION
Follow-up to #122, which updated the test card numbers in `api-reference/introduction.mdx`. A few other places still referenced the previous card numbers. This PR brings them in line so the test cards are consistent across the docs and examples.

### Updated references
- `packages/docs/getting-started/test-mode.mdx` — full test card table
- `packages/docs/getting-started/quickstart.mdx` — inline test card note
- `packages/docs/skills/creem-api/Skill.md` — test cards list
- `packages/convex/example-react/src/App.tsx` — example UI hint
- `packages/better-auth/test/nextjs-app/TESTING_GUIDE.md`
- `packages/better-auth/test/nextjs-app/QUICK_START.md`

All values now match the table in #122 (success / declined / insufficient funds / incorrect CVC / 3DS challenge). Docs-and-examples only; no code behavior changes.