### PR TITLE
docs: add Remote Digital File-Sharing Services and Cyberlockers to prohibited products

### DIFF
--- a/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
+++ b/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
@@ -115,6 +115,7 @@ We review accounts to ensure stores are legitimate and in compliance with our te
   - Donations or charity giving where no product exists or where the price is greater than the product value
   - Products or content for which you do not hold a proper license or intellectual property rights
   - Third-party content downloaders and rippers that violate platform Terms of Service
+  - Remote digital file-sharing services and cyberlockers
   - Marketplaces where you use your Creem store to partner to sell others' products
   - Dating sites
   - PLR or MRR products where you do not hold the original IP rights


### PR DESCRIPTION
Adds `Remote digital file-sharing services and cyberlockers` to the prohibited products list in the Account Reviews docs.

**File:** `packages/docs/merchant-of-record/account-reviews/account-reviews.mdx`

Placed next to the related "third-party content downloaders and rippers" entry. Requested by Toms.