### PR TITLE
docs: add metaphysical services to prohibited products

### DIFF
--- a/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
+++ b/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
@@ -122,6 +122,7 @@ We review accounts to ensure stores are legitimate and in compliance with our te
   - Counterfeit goods
   - Illegal or age-restricted products such as drugs, alcohol, tobacco, vaping products, or weapons
   - Regulated services such as gambling, lending, telemarketing, debt relief, or banking/financing services
+  - Metaphysical, fortune-telling, and spiritual outcome services
   - Timeshares
   - Pharmacies, pharmaceuticals, and nutraceuticals
   - Homework/essay mills


### PR DESCRIPTION
## Summary
- Add a single public-doc prohibited-products bullet for metaphysical, fortune-telling, and spiritual outcome services.

## Testing
- Not run; docs-only one-line MDX change.