### PR TITLE
docs: add Rekomi to Community Resources integrations table

### DIFF
--- a/packages/docs/code/community/community-resources.mdx
+++ b/packages/docs/code/community/community-resources.mdx
@@ -118,6 +118,7 @@ Third-party platforms and services that integrate directly with Creem to extend 
 | Name | Category | Description | Link | 
 | ---- | -------- | ----------- | ---- |
 | [Evendeals](/integrations/evendeals) | Purchase Parity | Adjust prices based on visitor location to boost international conversions by up to 30%. | [Website](https://www.evendeals.com) |
+| [Rekomi](/integrations/rekomi) | Affiliate Marketing | Run an affiliate program for your Creem products: automatic referral tracking, refund-aware commissions, and affiliate payouts with tax forms handled in 150+ countries. | [Website](https://rekomi.com) |
 
 ---
 


### PR DESCRIPTION
Tiny follow-up to #149, which is now live at https://docs.creem.io/integrations/rekomi: adds a one-row entry for Rekomi to the Integrations table on the Community Resources page, matching the existing Evendeals row format.

Thanks again for merging the integration guide!

🤖 Generated with [Claude Code](https://claude.com/claude-code)