### PR TITLE
fix(openapi): mark customer country as nullable

### DIFF
--- a/packages/creem-sdk/openapi.json
+++ b/packages/creem-sdk/openapi.json
@@ -3075,7 +3075,8 @@
             "type": "string",
             "description": "The ISO alpha-2 country code for the customer.",
             "example": "US",
-            "pattern": "^[A-Z]{2}$"
+            "pattern": "^[A-Z]{2}$",
+            "nullable": true
           },
           "created_at": {
             "format": "date-time",

--- a/packages/docs/api-reference/openapi.json
+++ b/packages/docs/api-reference/openapi.json
@@ -3075,7 +3075,8 @@
             "type": "string",
             "description": "The ISO alpha-2 country code for the customer.",
             "example": "US",
-            "pattern": "^[A-Z]{2}$"
+            "pattern": "^[A-Z]{2}$",
+            "nullable": true
           },
           "created_at": {
             "format": "date-time",


### PR DESCRIPTION
## Mark customer `country` as nullable in the OpenAPI schema

### Summary
The `CustomerEntity.country` field is declared as a non-nullable required string, but the API can legitimately return `country: null` (the field is optional at the data layer and is not always collected at customer creation time). As a result, the generated SDK validates these valid responses with `z.string()` and throws a `ResponseValidationError`.

### Change
Add `"nullable": true` to the `country` property in the customer schema. The field remains required (it is always present in the response payload); only its value may be `null`.

### Notes
- This updates the OpenAPI source (`packages/creem-sdk/openapi.json`). The TypeScript SDK and docs copy will be regenerated from this spec via Speakeasy.
