### PR TITLE
docs: [ENG-495] document Product CRUD API (status filter, retrieve/update/archive)

### DIFF
--- a/packages/creem-sdk/openapi.json
+++ b/packages/creem-sdk/openapi.json
@@ -140,6 +140,15 @@
               "example": 10,
               "type": "number"
             }
+          },
+          {
+            "name": "status",
+            "required": false,
+            "in": "query",
+            "description": "Filter products by lifecycle status. Omit to return products of any status. `active` returns only non-archived products (the common case for catalogues and pricing pages); `archived` returns only archived products (useful for configuration synchronization).",
+            "schema": {
+              "$ref": "#/components/schemas/ProductStatus"
+            }
           }
         ],
         "responses": {
@@ -2507,6 +2516,150 @@
           }
         },
         "tags": ["Customer Credits - Accounts (Experimental)"],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/v1/products/{id}": {
+      "get": {
+        "operationId": "getProduct",
+        "x-speakeasy-name-override": "get",
+        "summary": "Retrieve a product",
+        "description": "Retrieve a single product by its ID.",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The product ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the product",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductEntity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing API key"
+          },
+          "404": {
+            "description": "Not Found - Resource does not exist"
+          }
+        },
+        "tags": ["Products"],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "updateProduct",
+        "x-speakeasy-name-override": "update",
+        "summary": "Update a product",
+        "description": "Update a product. Only supplied fields change. Changing a price field mints a new default price; existing subscriptions keep the price they were purchased under.",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The product ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProductRequestEntity"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated the product",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductEntity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing API key"
+          },
+          "404": {
+            "description": "Not Found - Resource does not exist"
+          }
+        },
+        "tags": ["Products"],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "archiveProduct",
+        "x-speakeasy-name-override": "archive",
+        "summary": "Archive a product",
+        "description": "Archive a product (soft-delete). The product is retained for historical orders and subscriptions but can no longer be purchased. Archived products remain retrievable and appear in list results when filtering by `status=archived`.",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The product ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully archived the product",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductEntity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing API key"
+          },
+          "404": {
+            "description": "Not Found - Resource does not exist"
+          }
+        },
+        "tags": ["Products"],
         "security": [
           {
             "ApiKey": []
@@ -5786,6 +5939,61 @@
           }
         },
         "x-speakeasy-include": true
+      },
+      "UpdateProductRequestEntity": {
+        "type": "object",
+        "description": "Product update payload. Only supplied fields change. Changing a price field mints a new default price; existing subscriptions keep the price they were purchased under.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the product"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the product"
+          },
+          "image_url": {
+            "type": "string",
+            "description": "URL of the product image",
+            "example": "https://picsum.photos/200/300"
+          },
+          "default_success_url": {
+            "type": "string",
+            "description": "The URL to which the user will be redirected after successfull payment.",
+            "example": "https://example.com/?status=successful"
+          },
+          "price": {
+            "type": "integer",
+            "description": "The price of the product in cents. Must be 0 (free product) or at least 100 (one whole unit of the currency).",
+            "example": 400
+          },
+          "currency": {
+            "example": "USD",
+            "$ref": "#/components/schemas/ProductCurrency"
+          },
+          "billing_type": {
+            "example": "recurring",
+            "$ref": "#/components/schemas/ProductRequestBillingType"
+          },
+          "billing_period": {
+            "example": "every-month",
+            "$ref": "#/components/schemas/ProductRequestBillingPeriod"
+          },
+          "tax_mode": {
+            "example": "inclusive",
+            "$ref": "#/components/schemas/TaxMode"
+          },
+          "pay_what_you_want": {
+            "type": "boolean",
+            "description": "Enable pay-what-you-want pricing: the customer chooses the amount at checkout. The `price` field acts as the minimum the customer must pay. Only supported for one-time payment products.",
+            "example": false
+          },
+          "suggested_price": {
+            "type": "integer",
+            "description": "Suggested amount in cents, pre-filled at checkout when pay_what_you_want is enabled. Must be greater than or equal to `price` (the minimum). Ignored when pay_what_you_want is disabled.",
+            "example": 1500
+          }
+        }
       }
     }
   },

--- a/packages/docs/api-reference/endpoint/archive-product.mdx
+++ b/packages/docs/api-reference/endpoint/archive-product.mdx
@@ -1,0 +1,5 @@
+---
+title: "Archive a product"
+description: "Archive a product (soft-delete). The product is retained for historical orders and subscriptions but can no longer be purchased."
+openapi: delete /v1/products/{id}
+---

--- a/packages/docs/api-reference/endpoint/get-product-by-id.mdx
+++ b/packages/docs/api-reference/endpoint/get-product-by-id.mdx
@@ -1,0 +1,5 @@
+---
+title: "Retrieve a product by ID"
+description: "Retrieve a single product by its ID."
+openapi: get /v1/products/{id}
+---

--- a/packages/docs/api-reference/endpoint/update-product.mdx
+++ b/packages/docs/api-reference/endpoint/update-product.mdx
@@ -1,0 +1,5 @@
+---
+title: "Update a product"
+description: "Update a product. Only supplied fields change; changing a price field mints a new default price while existing subscriptions keep the price they were purchased under."
+openapi: patch /v1/products/{id}
+---

--- a/packages/docs/api-reference/openapi.json
+++ b/packages/docs/api-reference/openapi.json
@@ -140,6 +140,15 @@
               "example": 10,
               "type": "number"
             }
+          },
+          {
+            "name": "status",
+            "required": false,
+            "in": "query",
+            "description": "Filter products by lifecycle status. Omit to return products of any status. `active` returns only non-archived products (the common case for catalogues and pricing pages); `archived` returns only archived products (useful for configuration synchronization).",
+            "schema": {
+              "$ref": "#/components/schemas/ProductStatus"
+            }
           }
         ],
         "responses": {
@@ -2507,6 +2516,150 @@
           }
         },
         "tags": ["Customer Credits - Accounts (Experimental)"],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/v1/products/{id}": {
+      "get": {
+        "operationId": "getProduct",
+        "x-speakeasy-name-override": "get",
+        "summary": "Retrieve a product",
+        "description": "Retrieve a single product by its ID.",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The product ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the product",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductEntity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing API key"
+          },
+          "404": {
+            "description": "Not Found - Resource does not exist"
+          }
+        },
+        "tags": ["Products"],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "updateProduct",
+        "x-speakeasy-name-override": "update",
+        "summary": "Update a product",
+        "description": "Update a product. Only supplied fields change. Changing a price field mints a new default price; existing subscriptions keep the price they were purchased under.",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The product ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProductRequestEntity"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated the product",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductEntity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing API key"
+          },
+          "404": {
+            "description": "Not Found - Resource does not exist"
+          }
+        },
+        "tags": ["Products"],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "archiveProduct",
+        "x-speakeasy-name-override": "archive",
+        "summary": "Archive a product",
+        "description": "Archive a product (soft-delete). The product is retained for historical orders and subscriptions but can no longer be purchased. Archived products remain retrievable and appear in list results when filtering by `status=archived`.",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The product ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully archived the product",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductEntity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing API key"
+          },
+          "404": {
+            "description": "Not Found - Resource does not exist"
+          }
+        },
+        "tags": ["Products"],
         "security": [
           {
             "ApiKey": []
@@ -5786,6 +5939,61 @@
           }
         },
         "x-speakeasy-include": true
+      },
+      "UpdateProductRequestEntity": {
+        "type": "object",
+        "description": "Product update payload. Only supplied fields change. Changing a price field mints a new default price; existing subscriptions keep the price they were purchased under.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the product"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the product"
+          },
+          "image_url": {
+            "type": "string",
+            "description": "URL of the product image",
+            "example": "https://picsum.photos/200/300"
+          },
+          "default_success_url": {
+            "type": "string",
+            "description": "The URL to which the user will be redirected after successfull payment.",
+            "example": "https://example.com/?status=successful"
+          },
+          "price": {
+            "type": "integer",
+            "description": "The price of the product in cents. Must be 0 (free product) or at least 100 (one whole unit of the currency).",
+            "example": 400
+          },
+          "currency": {
+            "example": "USD",
+            "$ref": "#/components/schemas/ProductCurrency"
+          },
+          "billing_type": {
+            "example": "recurring",
+            "$ref": "#/components/schemas/ProductRequestBillingType"
+          },
+          "billing_period": {
+            "example": "every-month",
+            "$ref": "#/components/schemas/ProductRequestBillingPeriod"
+          },
+          "tax_mode": {
+            "example": "inclusive",
+            "$ref": "#/components/schemas/TaxMode"
+          },
+          "pay_what_you_want": {
+            "type": "boolean",
+            "description": "Enable pay-what-you-want pricing: the customer chooses the amount at checkout. The `price` field acts as the minimum the customer must pay. Only supported for one-time payment products.",
+            "example": false
+          },
+          "suggested_price": {
+            "type": "integer",
+            "description": "Suggested amount in cents, pre-filled at checkout when pay_what_you_want is enabled. Must be greater than or equal to `price` (the minimum). Ignored when pay_what_you_want is disabled.",
+            "example": 1500
+          }
+        }
       }
     }
   },

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-
   "seo": {
     "indexing": "all",
     "metatags": {
@@ -232,7 +231,10 @@
             "pages": [
               "api-reference/endpoint/create-product",
               "api-reference/endpoint/get-product",
-              "api-reference/endpoint/search-products"
+              "api-reference/endpoint/get-product-by-id",
+              "api-reference/endpoint/search-products",
+              "api-reference/endpoint/update-product",
+              "api-reference/endpoint/archive-product"
             ]
           },
           {


### PR DESCRIPTION
## What

Documents the ENG-495 Products CRUD API in the public API reference (`packages/docs`).

## Changes

- **`GET /v1/products/search`** — add the `status` (`active` | `archived`) query filter. Omit for any status; `active` = non-archived (catalogues/pricing pages), `archived` = archived only (config sync).
- **`GET /v1/products/{id}`** — new: retrieve a product by id.
- **`PATCH /v1/products/{id}`** — new: update a product. Only supplied fields change; changing a price field mints a new default price while existing subscriptions keep the price they were purchased under.
- **`DELETE /v1/products/{id}`** — new: archive (soft-delete). Product is retained for historical orders/subscriptions but can no longer be purchased.
- Add `UpdateProductRequestEntity` schema.
- Register the three new endpoint pages in `docs.json` under the **Product** group.

No Prices API endpoints — those were removed in ENG-495.

## Note on generation

Per `packages/docs/CLAUDE.md` the canonical source of truth is the backend Swagger (`../creem-sdk/openapi.json`, synced via `pnpm gen:sdk`). These docs were authored directly to match the shipped ENG-495 backend controller; once the backend is deployed to an env exposing `/open-api/json`, a `generate:api:remote` run will reconcile the spec and should be a no-op against this content.

Prettier-formatted; both JSON files validate.
