### PR TITLE
docs: add online traffic engagement prohibition

### DIFF
--- a/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
+++ b/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
@@ -110,6 +110,7 @@ We review accounts to ensure stores are legitimate and in compliance with our te
   - Sexually-oriented or pornographic content of any kind, including AI-generated content and NSFW chatbots
   - Face-swap, deepfake, and face-manipulation tools of any kind
   - IPTV services
+  - Online traffic and engagement services
   - Physical goods of any kind
   - Spyware or parental control apps
   - Donations or charity giving where no product exists or where the price is greater than the product value


### PR DESCRIPTION
## Summary
- Add Online traffic and engagement services to the prohibited products list in public docs.

## Validation
- `pnpm --filter ./packages/docs run validate`
- `git diff --check`

Note: targeted Prettier check currently reports existing formatting differences in this MDX file; I left formatting untouched to keep the diff to the policy line.