### PR TITLE
docs: [NO-TASK] fix "Affilliates" typo in Affonso integration page title

### DIFF
--- a/packages/docs/integrations/affiliates.mdx
+++ b/packages/docs/integrations/affiliates.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Affilliates'
+title: 'Affiliates'
 description: 'Create affiliate programs while processing transactions through Creem.'
 ---
 


### PR DESCRIPTION
One-character fix: the Affonso integration page frontmatter title read "Affilliates" (double l). Reported by an external contributor in PR #149 discussion. Only occurrence in the docs.