### PR TITLE
docs: add click-to-copy buttons for test card numbers

### DIFF
--- a/packages/docs/api-reference/introduction.mdx
+++ b/packages/docs/api-reference/introduction.mdx
@@ -3,6 +3,8 @@ title: "Introduction"
 description: "Everything you need to start integrating with the Creem API: endpoints, authentication, test mode, webhooks, and SDKs."
 ---
 
+import { Copy } from "/snippets/copy.jsx";
+
 The Creem API is built on REST principles and uses HTTPS for all requests. It returns JSON-encoded responses and uses standard HTTP status codes.
 
 ## Base URL
@@ -50,14 +52,14 @@ To activate test mode, toggle **Test Mode** in the bottom of the left sidebar of
 
 ### Test Cards
 
-Use these card numbers to simulate different payment scenarios. All cards work with any future expiration date, any CVV, and any billing information.
+Use these card numbers to simulate different payment scenarios. All cards work with any future expiration date, any CVV, and any billing information. Click a card number to copy it.
 
-| Card Number           | Behavior           |
-| --------------------- | ------------------ |
-| `4111 1111 1111 1111` | Successful payment |
-| `4507 9900 0000 0028` | Card declined      |
-| `4507 9900 0000 0010` | Insufficient funds |
-| `4507 9900 0000 0044` | Incorrect CVC      |
+| Card Number                        | Behavior           |
+| ---------------------------------- | ------------------ |
+| <Copy>`4111 1111 1111 1111`</Copy> | Successful payment |
+| <Copy>`4507 9900 0000 0028`</Copy> | Card declined      |
+| <Copy>`4507 9900 0000 0010`</Copy> | Insufficient funds |
+| <Copy>`4507 9900 0000 0044`</Copy> | Incorrect CVC      |
 
 ### Using Test Mode in Code
 

--- a/packages/docs/getting-started/quickstart.mdx
+++ b/packages/docs/getting-started/quickstart.mdx
@@ -3,6 +3,8 @@ title: "Quickstart"
 description: "Start accepting payments in minutes with Creem."
 ---
 
+import { Copy } from "/snippets/copy.jsx";
+
 Choose the path that works best for you:
 
 <CardGroup cols={2}>
@@ -498,7 +500,8 @@ npm run dev
 6. Visit `http://localhost:3000` and click "Buy Now"
 
 <Note>
-  In test mode, use test card number `4111 1111 1111 1111` with any future expiry date and any CVC.
+  In test mode, use test card number <Copy>`4111 1111 1111 1111`</Copy> with any future expiry date
+  and any CVC.
 </Note>
 
 ---

--- a/packages/docs/getting-started/test-mode.mdx
+++ b/packages/docs/getting-started/test-mode.mdx
@@ -3,6 +3,8 @@ title: "Test Mode"
 description: "Develop and test your integration safely without processing real payments or affecting production data"
 ---
 
+import { Copy } from "/snippets/copy.jsx";
+
 Test Mode allows you to build and test your Creem integration in a completely isolated environment. All API calls, payments, webhooks, and data are kept separate from your production environment, ensuring you can develop with confidence.
 
 <Tip>
@@ -161,12 +163,12 @@ Use these test card numbers to simulate different payment scenarios:
   All test card numbers work with any future expiration date, any CVV, and any billing information.
 </Note>
 
-| Card Number           | Behavior           |
-| --------------------- | ------------------ |
-| `4111 1111 1111 1111` | Successful payment |
-| `4507 9900 0000 0028` | Card declined      |
-| `4507 9900 0000 0010` | Insufficient funds |
-| `4507 9900 0000 0044` | Incorrect CVC      |
+| Card Number                        | Behavior           |
+| ---------------------------------- | ------------------ |
+| <Copy>`4111 1111 1111 1111`</Copy> | Successful payment |
+| <Copy>`4507 9900 0000 0028`</Copy> | Card declined      |
+| <Copy>`4507 9900 0000 0010`</Copy> | Insufficient funds |
+| <Copy>`4507 9900 0000 0044`</Copy> | Incorrect CVC      |
 
 ## Webhook Testing
 

--- a/packages/docs/snippets/copy.jsx
+++ b/packages/docs/snippets/copy.jsx
@@ -1,0 +1,79 @@
+// Generic click-to-copy wrapper: <Copy>`4111 1111 1111 1111`</Copy>
+// Copies the rendered text of its children (or the `text` prop when given).
+// Icons match Mintlify's code-block copy button (lucide copy/check), always
+// visible but dimmed so the affordance also works on touch devices.
+//
+// Mintlify compiles each imported snippet export independently, so this
+// component must stay fully self-contained (no references to other exports
+// or module-level constants).
+export const Copy = ({ children, text }) => {
+  const [copied, setCopied] = useState(false);
+  const [hovered, setHovered] = useState(false);
+
+  const handleCopy = (event) => {
+    const content = event.currentTarget.querySelector("[data-copy-content]");
+    const value = (text ?? (content ? content.textContent : "")).trim();
+    if (!value) return;
+    navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      title="Copy to clipboard"
+      aria-label={text ? `Copy ${text}` : "Copy to clipboard"}
+      style={{
+        cursor: "pointer",
+        whiteSpace: "nowrap",
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "0.4em",
+        verticalAlign: "middle",
+      }}
+    >
+      <span data-copy-content>{children}</span>
+      <span
+        aria-hidden="true"
+        style={{
+          display: "inline-flex",
+          opacity: copied ? 1 : hovered ? 0.9 : 0.45,
+          transition: "opacity 120ms ease-in-out",
+        }}
+      >
+        {copied ? (
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M20 6 9 17l-5-5" />
+          </svg>
+        ) : (
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+            <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+          </svg>
+        )}
+      </span>
+    </button>
+  );
+};


### PR DESCRIPTION
This adds a copy button to card numbers for user convenience. I've created the copy functionality as a reusable inline component so we can also reuse it in other places. 

<img width="934" height="324" alt="image" src="https://github.com/user-attachments/assets/2d27ae51-9c6c-46e0-8137-01f10cee1903" />
