### PR TITLE
docs: add currency support information to product creation guide and FAQ

### DIFF
--- a/packages/docs/guides/create-your-first-product.mdx
+++ b/packages/docs/guides/create-your-first-product.mdx
@@ -33,6 +33,8 @@ Create a new product by adding:
 - **Description**: Details about what customers will receive
 - **Pricing**: Choose Single Payment, Subscription, or Free. Free products are
   one-time products with a `0` price.
+- **Currency**: The currency customers are charged in. Creem currently supports
+  **USD** and **EUR**.
 - **Image** (optional): Add a product image that will be shown to customers
 
 <AccordionGroup>

--- a/packages/docs/guides/faq.mdx
+++ b/packages/docs/guides/faq.mdx
@@ -56,6 +56,9 @@ description: 'Answers to the most common questions about using Creem.'
   <Accordion title="Does Creem support weekly billing?">
     Currently, Creem supports **monthly**, **3-month**, **6-month**, and **yearly** billing cycles for subscriptions. Weekly billing is not available at this time.
   </Accordion>
+  <Accordion title="Which currencies does Creem support?">
+    You can price products in **USD** and **EUR** today. Set the currency when creating a product (see [Create Your First Product](/guides/create-your-first-product)). Regardless of the currency you charge in, Creem handles tax collection and remittance as your [Merchant of Record](/merchant-of-record/what-is). Payout currency is handled separately — see [Payouts](/merchant-of-record/finance/payouts).
+  </Accordion>
 </AccordionGroup>
 
 ## Payouts & Finance


### PR DESCRIPTION
Addresses the following user question from Discord: https://discord.com/channels/1262843562140241952/1262850247239929998/1521492031581720688