### PR TITLE
fix(cli): stop sending test-environment requests to the production API host

### DIFF
--- a/.changeset/wild-buttons-shave.md
+++ b/.changeset/wild-buttons-shave.md
@@ -1,0 +1,10 @@
+---
+"@creem_io/cli": patch
+---
+
+Fix test-environment requests being sent to the production API host. The CLI
+selected its server with `serverIdx`, which was removed in `creem@1.5.0`
+(renamed to `server`); with `creem` resolving to 1.5.x on fresh installs the
+option was silently ignored and every request defaulted to `api.creem.io`,
+so `creem_test_` keys always failed with `401 Invalid API Key`. The client is
+now constructed with `serverURL`, which is stable across creem SDK versions.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -124,7 +124,9 @@ Include `trace_id` in support requests. The `message` array contains specific va
 import { Creem } from "creem";
 const creem = new Creem({
   apiKey: process.env.CREEM_API_KEY!,
-  serverIdx: 0, // 0 = production, 1 = test
+  // Use serverURL (stable across SDK versions); the server-selection option
+  // was renamed in creem 1.5.0 (serverIdx -> server).
+  serverURL: "https://api.creem.io", // test: https://test-api.creem.io
 });
 
 // Wrapper SDK
@@ -793,7 +795,7 @@ Verification is straightforward and typically fast. Once approved, switch to liv
 creem login --api-key creem_LIVE_KEY_HERE
 ```
 
-The environment switches automatically based on the key prefix. For SDKs, change `testMode: false` or `serverIdx: 0`.
+The environment switches automatically based on the key prefix. For SDKs, change `testMode: false` or `serverURL: "https://api.creem.io"`.
 
 ---
 

--- a/packages/cli/src/lib/api.ts
+++ b/packages/cli/src/lib/api.ts
@@ -34,10 +34,11 @@ export function getClient(): Creem {
 
   // Recreate client if API key or environment changed
   if (!clientInstance || apiKey !== cachedApiKey || environment !== cachedEnvironment) {
+    // serverURL is stable across creem SDK 1.4.x/1.5.x; the server-selection
+    // option was renamed (serverIdx -> server) in 1.5.0.
     clientInstance = new Creem({
       apiKey,
-      // 0 = live (api.creem.io), 1 = test (test-api.creem.io)
-      serverIdx: environment === "live" ? 0 : 1,
+      serverURL: API_URLS[environment] || API_URLS.test,
     });
     cachedApiKey = apiKey;
     cachedEnvironment = environment;
@@ -71,7 +72,7 @@ export async function validateApiKey(
   try {
     const testClient = new Creem({
       apiKey,
-      serverIdx: env === "live" ? 0 : 1,
+      serverURL: API_URLS[env] || API_URLS.test,
     });
 
     // Make a simple API call to validate the key


### PR DESCRIPTION
## What & why

Fixes #135. With `creem` resolving to 1.5.x, the CLI's `serverIdx` option no longer exists (renamed to `server` in 1.5.0), so it was silently ignored and all requests went to the production host — test keys always got 401. This constructs the client with `serverURL` instead, which works on both 1.4.x and 1.5.x. Also corrects the `serverIdx` examples in AGENTS.md and adds a changeset.

## Testing

- `pnpm build && pnpm typecheck` pass; `pnpm test` passes with `TEST_API_KEY` set (72 tests).
- Built the CLI and verified with a real test key: `creem login` succeeds and `creem products list` returns test-mode data. Before the fix, a proxy trace showed `CONNECT api.creem.io:443` with `environment=test`.

## AI usage

- [ ] I did not use AI tools for this PR.
- [x] I used AI tools, a human has reviewed and can explain every change, and this description was written or edited by a human.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.