### PR TITLE
docs: fix duplicate http tag in API reference base URLs

### DIFF
--- a/packages/docs/api-reference/introduction.mdx
+++ b/packages/docs/api-reference/introduction.mdx
@@ -12,8 +12,8 @@ The Creem API is built on REST principles and uses HTTPS for all requests. It re
 All API requests are made to the following base URLs:
 
 <Tabs>
-  <Tab title="Production">```http https://api.creem.io/v1 ```</Tab>
-  <Tab title="Test Mode">```http https://test-api.creem.io/v1 ```</Tab>
+  <Tab title="Production">`https://api.creem.io/v1`</Tab>
+  <Tab title="Test Mode">`https://test-api.creem.io/v1`</Tab>
 </Tabs>
 
 <Warning>


### PR DESCRIPTION
## Summary
- The Production and Test Mode **Base URL** tabs on the API Reference introduction page rendered as `http https://api.creem.io/v1` / `http https://test-api.creem.io/v1`.
- Cause: an inline ` ```http ` fenced code block, whose `http` language tag was displayed literally alongside the URL.
- Fixed by switching to inline code so only the URL is shown.

Affects:
- https://docs.creem.io/api-reference/introduction#production
- https://docs.creem.io/api-reference/introduction#test-mode

## Test plan
- [ ] Preview the API Reference introduction page and confirm the Base URL tabs show only `https://api.creem.io/v1` and `https://test-api.creem.io/v1`.

Made with [Cursor](https://cursor.com)