### PR TITLE
chore: [ENG-957] migrate CLI to creem SDK 1.5.x

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creem_io/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Official CLI for Creem - the Stripe alternative for SaaS",
   "keywords": [
     "creem",
@@ -39,7 +39,7 @@
     "chalk": "^4.1.2",
     "cli-table3": "^0.6.5",
     "commander": "^12.1.0",
-    "creem": "^1.3.6",
+    "creem": "^1.5.3",
     "ora": "^5.4.1"
   },
   "devDependencies": {

--- a/packages/cli/src/commands/customers.ts
+++ b/packages/cli/src/commands/customers.ts
@@ -90,11 +90,10 @@ function getCustomersTuiDescriptor(): TuiModuleDescriptor<Customer> {
     ],
     fetchPage: async (page: number, pageSize: number) => {
       const client = getClient();
-      const result = (await client.customers.list(
-        page,
-        pageSize,
-      )) as unknown as CustomerListResponse;
-      const { items, pagination } = result;
+      const result = (await client.customers.list(page, pageSize)) as unknown as {
+        result: CustomerListResponse;
+      };
+      const { items, pagination } = result.result;
       return {
         items,
         hasMore: pagination.nextPage !== undefined,
@@ -159,14 +158,14 @@ export function createCustomersCommand(): Command {
         const result = (await client.customers.list(
           parseInt(options.page, 10),
           parseInt(options.limit, 10),
-        )) as unknown as CustomerListResponse;
+        )) as unknown as { result: CustomerListResponse };
 
         spinner.stop();
 
-        const { items, pagination } = result;
+        const { items, pagination } = result.result;
 
         if (shouldOutputJson(options.json)) {
-          output.outputJson(result);
+          output.outputJson(result.result);
           return;
         }
 

--- a/packages/cli/src/commands/products.ts
+++ b/packages/cli/src/commands/products.ts
@@ -127,11 +127,10 @@ function getProductsTuiDescriptor(): TuiModuleDescriptor<Product> {
     ],
     fetchPage: async (page: number, pageSize: number) => {
       const client = getClient();
-      const response = (await client.products.search(
-        page,
-        pageSize,
-      )) as unknown as ProductListResponse;
-      const { items, pagination } = response;
+      const response = (await client.products.search(page, pageSize)) as unknown as {
+        result: ProductListResponse;
+      };
+      const { items, pagination } = response.result;
       return {
         items,
         hasMore: pagination.nextPage !== undefined,
@@ -392,14 +391,14 @@ ${chalk.dim("Examples:")}
         const response = (await client.products.search(
           parseInt(options.page, 10),
           parseInt(options.limit, 10),
-        )) as unknown as ProductListResponse;
+        )) as unknown as { result: ProductListResponse };
 
         spinner.stop();
 
-        const { items, pagination } = response;
+        const { items, pagination } = response.result;
 
         if (shouldOutputJson(options.json)) {
-          output.outputJson(response);
+          output.outputJson(response.result);
           return;
         }
 

--- a/packages/cli/src/commands/subscriptions.ts
+++ b/packages/cli/src/commands/subscriptions.ts
@@ -87,7 +87,9 @@ async function fetchSubscriptionsFromTransactions(
       transactionPage,
       50,
     );
-    const items = (transactions as { items?: Array<{ subscription?: string }> }).items || [];
+    const items =
+      (transactions as { result?: { items?: Array<{ subscription?: string }> } }).result?.items ||
+      [];
 
     if (items.length === 0) {
       noMoreTransactions = true;

--- a/packages/cli/src/commands/transactions.ts
+++ b/packages/cli/src/commands/transactions.ts
@@ -226,8 +226,8 @@ function getTransactionsTuiDescriptor(): TuiModuleDescriptor<Transaction> {
         undefined,
         page,
         pageSize,
-      )) as unknown as TransactionListResponse;
-      const { items, pagination } = result;
+      )) as unknown as { result: TransactionListResponse };
+      const { items, pagination } = result.result;
       return {
         items,
         hasMore: pagination.nextPage !== undefined,
@@ -295,14 +295,14 @@ export function createTransactionsCommand(): Command {
             options.product,
             parseInt(options.page, 10),
             parseInt(options.limit, 10),
-          )) as unknown as TransactionListResponse;
+          )) as unknown as { result: TransactionListResponse };
 
           spinner.stop();
 
-          const { items, pagination } = result;
+          const { items, pagination } = result.result;
 
           if (shouldOutputJson(options.json)) {
-            output.outputJson(result);
+            output.outputJson(result.result);
             return;
           }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,8 @@
 
 import { Command } from "commander";
 import chalk from "chalk";
+import { readFileSync } from "fs";
+import { join } from "path";
 import {
   createLoginCommand,
   createLogoutCommand,
@@ -16,7 +18,11 @@ import {
   createMigrateCommand,
 } from "./commands";
 
-const VERSION = "0.1.3";
+const VERSION = (
+  JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf8")) as {
+    version: string;
+  }
+).version;
 
 const creem = chalk.hex("#ffbe98");
 

--- a/packages/cli/src/lib/api.ts
+++ b/packages/cli/src/lib/api.ts
@@ -36,8 +36,7 @@ export function getClient(): Creem {
   if (!clientInstance || apiKey !== cachedApiKey || environment !== cachedEnvironment) {
     clientInstance = new Creem({
       apiKey,
-      // 0 = live (api.creem.io), 1 = test (test-api.creem.io)
-      serverIdx: environment === "live" ? 0 : 1,
+      server: environment === "live" ? "prod" : "test",
     });
     cachedApiKey = apiKey;
     cachedEnvironment = environment;
@@ -71,7 +70,7 @@ export async function validateApiKey(
   try {
     const testClient = new Creem({
       apiKey,
-      serverIdx: env === "live" ? 0 : 1,
+      server: env === "live" ? "prod" : "test",
     });
 
     // Make a simple API call to validate the key

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0
       creem:
-        specifier: ^1.3.6
-        version: 1.4.4
+        specifier: ^1.5.3
+        version: 1.5.3
       ora:
         specifier: ^5.4.1
         version: 5.4.1
@@ -198,7 +198,7 @@ importers:
         version: 5.1.4(vite@7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.8.3))
       '@vitest/coverage-v8':
         specifier: 4.0.18
-        version: 4.0.18(vitest@4.0.18(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.8.3))
+        version: 4.0.18(vitest@4.0.18(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(supports-color@5.5.0))(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.8.3))
       autoprefixer:
         specifier: 10.4.27
         version: 10.4.27(postcss@8.5.6)
@@ -243,7 +243,7 @@ importers:
         version: 17.3.0
       jsdom:
         specifier: ^28.1.0
-        version: 28.1.0(@noble/hashes@2.0.1)
+        version: 28.1.0(@noble/hashes@2.0.1)(supports-color@5.5.0)
       lucide-react:
         specifier: 0.575.0
         version: 0.575.0(react@19.2.4)
@@ -294,7 +294,7 @@ importers:
         version: 7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.8.3)
       vitest:
         specifier: 4.0.18
-        version: 4.0.18(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.8.3)
+        version: 4.0.18(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(supports-color@5.5.0))(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.8.3)
       wrangler:
         specifier: 4.69.0
         version: 4.69.0
@@ -6764,10 +6764,6 @@ packages:
 
   crc@3.8.0:
     resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
-
-  creem@1.4.4:
-    resolution: {integrity: sha512-hfnHOIqNERf783FMJOOpbmD701y4t6HuVKR8kIm16X3l5OK6yMM0ifd2zY8CbRqSLeqK/iQV1D8FLgZEVs7Alg==}
-    hasBin: true
 
   creem@1.5.3:
     resolution: {integrity: sha512-GYd8QbG293fcjg6LkeRDpTam83xjjRjv/j/PeYOYwFhsc6zESZyq6SbV5yBnsBWJyjnzgSgA5bezedNnv+CMfw==}
@@ -16807,8 +16803,8 @@ snapshots:
       aggregate-error: 5.0.0
       debug: 4.4.3(supports-color@5.5.0)
       dir-glob: 3.0.1
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@5.5.0)
+      https-proxy-agent: 7.0.6(supports-color@5.5.0)
       issue-parser: 7.0.1
       lodash-es: 4.17.23
       mime: 4.1.0
@@ -18849,7 +18845,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.8.3))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(supports-color@5.5.0))(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.8.3))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -18861,7 +18857,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.8.3)
+      vitest: 4.0.18(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(supports-color@5.5.0))(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.8.3)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -20819,14 +20815,6 @@ snapshots:
     dependencies:
       buffer: 5.7.1
 
-  creem@1.4.4:
-    dependencies:
-      '@modelcontextprotocol/sdk': 1.28.0(zod@3.25.76)
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
   creem@1.5.3:
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
@@ -22580,7 +22568,7 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@5.5.0):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@5.5.0)
@@ -22602,7 +22590,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@5.5.0):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@5.5.0)
@@ -23042,7 +23030,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jsdom@28.1.0(@noble/hashes@2.0.1):
+  jsdom@28.1.0(@noble/hashes@2.0.1)(supports-color@5.5.0):
     dependencies:
       '@acemir/cssom': 0.9.31
       '@asamuzakjp/dom-selector': 6.8.1
@@ -23052,8 +23040,8 @@ snapshots:
       data-urls: 7.0.0(@noble/hashes@2.0.1)
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0(@noble/hashes@2.0.1)
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@5.5.0)
+      https-proxy-agent: 7.0.6(supports-color@5.5.0)
       is-potential-custom-element-name: 1.0.1
       parse5: 8.0.0
       saxes: 6.0.0
@@ -27242,7 +27230,7 @@ snapshots:
       '@edge-runtime/vm': 5.0.0
       '@types/debug': 4.1.13
       '@types/node': 20.19.37
-      jsdom: 28.1.0(@noble/hashes@2.0.1)
+      jsdom: 28.1.0(@noble/hashes@2.0.1)(supports-color@5.5.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -27286,7 +27274,7 @@ snapshots:
       '@edge-runtime/vm': 5.0.0
       '@types/debug': 4.1.13
       '@types/node': 25.9.3
-      jsdom: 28.1.0(@noble/hashes@2.0.1)
+      jsdom: 28.1.0(@noble/hashes@2.0.1)(supports-color@5.5.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -27301,7 +27289,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.8.3):
+  vitest@4.0.18(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(supports-color@5.5.0))(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.8.3))
@@ -27327,7 +27315,7 @@ snapshots:
       '@edge-runtime/vm': 5.0.0
       '@opentelemetry/api': 1.9.1
       '@types/node': 20.19.35
-      jsdom: 28.1.0(@noble/hashes@2.0.1)
+      jsdom: 28.1.0(@noble/hashes@2.0.1)(supports-color@5.5.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -27367,7 +27355,7 @@ snapshots:
       '@edge-runtime/vm': 5.0.0
       '@opentelemetry/api': 1.9.1
       '@types/node': 20.19.37
-      jsdom: 28.1.0(@noble/hashes@2.0.1)
+      jsdom: 28.1.0(@noble/hashes@2.0.1)(supports-color@5.5.0)
     transitivePeerDependencies:
       - msw
 
@@ -27397,7 +27385,7 @@ snapshots:
       '@edge-runtime/vm': 5.0.0
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.9.3
-      jsdom: 28.1.0(@noble/hashes@2.0.1)
+      jsdom: 28.1.0(@noble/hashes@2.0.1)(supports-color@5.5.0)
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
## Summary

Migrates `@creem_io/cli` to the `creem` SDK 1.5.x API and ships it as `0.2.2`.

The CLI depended on `creem: ^1.3.6`, which now floats to `1.5.3` on fresh installs. SDK 1.5.x changed two things that the CLI relied on:

1. The constructor option `serverIdx: 0 | 1` was replaced by a named `server: "prod" | "test"` option. The old option is silently ignored on 1.5.x, so environment/server resolution fell back to the default, sending every request to the production server regardless of configured environment.
2. Paginated list methods (`products.search`, `transactions.search`, `customers.list`) now return a `PageIterator` and wrap the payload under a `.result` property instead of exposing `{ items, pagination }` at the top level.

This PR updates the CLI to the new API surface, pins the dependency to `^1.5.3`, and fixes the version reporting.

## Changes

- `package.json`: bump `creem` to `^1.5.3`; bump CLI version `0.2.1` → `0.2.2`.
- `src/lib/api.ts`: use `server: environment === "live" ? "prod" : "test"` in both the client factory and `validateApiKey` (replaces `serverIdx`).
- `src/commands/{products,transactions,customers}.ts`: read paginated results from `response.result`. `--json` output continues to emit the `{ items, pagination }` shape (unwrapped from `.result`), so existing scripts are unaffected.
- `src/commands/subscriptions.ts`: read transaction items from `.result.items` in the subscription-scan helper.
- `src/index.ts`: derive `--version` from `package.json` at runtime instead of a hardcoded constant (previously reported `0.1.3` in every build).
- `pnpm-lock.yaml`: regenerated to resolve `creem@1.5.3`.

## Verification

- `pnpm --filter @creem_io/cli run build` — clean (`tsc`, 0 errors).
- `prettier --check` — clean.
- `creem --version` → `0.2.2`.
- SDK server resolution confirmed: `server: "test"` → `https://test-api.creem.io/`, `server: "prod"` → `https://api.creem.io/`.
- CLI smoke tests (`--help`, `products --help`, `whoami`) start without error.

Resolves ENG-957.
