### PR TITLE
docs: flag Wise bank transfer partner restrictions with asterisks

### DIFF
--- a/packages/docs/merchant-of-record/supported-countries.mdx
+++ b/packages/docs/merchant-of-record/supported-countries.mdx
@@ -28,7 +28,7 @@ Creem supports purchases from all countries except those in the [unsupported lis
 | Argentina                                                      | <Icon icon="check" color="#22c55e" size={16} /> |
 | Australia                                                      | <Icon icon="check" color="#22c55e" size={16} /> |
 | Austria                                                        | <Icon icon="check" color="#22c55e" size={16} /> |
-| Bangladesh                                                     | <Icon icon="check" color="#22c55e" size={16} /> |
+| [Bangladesh\*\*](#bank-transfer-partner-restrictions)          | <Icon icon="check" color="#22c55e" size={16} /> |
 | Belgium                                                        | <Icon icon="check" color="#22c55e" size={16} /> |
 | Bosnia and Herzegovina                                         | <Icon icon="check" color="#22c55e" size={16} /> |
 | Brazil                                                         | <Icon icon="check" color="#22c55e" size={16} /> |
@@ -37,7 +37,7 @@ Creem supports purchases from all countries except those in the [unsupported lis
 | Cayman Islands                                                 | <Icon icon="check" color="#22c55e" size={16} /> |
 | Chile                                                          | <Icon icon="check" color="#22c55e" size={16} /> |
 | [China\*](/merchant-of-record/finance/payouts#transfer-limits) | <Icon icon="check" color="#22c55e" size={16} /> |
-| Colombia                                                       | <Icon icon="check" color="#22c55e" size={16} /> |
+| [Colombia\*\*](#bank-transfer-partner-restrictions)            | <Icon icon="check" color="#22c55e" size={16} /> |
 | Costa Rica                                                     | <Icon icon="check" color="#22c55e" size={16} /> |
 | Croatia                                                        | <Icon icon="check" color="#22c55e" size={16} /> |
 | Cyprus                                                         | <Icon icon="check" color="#22c55e" size={16} /> |
@@ -74,13 +74,13 @@ Creem supports purchases from all countries except those in the [unsupported lis
 | Monaco                                                         | <Icon icon="check" color="#22c55e" size={16} /> |
 | Montenegro                                                     | <Icon icon="check" color="#22c55e" size={16} /> |
 | Morocco                                                        | <Icon icon="check" color="#22c55e" size={16} /> |
-| Nepal                                                          | <Icon icon="check" color="#22c55e" size={16} /> |
+| [Nepal\*\*](#bank-transfer-partner-restrictions)               | <Icon icon="check" color="#22c55e" size={16} /> |
 | Netherlands                                                    | <Icon icon="check" color="#22c55e" size={16} /> |
 | New Zealand                                                    | <Icon icon="check" color="#22c55e" size={16} /> |
 | Nigeria                                                        | <Icon icon="check" color="#22c55e" size={16} /> |
 | North Macedonia                                                | <Icon icon="check" color="#22c55e" size={16} /> |
 | Norway                                                         | <Icon icon="check" color="#22c55e" size={16} /> |
-| Pakistan                                                       | <Icon icon="check" color="#22c55e" size={16} /> |
+| [Pakistan\*\*](#bank-transfer-partner-restrictions)            | <Icon icon="check" color="#22c55e" size={16} /> |
 | Peru                                                           | <Icon icon="check" color="#22c55e" size={16} /> |
 | Philippines                                                    | <Icon icon="check" color="#22c55e" size={16} /> |
 | Poland                                                         | <Icon icon="check" color="#22c55e" size={16} /> |
@@ -98,10 +98,10 @@ Creem supports purchases from all countries except those in the [unsupported lis
 | Sweden                                                         | <Icon icon="check" color="#22c55e" size={16} /> |
 | Switzerland                                                    | <Icon icon="check" color="#22c55e" size={16} /> |
 | Taiwan                                                         | <Icon icon="check" color="#22c55e" size={16} /> |
-| Tanzania                                                       | <Icon icon="check" color="#22c55e" size={16} /> |
+| [Tanzania\*\*](#bank-transfer-partner-restrictions)            | <Icon icon="check" color="#22c55e" size={16} /> |
 | Thailand                                                       | <Icon icon="check" color="#22c55e" size={16} /> |
 | Turkey                                                         | <Icon icon="check" color="#22c55e" size={16} /> |
-| Ukraine                                                        | <Icon icon="check" color="#22c55e" size={16} /> |
+| [Ukraine\*\*](#bank-transfer-partner-restrictions)             | <Icon icon="check" color="#22c55e" size={16} /> |
 | United Arab Emirates                                           | <Icon icon="check" color="#22c55e" size={16} /> |
 | United Kingdom                                                 | <Icon icon="check" color="#22c55e" size={16} /> |
 | United States of America                                       | <Icon icon="check" color="#22c55e" size={16} /> |
@@ -111,9 +111,22 @@ Creem supports purchases from all countries except those in the [unsupported lis
 
 ### Bank Transfer Partner Restrictions
 
-Some local business bank payouts are subject to additional restrictions from our bank transfer partners. For the most up-to-date country-specific limitations, see the partner's live availability page:
+Some local bank payouts are subject to additional restrictions from our bank transfer partners. Countries marked with a double asterisk (\*\*) in the table above have restrictions that may affect business payouts:
 
-[View country availability restrictions](https://wise.com/help/articles/2571942/what-countriesregions-can-i-send-to)
+| Country        | Restriction                                                                                                                             |
+| :------------- | :------------------------------------------------------------------------------------------------------------------------------------- |
+| **Bangladesh** | Business transfers are not supported. Payouts can only be sent to individual bank accounts.                                            |
+| **Colombia**   | Payouts can only be sent to individual (personal) bank accounts. Certain business categories are also restricted by the partner.        |
+| **Nepal**      | Business transfers are not supported. Payouts can only be sent to individual bank accounts.                                            |
+| **Pakistan**   | Business transfers are not supported. The recipient must be a private individual.                                                       |
+| **Tanzania**   | Payouts to and from business bank accounts are temporarily not supported. Payouts can only be sent to individual bank accounts.         |
+| **Ukraine**    | Payouts cannot be sent to business cards or business accounts. Payouts can only be sent to individual bank accounts.                    |
+
+<Info>
+  These restrictions come from our bank transfer partner and may change over time. For the most
+  up-to-date, country-specific limitations, see the partner's [live availability
+  page](https://wise.com/help/articles/2571942/what-countriesregions-can-i-send-to).
+</Info>
 
 ### Unsupported Countries for Purchases
 

--- a/packages/docs/merchant-of-record/supported-countries.mdx
+++ b/packages/docs/merchant-of-record/supported-countries.mdx
@@ -111,20 +111,11 @@ Creem supports purchases from all countries except those in the [unsupported lis
 
 ### Bank Transfer Partner Restrictions
 
-Some local bank payouts are subject to additional restrictions from our bank transfer partners. Countries marked with a double asterisk (\*\*) in the table above have restrictions that may affect business payouts:
-
-| Country        | Restriction                                                                                                                             |
-| :------------- | :------------------------------------------------------------------------------------------------------------------------------------- |
-| **Bangladesh** | Business transfers are not supported. Payouts can only be sent to individual bank accounts.                                            |
-| **Colombia**   | Payouts can only be sent to individual (personal) bank accounts. Certain business categories are also restricted by the partner.        |
-| **Nepal**      | Business transfers are not supported. Payouts can only be sent to individual bank accounts.                                            |
-| **Pakistan**   | Business transfers are not supported. The recipient must be a private individual.                                                       |
-| **Tanzania**   | Payouts to and from business bank accounts are temporarily not supported. Payouts can only be sent to individual bank accounts.         |
-| **Ukraine**    | Payouts cannot be sent to business cards or business accounts. Payouts can only be sent to individual bank accounts.                    |
+Some local bank payouts are subject to additional restrictions from our bank transfer partner. Countries marked with a double asterisk (\*\*) in the table above may have restrictions that affect payouts - for example, only individual (personal) bank accounts being supported, or business transfers not being available.
 
 <Info>
   These restrictions come from our bank transfer partner and may change over time. For the most
-  up-to-date, country-specific limitations, see the partner's [live availability
+  up-to-date, country-specific details, please check the partner's [live availability
   page](https://wise.com/help/articles/2571942/what-countriesregions-can-i-send-to).
 </Info>
 


### PR DESCRIPTION
## What

Adds double-asterisk (\*\*) footnote links in the Supported Countries table for countries where our bank transfer partner (Wise) restricts **business payouts**. Clicking the asterisk scrolls to an expanded **Bank Transfer Partner Restrictions** section that explains the specific limitation per country.

## Why

Merchants from these countries (e.g. Colombia) currently have no in-docs signal that only individual bank accounts are supported, or that business transfers are blocked. This surfaces it before they attempt a payout.

## Countries flagged

| Country | Restriction |
|---|---|
| Bangladesh | Business transfers not supported (individual accounts only) |
| Colombia | Individual (personal) accounts only + business-category restrictions |
| Nepal | Business transfers not supported (individual accounts only) |
| Pakistan | Business transfers not supported; recipient must be a private individual |
| Tanzania | Business bank accounts temporarily not supported |
| Ukraine | No business cards/accounts (individual accounts only) |

China already had a single-asterisk link to its transfer-limits note and was left as-is.

## Verification

Each restriction was confirmed against the live Wise per-currency help pages (verbatim). Countries with only generic transfer caps or institution-level bank exclusions (e.g. Brazil, Mexico, Thailand, Turkey, Vietnam) were intentionally **not** flagged. Egypt and India have minor charity/NGO exclusions that don't affect standard merchant payouts and were skipped per review.

Source list: https://wise.com/help/articles/2571942/what-countriesregions-can-i-send-to