### PR TITLE
feat: [ENG-952] add read-only affiliate API to OpenAPI spec

### DIFF
--- a/packages/creem-sdk/openapi.json
+++ b/packages/creem-sdk/openapi.json
@@ -2666,6 +2666,226 @@
           }
         ]
       }
+    },
+    "/v1/affiliates": {
+      "get": {
+        "operationId": "listAffiliates",
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "page_number",
+              "in": "parameters",
+              "type": "page"
+            },
+            {
+              "name": "page_size",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "numPages": "$.pagination.total_pages",
+            "results": "$.items"
+          }
+        },
+        "x-speakeasy-name-override": "list",
+        "summary": "List all affiliates",
+        "description": "Retrieve a paginated list of your affiliates with their referral link, click and conversion counts, and lifetime commission. Affiliates who were invited but have not yet joined a program are not included.",
+        "parameters": [
+          {
+            "name": "page_number",
+            "required": false,
+            "in": "query",
+            "description": "The page number for pagination.",
+            "schema": {
+              "default": 1,
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "page_size",
+            "required": false,
+            "in": "query",
+            "description": "The number of items per page.",
+            "schema": {
+              "default": 50,
+              "example": 50,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved affiliates",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffiliateListEntity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing API key"
+          },
+          "404": {
+            "description": "Not Found - Resource does not exist"
+          }
+        },
+        "tags": ["Affiliates"],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/v1/affiliates/{id}": {
+      "get": {
+        "operationId": "retrieveAffiliate",
+        "x-speakeasy-name-override": "retrieve",
+        "summary": "Retrieve an affiliate",
+        "description": "Retrieve a single affiliate by ID, including referral link, click and conversion counts, and lifetime commission.",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The unique identifier of the affiliate",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the affiliate",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffiliateEntity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing API key"
+          },
+          "404": {
+            "description": "Not Found - Resource does not exist"
+          }
+        },
+        "tags": ["Affiliates"],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/v1/affiliates/{id}/commissions": {
+      "get": {
+        "operationId": "listAffiliateCommissions",
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "page_number",
+              "in": "parameters",
+              "type": "page"
+            },
+            {
+              "name": "page_size",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "numPages": "$.pagination.total_pages",
+            "results": "$.items"
+          }
+        },
+        "x-speakeasy-name-override": "listCommissions",
+        "summary": "List affiliate commissions",
+        "description": "Retrieve a paginated list of an affiliate’s commissions. Filter by settlement status (pending, approved, paid).",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The unique identifier of the affiliate",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "required": false,
+            "in": "query",
+            "description": "Filter commissions by settlement status.",
+            "schema": {
+              "$ref": "#/components/schemas/CommissionStatus"
+            }
+          },
+          {
+            "name": "page_number",
+            "required": false,
+            "in": "query",
+            "description": "The page number for pagination.",
+            "schema": {
+              "default": 1,
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "page_size",
+            "required": false,
+            "in": "query",
+            "description": "The number of items per page.",
+            "schema": {
+              "default": 10,
+              "example": 10,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved affiliate commissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommissionListEntity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing API key"
+          },
+          "404": {
+            "description": "Not Found - Resource does not exist"
+          }
+        },
+        "tags": ["Affiliates"],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
     }
   },
   "info": {
@@ -5994,6 +6214,184 @@
             "example": 1500
           }
         }
+      },
+      "AffiliateEntity": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the object."
+          },
+          "mode": {
+            "$ref": "#/components/schemas/EnvironmentMode"
+          },
+          "object": {
+            "type": "string",
+            "description": "String representing the object's type. Objects of the same type share the same value.",
+            "example": "affiliate"
+          },
+          "email": {
+            "type": "string",
+            "description": "The email address the affiliate was invited with.",
+            "example": "partner@example.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name of the affiliate, if set.",
+            "example": "Jane Partner",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "description": "The affiliate's status within your program, reflecting their membership standing: `active`, `pending` (awaiting approval), `rejected`, `suspended`, or `inactive` (left or removed). Invited-but-not-yet-joined affiliates are not returned by this endpoint.",
+            "example": "active"
+          },
+          "referral_code": {
+            "type": "string",
+            "description": "The affiliate's unique referral code.",
+            "example": "a1b2c3d4"
+          },
+          "referral_link": {
+            "type": "string",
+            "description": "The affiliate's shareable referral link. Traffic arriving through it is attributed to this affiliate.",
+            "example": "https://creem.io/affiliate?code=a1b2c3d4"
+          },
+          "clicks": {
+            "type": "number",
+            "description": "Total number of clicks recorded on the affiliate’s links.",
+            "example": 128
+          },
+          "conversions": {
+            "type": "number",
+            "description": "Total number of conversions attributed to the affiliate.",
+            "example": 12
+          },
+          "earnings": {
+            "type": "number",
+            "description": "Lifetime commission earned by the affiliate, in cents (1000 = $10.00), reported in a single primary currency (see `currency`). Affiliates earning in multiple currencies show only their highest-earning currency here; use the affiliate's commissions endpoint for the full per-currency breakdown.",
+            "example": 4200
+          },
+          "currency": {
+            "type": "string",
+            "description": "Three-letter ISO currency code, in uppercase, for the `earnings` amount. This is the affiliate's primary (highest-earning) currency; commissions in other currencies are listed individually on the commissions endpoint.",
+            "example": "USD"
+          }
+        },
+        "required": [
+          "id",
+          "mode",
+          "object",
+          "email",
+          "status",
+          "referral_code",
+          "referral_link",
+          "clicks",
+          "conversions",
+          "earnings",
+          "currency"
+        ]
+      },
+      "AffiliateListEntity": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "List of affiliate items",
+            "items": {
+              "$ref": "#/components/schemas/AffiliateEntity"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "description": "Pagination details for the list",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationEntity"
+              }
+            ]
+          }
+        },
+        "required": ["items", "pagination"]
+      },
+      "CommissionEntity": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the object."
+          },
+          "mode": {
+            "$ref": "#/components/schemas/EnvironmentMode"
+          },
+          "object": {
+            "type": "string",
+            "description": "String representing the object's type. Objects of the same type share the same value.",
+            "example": "commission"
+          },
+          "affiliate": {
+            "type": "string",
+            "description": "The ID of the affiliate this commission belongs to.",
+            "example": "aff_1234567890"
+          },
+          "amount": {
+            "type": "number",
+            "description": "The commission amount in cents. 1000 = $10.00",
+            "example": 600
+          },
+          "currency": {
+            "type": "string",
+            "description": "Three-letter ISO currency code, in uppercase, for the commission amount.",
+            "example": "USD"
+          },
+          "status": {
+            "$ref": "#/components/schemas/CommissionStatus"
+          },
+          "sale": {
+            "type": "string",
+            "description": "The ID of the sale transaction that generated this commission, if available.",
+            "example": "tran_1234567890",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "number",
+            "description": "Creation date of the commission as a timestamp."
+          }
+        },
+        "required": [
+          "id",
+          "mode",
+          "object",
+          "affiliate",
+          "amount",
+          "currency",
+          "status",
+          "created_at"
+        ]
+      },
+      "CommissionListEntity": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "List of commission items",
+            "items": {
+              "$ref": "#/components/schemas/CommissionEntity"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "description": "Pagination details for the list",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationEntity"
+              }
+            ]
+          }
+        },
+        "required": ["items", "pagination"]
+      },
+      "CommissionStatus": {
+        "type": "string",
+        "description": "The settlement status of the commission. `pending` while on hold, `approved` once cleared and available, `paid` once settled by a payout.",
+        "enum": ["pending", "approved", "paid"]
       }
     }
   },

--- a/packages/docs/CLAUDE.md
+++ b/packages/docs/CLAUDE.md
@@ -231,6 +231,7 @@ API keys can have granular scopes following `resource:action` pattern:
 | licenses | licenses:read | licenses:write |
 | discounts | discounts:read | discounts:write |
 | stats | stats:read | — |
+| affiliates | affiliates:read | — |
 
 Special scope: `*:*` grants full access to all resources.
 
@@ -246,6 +247,7 @@ Special scope: `*:*` grants full access to all resources.
 | **License** | Validate, Activate, Deactivate |
 | **Discount** | Create, Retrieve, Delete |
 | **Stats** | Revenue, Subscriptions, Customers, MRR, Churn, LTV |
+| **Affiliate** | List affiliates, Retrieve affiliate, List commissions |
 
 ### Core Data Entities
 

--- a/packages/docs/api-reference/endpoint/get-affiliate.mdx
+++ b/packages/docs/api-reference/endpoint/get-affiliate.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Retrieve an affiliate'
+description: 'Retrieve a single affiliate by ID, including referral link, click and conversion counts, and lifetime commission.'
+openapi: get /v1/affiliates/{id}
+---

--- a/packages/docs/api-reference/endpoint/list-affiliate-commissions.mdx
+++ b/packages/docs/api-reference/endpoint/list-affiliate-commissions.mdx
@@ -1,0 +1,5 @@
+---
+title: 'List affiliate commissions'
+description: 'Retrieve a paginated list of an affiliate’s commissions. Filter by settlement status (pending, approved, paid).'
+openapi: get /v1/affiliates/{id}/commissions
+---

--- a/packages/docs/api-reference/endpoint/list-affiliates.mdx
+++ b/packages/docs/api-reference/endpoint/list-affiliates.mdx
@@ -1,0 +1,5 @@
+---
+title: 'List all affiliates'
+description: 'Retrieve a paginated list of your affiliates with their referral link, click and conversion counts, and lifetime commission. Affiliates who were invited but have not yet joined a program are not included.'
+openapi: get /v1/affiliates
+---

--- a/packages/docs/api-reference/openapi.json
+++ b/packages/docs/api-reference/openapi.json
@@ -2666,6 +2666,226 @@
           }
         ]
       }
+    },
+    "/v1/affiliates": {
+      "get": {
+        "operationId": "listAffiliates",
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "page_number",
+              "in": "parameters",
+              "type": "page"
+            },
+            {
+              "name": "page_size",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "numPages": "$.pagination.total_pages",
+            "results": "$.items"
+          }
+        },
+        "x-speakeasy-name-override": "list",
+        "summary": "List all affiliates",
+        "description": "Retrieve a paginated list of your affiliates with their referral link, click and conversion counts, and lifetime commission. Affiliates who were invited but have not yet joined a program are not included.",
+        "parameters": [
+          {
+            "name": "page_number",
+            "required": false,
+            "in": "query",
+            "description": "The page number for pagination.",
+            "schema": {
+              "default": 1,
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "page_size",
+            "required": false,
+            "in": "query",
+            "description": "The number of items per page.",
+            "schema": {
+              "default": 50,
+              "example": 50,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved affiliates",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffiliateListEntity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing API key"
+          },
+          "404": {
+            "description": "Not Found - Resource does not exist"
+          }
+        },
+        "tags": ["Affiliates"],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/v1/affiliates/{id}": {
+      "get": {
+        "operationId": "retrieveAffiliate",
+        "x-speakeasy-name-override": "retrieve",
+        "summary": "Retrieve an affiliate",
+        "description": "Retrieve a single affiliate by ID, including referral link, click and conversion counts, and lifetime commission.",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The unique identifier of the affiliate",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the affiliate",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffiliateEntity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing API key"
+          },
+          "404": {
+            "description": "Not Found - Resource does not exist"
+          }
+        },
+        "tags": ["Affiliates"],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/v1/affiliates/{id}/commissions": {
+      "get": {
+        "operationId": "listAffiliateCommissions",
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "page_number",
+              "in": "parameters",
+              "type": "page"
+            },
+            {
+              "name": "page_size",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "numPages": "$.pagination.total_pages",
+            "results": "$.items"
+          }
+        },
+        "x-speakeasy-name-override": "listCommissions",
+        "summary": "List affiliate commissions",
+        "description": "Retrieve a paginated list of an affiliate’s commissions. Filter by settlement status (pending, approved, paid).",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The unique identifier of the affiliate",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "required": false,
+            "in": "query",
+            "description": "Filter commissions by settlement status.",
+            "schema": {
+              "$ref": "#/components/schemas/CommissionStatus"
+            }
+          },
+          {
+            "name": "page_number",
+            "required": false,
+            "in": "query",
+            "description": "The page number for pagination.",
+            "schema": {
+              "default": 1,
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "page_size",
+            "required": false,
+            "in": "query",
+            "description": "The number of items per page.",
+            "schema": {
+              "default": 10,
+              "example": 10,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved affiliate commissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommissionListEntity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing API key"
+          },
+          "404": {
+            "description": "Not Found - Resource does not exist"
+          }
+        },
+        "tags": ["Affiliates"],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
     }
   },
   "info": {
@@ -5994,6 +6214,184 @@
             "example": 1500
           }
         }
+      },
+      "AffiliateEntity": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the object."
+          },
+          "mode": {
+            "$ref": "#/components/schemas/EnvironmentMode"
+          },
+          "object": {
+            "type": "string",
+            "description": "String representing the object's type. Objects of the same type share the same value.",
+            "example": "affiliate"
+          },
+          "email": {
+            "type": "string",
+            "description": "The email address the affiliate was invited with.",
+            "example": "partner@example.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name of the affiliate, if set.",
+            "example": "Jane Partner",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "description": "The affiliate's status within your program, reflecting their membership standing: `active`, `pending` (awaiting approval), `rejected`, `suspended`, or `inactive` (left or removed). Invited-but-not-yet-joined affiliates are not returned by this endpoint.",
+            "example": "active"
+          },
+          "referral_code": {
+            "type": "string",
+            "description": "The affiliate's unique referral code.",
+            "example": "a1b2c3d4"
+          },
+          "referral_link": {
+            "type": "string",
+            "description": "The affiliate's shareable referral link. Traffic arriving through it is attributed to this affiliate.",
+            "example": "https://creem.io/affiliate?code=a1b2c3d4"
+          },
+          "clicks": {
+            "type": "number",
+            "description": "Total number of clicks recorded on the affiliate’s links.",
+            "example": 128
+          },
+          "conversions": {
+            "type": "number",
+            "description": "Total number of conversions attributed to the affiliate.",
+            "example": 12
+          },
+          "earnings": {
+            "type": "number",
+            "description": "Lifetime commission earned by the affiliate, in cents (1000 = $10.00), reported in a single primary currency (see `currency`). Affiliates earning in multiple currencies show only their highest-earning currency here; use the affiliate's commissions endpoint for the full per-currency breakdown.",
+            "example": 4200
+          },
+          "currency": {
+            "type": "string",
+            "description": "Three-letter ISO currency code, in uppercase, for the `earnings` amount. This is the affiliate's primary (highest-earning) currency; commissions in other currencies are listed individually on the commissions endpoint.",
+            "example": "USD"
+          }
+        },
+        "required": [
+          "id",
+          "mode",
+          "object",
+          "email",
+          "status",
+          "referral_code",
+          "referral_link",
+          "clicks",
+          "conversions",
+          "earnings",
+          "currency"
+        ]
+      },
+      "AffiliateListEntity": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "List of affiliate items",
+            "items": {
+              "$ref": "#/components/schemas/AffiliateEntity"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "description": "Pagination details for the list",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationEntity"
+              }
+            ]
+          }
+        },
+        "required": ["items", "pagination"]
+      },
+      "CommissionEntity": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the object."
+          },
+          "mode": {
+            "$ref": "#/components/schemas/EnvironmentMode"
+          },
+          "object": {
+            "type": "string",
+            "description": "String representing the object's type. Objects of the same type share the same value.",
+            "example": "commission"
+          },
+          "affiliate": {
+            "type": "string",
+            "description": "The ID of the affiliate this commission belongs to.",
+            "example": "aff_1234567890"
+          },
+          "amount": {
+            "type": "number",
+            "description": "The commission amount in cents. 1000 = $10.00",
+            "example": 600
+          },
+          "currency": {
+            "type": "string",
+            "description": "Three-letter ISO currency code, in uppercase, for the commission amount.",
+            "example": "USD"
+          },
+          "status": {
+            "$ref": "#/components/schemas/CommissionStatus"
+          },
+          "sale": {
+            "type": "string",
+            "description": "The ID of the sale transaction that generated this commission, if available.",
+            "example": "tran_1234567890",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "number",
+            "description": "Creation date of the commission as a timestamp."
+          }
+        },
+        "required": [
+          "id",
+          "mode",
+          "object",
+          "affiliate",
+          "amount",
+          "currency",
+          "status",
+          "created_at"
+        ]
+      },
+      "CommissionListEntity": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "List of commission items",
+            "items": {
+              "$ref": "#/components/schemas/CommissionEntity"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "description": "Pagination details for the list",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationEntity"
+              }
+            ]
+          }
+        },
+        "required": ["items", "pagination"]
+      },
+      "CommissionStatus": {
+        "type": "string",
+        "description": "The settlement status of the commission. `pending` while on hold, `approved` once cleared and available, `paid` once settled by a payout.",
+        "enum": ["pending", "approved", "paid"]
       }
     }
   },

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -292,6 +292,15 @@
             "pages": ["api-reference/endpoint/get-stats-summary"]
           },
           {
+            "group": "Affiliate",
+            "icon": "handshake",
+            "pages": [
+              "api-reference/endpoint/list-affiliates",
+              "api-reference/endpoint/get-affiliate",
+              "api-reference/endpoint/list-affiliate-commissions"
+            ]
+          },
+          {
             "group": "Customer Credits",
             "icon": "coins",
             "pages": [

--- a/packages/docs/features/affiliate-program.mdx
+++ b/packages/docs/features/affiliate-program.mdx
@@ -366,6 +366,13 @@ If you're an affiliate for multiple merchants, you can switch between programs u
 
 <CardGroup cols={2}>
   <Card
+    title="API Reference"
+    icon="book"
+    href="/api-reference/endpoint/list-affiliates"
+  >
+    Pull affiliate stats and commissions into your own product via the API
+  </Card>
+  <Card
     title="Revenue Splits"
     icon="money-bill-transfer"
     href="/features/split-payments"

--- a/packages/docs/scripts/generate-api-docs.js
+++ b/packages/docs/scripts/generate-api-docs.js
@@ -44,6 +44,7 @@ const FILENAME_OVERRIDES = {
   resumeSubscription: "resume-subscription",
   createCheckout: "create-checkout",
   createProduct: "create-product",
+  retrieveAffiliate: "get-affiliate",
 };
 
 // Fallback descriptions when not provided in OpenAPI spec


### PR DESCRIPTION
## What

Adds the read-only **affiliate API** to the OpenAPI source spec, mirroring the merged & deployed backend PR [armitage-labs/pugpay-monorepo#2402](https://github.com/armitage-labs/pugpay-monorepo/pull/2402) ([ENG-952](https://linear.app/creem/issue/ENG-952)). Because it's a new public API surface, the SDK/docs spec in this repo needs to pick it up.

**New paths** (all `GET`, `ApiKey` auth, `affiliates:read` scope):
- `GET /v1/affiliates` — paginated affiliate list (referral link, clicks, conversions, lifetime commission)
- `GET /v1/affiliates/{id}` — single affiliate summary
- `GET /v1/affiliates/{id}/commissions` — paginated commissions, `status` filter (`pending`/`approved`/`paid`)

**New schemas:** `AffiliateEntity`, `AffiliateListEntity`, `CommissionEntity`, `CommissionListEntity`, `CommissionStatus`.

## How

Synced from the live backend OpenAPI (`api.creem.io/open-api/json`, verified identical to `test-api.creem.io`). Applied surgically — **additive only, 0 deletions**:

- Only the 3 affiliate paths + 5 affiliate schemas were inserted.
- The manually-maintained standalone schemas that aren't part of the backend runtime spec (webhook event entities, `RefundEntity`, `DisputeEntity`, etc.) are **preserved untouched** — a wholesale overwrite would have dropped them.
- Ran repo prettier on `openapi.json`, then copied to `packages/docs/api-reference/openapi.json` (the `gen:sdk` convention).

## Notes

- I did **not** run `speakeasy run` locally — the `Speakeasy SDK Generation` workflow triggers on push to `main` touching `packages/creem-sdk/openapi.json` and opens the SDK regen PR automatically.
- Affiliate operations already carry inline `x-speakeasy-name-override` (list / retrieve / listCommissions) and derive their group from the `Affiliates` tag, so no overlay changes were needed.
- All `$ref`s resolve against existing schemas (`PaginationEntity`, `EnvironmentMode`) — nothing dangling.

## Verification

- Both `openapi.json` files parse as valid JSON.
- Diff confirmed additive: `git diff --numstat` → `398 insertions, 0 deletions` per file; no non-affiliate path/schema touched.
- Live spec cross-checked prod vs test — identical.