### PR TITLE
docs: add Referral Program page to Features nav

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -154,6 +154,7 @@
               "features/seat-based-billing",
               "features/split-payments",
               "features/affiliate-program",
+              "features/referral-program",
               "features/storefronts",
               "features/discounts",
               "features/trials",


### PR DESCRIPTION
## What

Adds `features/referral-program` to the **Features** navigation group in `packages/docs/docs.json`.

## Why

The Referral Program page (`packages/docs/features/referral-program.mdx`) already exists and renders live at [docs.creem.io/features/referral-program](https://docs.creem.io/features/referral-program), but it was orphaned — not listed anywhere in the sidebar nav, so it was unreachable from the menu.

## Change

Single-line addition, placed next to its sibling `features/affiliate-program`:

```diff
               "features/affiliate-program",
+              "features/referral-program",
               "features/storefronts",
```

No content changes — the page `.mdx` already exists. `docs.json` validated as well-formed JSON.