### PR TITLE
chore(skills): serve the plugin marketplace from the repo root

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,17 +2,17 @@
   "name": "creem-skills",
   "owner": {
     "name": "Creem",
-    "email": "support@creem.io"
+    "email": "support@creem.io",
+    "url": "https://creem.io"
   },
   "metadata": {
     "description": "Official Creem payment integration skills for AI coding assistants",
-    "version": "1.0.0",
-    "pluginRoot": ".."
+    "version": "1.0.0"
   },
   "plugins": [
     {
       "name": "creem-api",
-      "source": "./creem-api",
+      "source": "./packages/docs/skills/creem-api",
       "description": "Integrate Creem payment infrastructure for checkouts, subscriptions, licenses, and webhooks. Complete API reference with implementation patterns.",
       "version": "1.0.0",
       "author": {
@@ -20,7 +20,7 @@
         "email": "support@creem.io"
       },
       "homepage": "https://docs.creem.io/code/sdks/ai-agents",
-      "repository": "https://github.com/armitage-labs/creem-skills",
+      "repository": "https://github.com/armitage-labs/creem",
       "license": "MIT",
       "keywords": [
         "payments",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,11 @@ jobs:
 
       - name: Format check
         run: pnpm format:check
+
+      # The skill is distributed as a Claude Code plugin from this repo's root
+      # marketplace manifest. A broken manifest or a moved plugin path silently
+      # ships a skill nobody can install, so validate both on every PR.
+      - name: Validate plugin marketplace
+        run: |
+          npx -y @anthropic-ai/claude-code@latest plugin validate .
+          npx -y @anthropic-ai/claude-code@latest plugin validate ./packages/docs/skills/creem-api

--- a/packages/docs/ai/for-agents/skill-files.mdx
+++ b/packages/docs/ai/for-agents/skill-files.mdx
@@ -219,7 +219,7 @@ If you're an AI assistant reading this:
 If you're using Claude Code, you can install the skill with one command instead of manually downloading files:
 
 ```bash
-/plugin marketplace add armitage-labs/creem-skills
+/plugin marketplace add armitage-labs/creem
 /plugin install creem-api@creem-skills
 ```
 

--- a/packages/docs/ai/for-humans/getting-started.mdx
+++ b/packages/docs/ai/for-humans/getting-started.mdx
@@ -75,7 +75,7 @@ Your AI will periodically check your store and proactively ping you when somethi
 For Claude Code users, you can install the skill permanently:
 
 ```bash
-/plugin marketplace add armitage-labs/creem-skills
+/plugin marketplace add armitage-labs/creem
 /plugin install creem-api@creem-skills
 ```
 
@@ -92,7 +92,7 @@ Now Claude Code has Creem knowledge in every conversation, no need to reference 
 
     **Option 2: Install the skill permanently**
     ```bash
-    /plugin marketplace add armitage-labs/creem-skills
+    /plugin marketplace add armitage-labs/creem
     /plugin install creem-api@creem-skills
     ```
   </Accordion>

--- a/packages/docs/code/sdks/ai-agents.mdx
+++ b/packages/docs/code/sdks/ai-agents.mdx
@@ -52,22 +52,22 @@ A skill is a structured set of instructions and reference materials that AI assi
 
 <CardGroup cols={3}>
   <Card title="Claude Code (Recommended)" icon="terminal">
-    One-line install via the plugin marketplace: `/plugin marketplace add
-    armitage-labs/creem`
+    One-line install via the plugin marketplace: `/plugin marketplace add armitage-labs/creem`
   </Card>
   <Card
     title="GitHub Repository"
     icon="github"
-    href="https://github.com/armitage-labs/creem"
+    href="https://github.com/armitage-labs/creem/tree/main/packages/docs/skills/creem-api"
   >
-    Clone, fork, or download the skill files directly
+    Browse or fork the skill files directly
   </Card>
   <Card
-    title="Download ZIP"
+    title="Any Other Tool"
     icon="download"
-    href="https://github.com/armitage-labs/creem/archive/refs/heads/main.zip"
+    href="https://github.com/armitage-labs/creem/tree/main/packages/docs/skills/creem-api"
   >
-    Download as a ZIP file for manual setup
+    Copy the folder into your project: `npx degit armitage-labs/creem/packages/docs/skills/creem-api
+    creem-skill`
   </Card>
 </CardGroup>
 
@@ -210,10 +210,10 @@ Cursor supports adding context through multiple methods:
 
 **Option 1: Add to Project**
 
-1. Clone the skill repository into your project:
+1. Pull just the skill directory into your project:
 
    ```bash
-   git clone https://github.com/armitage-labs/creem.git .cursor/skills
+   npx degit armitage-labs/creem/packages/docs/skills/creem-api .cursor/skills/creem-api
    ```
 
 2. Reference the skill files in your conversations using `@` mentions:
@@ -249,10 +249,10 @@ Add the Creem documentation to Cursor's docs:
 
 Windsurf supports custom knowledge through its Cascade feature:
 
-1. Clone the skill repository:
+1. Pull just the skill directory:
 
    ```bash
-   git clone https://github.com/armitage-labs/creem.git .windsurf/creem
+   npx degit armitage-labs/creem/packages/docs/skills/creem-api .windsurf/creem
    ```
 
 2. Add to your project's knowledge base in Windsurf settings
@@ -269,8 +269,13 @@ Windsurf supports custom knowledge through its Cascade feature:
 
 For other AI coding assistants (GitHub Copilot Chat, Cody, Continue, etc.):
 
-1. **Download the skill files** from the GitHub repository
-2. **Add to your project** in a dedicated folder (e.g., `.ai/creem/`)
+1. **Pull the skill files** into a dedicated folder:
+
+   ```bash
+   npx degit armitage-labs/creem/packages/docs/skills/creem-api .ai/creem
+   ```
+
+2. **Add that folder** to your tool's context or knowledge base
 3. **Reference in context** when asking questions about Creem integration
 4. **Copy relevant sections** into your conversation when needed
 
@@ -482,11 +487,7 @@ The Creem skill is designed for **direct API integration** and complements our S
 Found an issue or want to improve the skill? We welcome contributions:
 
 <CardGroup cols={2}>
-  <Card
-    title="Report Issues"
-    icon="bug"
-    href="https://github.com/armitage-labs/creem/issues"
-  >
+  <Card title="Report Issues" icon="bug" href="https://github.com/armitage-labs/creem/issues">
     Found a bug or incorrect information? Let us know
   </Card>
   <Card
@@ -503,11 +504,7 @@ Found an issue or want to improve the skill? We welcome contributions:
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card
-    title="Install the Skill"
-    icon="terminal"
-    href="https://github.com/armitage-labs/creem"
-  >
+  <Card title="Install the Skill" icon="terminal" href="https://github.com/armitage-labs/creem">
     Run `/plugin marketplace add armitage-labs/creem` in Claude Code
   </Card>
   <Card title="API Reference" icon="book" href="/api-reference/introduction">

--- a/packages/docs/code/sdks/ai-agents.mdx
+++ b/packages/docs/code/sdks/ai-agents.mdx
@@ -10,7 +10,7 @@ AI coding assistants like Claude Code, Cursor, and Windsurf are transforming how
 Install the Creem skill with a single command:
 
 ```bash
-/plugin marketplace add armitage-labs/creem-skills
+/plugin marketplace add armitage-labs/creem
 ```
 
 Then install the skill using either method:
@@ -53,19 +53,19 @@ A skill is a structured set of instructions and reference materials that AI assi
 <CardGroup cols={3}>
   <Card title="Claude Code (Recommended)" icon="terminal">
     One-line install via the plugin marketplace: `/plugin marketplace add
-    armitage-labs/creem-skills`
+    armitage-labs/creem`
   </Card>
   <Card
     title="GitHub Repository"
     icon="github"
-    href="https://github.com/armitage-labs/creem-skills"
+    href="https://github.com/armitage-labs/creem"
   >
     Clone, fork, or download the skill files directly
   </Card>
   <Card
     title="Download ZIP"
     icon="download"
-    href="https://github.com/armitage-labs/creem-skills/archive/refs/heads/main.zip"
+    href="https://github.com/armitage-labs/creem/archive/refs/heads/main.zip"
   >
     Download as a ZIP file for manual setup
   </Card>
@@ -153,7 +153,7 @@ Claude Code's plugin marketplace makes installation effortless:
   <Step title="Add the Marketplace">
     Open Claude Code and run:
     ```bash
-    /plugin marketplace add armitage-labs/creem-skills
+    /plugin marketplace add armitage-labs/creem
     ```
   </Step>
   <Step title="Install the Skill">
@@ -199,7 +199,7 @@ Claude Code's plugin marketplace makes installation effortless:
 If you prefer not to use the marketplace, you can reference the skill directly in any conversation:
 
 ```
-Help me integrate Creem payments. Use the skill at https://github.com/armitage-labs/creem-skills
+Help me integrate Creem payments. Use the skill at https://github.com/armitage-labs/creem
 ```
 
 ---
@@ -213,7 +213,7 @@ Cursor supports adding context through multiple methods:
 1. Clone the skill repository into your project:
 
    ```bash
-   git clone https://github.com/armitage-labs/creem-skills.git .cursor/skills
+   git clone https://github.com/armitage-labs/creem.git .cursor/skills
    ```
 
 2. Reference the skill files in your conversations using `@` mentions:
@@ -252,7 +252,7 @@ Windsurf supports custom knowledge through its Cascade feature:
 1. Clone the skill repository:
 
    ```bash
-   git clone https://github.com/armitage-labs/creem-skills.git .windsurf/creem
+   git clone https://github.com/armitage-labs/creem.git .windsurf/creem
    ```
 
 2. Add to your project's knowledge base in Windsurf settings
@@ -485,14 +485,14 @@ Found an issue or want to improve the skill? We welcome contributions:
   <Card
     title="Report Issues"
     icon="bug"
-    href="https://github.com/armitage-labs/creem-skills/issues"
+    href="https://github.com/armitage-labs/creem/issues"
   >
     Found a bug or incorrect information? Let us know
   </Card>
   <Card
     title="Contribute"
     icon="code-pull-request"
-    href="https://github.com/armitage-labs/creem-skills/pulls"
+    href="https://github.com/armitage-labs/creem/pulls"
   >
     Submit improvements or new workflow examples
   </Card>
@@ -506,9 +506,9 @@ Found an issue or want to improve the skill? We welcome contributions:
   <Card
     title="Install the Skill"
     icon="terminal"
-    href="https://github.com/armitage-labs/creem-skills"
+    href="https://github.com/armitage-labs/creem"
   >
-    Run `/plugin marketplace add armitage-labs/creem-skills` in Claude Code
+    Run `/plugin marketplace add armitage-labs/creem` in Claude Code
   </Card>
   <Card title="API Reference" icon="book" href="/api-reference/introduction">
     Explore the full API documentation

--- a/packages/docs/skills/README.md
+++ b/packages/docs/skills/README.md
@@ -81,10 +81,10 @@ Help me integrate Creem payments. Use the skill at https://github.com/armitage-l
 
 ### Cursor
 
-1. Clone the skill repository into your project:
+1. Pull just the skill directory into your project:
 
    ```bash
-   git clone https://github.com/armitage-labs/creem.git .cursor/skills
+   npx degit armitage-labs/creem/packages/docs/skills/creem-api .cursor/skills/creem-api
    ```
 
 2. Reference the skill files in your conversations using `@` mentions:
@@ -94,10 +94,10 @@ Help me integrate Creem payments. Use the skill at https://github.com/armitage-l
 
 ### Windsurf
 
-1. Clone the skill repository:
+1. Pull just the skill directory:
 
    ```bash
-   git clone https://github.com/armitage-labs/creem.git .windsurf/creem
+   npx degit armitage-labs/creem/packages/docs/skills/creem-api .windsurf/creem
    ```
 
 2. Add to your project's knowledge base in Windsurf settings
@@ -106,7 +106,10 @@ Help me integrate Creem payments. Use the skill at https://github.com/armitage-l
 
 Most AI coding assistants support adding custom context. You can:
 
-1. Clone this repository into your project
+1. Pull the skill folder into your project:
+   ```bash
+   npx degit armitage-labs/creem/packages/docs/skills/creem-api .ai/creem
+   ```
 2. Add the files to your AI tool's context or knowledge base
 3. Reference the OpenAPI specification (`api-reference/openapi.json`) for structured API information
 

--- a/packages/docs/skills/README.md
+++ b/packages/docs/skills/README.md
@@ -7,7 +7,7 @@ Official Creem payment integration skills for AI coding assistants like Claude C
 Install the Creem skill with two simple commands:
 
 ```bash
-/plugin marketplace add armitage-labs/creem-skills
+/plugin marketplace add armitage-labs/creem
 /plugin install creem-api@creem-skills
 ```
 
@@ -46,7 +46,7 @@ A comprehensive skill for integrating the CREEM REST API. Covers:
 
 ```bash
 # Add the marketplace
-/plugin marketplace add armitage-labs/creem-skills
+/plugin marketplace add armitage-labs/creem
 
 # Install the skill
 /plugin install creem-api@creem-skills
@@ -76,7 +76,7 @@ A comprehensive skill for integrating the CREEM REST API. Covers:
 Reference the skill in any conversation:
 
 ```
-Help me integrate Creem payments. Use the skill at https://github.com/armitage-labs/creem-skills
+Help me integrate Creem payments. Use the skill at https://github.com/armitage-labs/creem
 ```
 
 ### Cursor
@@ -84,7 +84,7 @@ Help me integrate Creem payments. Use the skill at https://github.com/armitage-l
 1. Clone the skill repository into your project:
 
    ```bash
-   git clone https://github.com/armitage-labs/creem-skills.git .cursor/skills
+   git clone https://github.com/armitage-labs/creem.git .cursor/skills
    ```
 
 2. Reference the skill files in your conversations using `@` mentions:
@@ -97,7 +97,7 @@ Help me integrate Creem payments. Use the skill at https://github.com/armitage-l
 1. Clone the skill repository:
 
    ```bash
-   git clone https://github.com/armitage-labs/creem-skills.git .windsurf/creem
+   git clone https://github.com/armitage-labs/creem.git .windsurf/creem
    ```
 
 2. Add to your project's knowledge base in Windsurf settings

--- a/packages/docs/skills/creem-api/.claude-plugin/plugin.json
+++ b/packages/docs/skills/creem-api/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
     "email": "support@creem.io"
   },
   "homepage": "https://docs.creem.io/code/sdks/ai-agents",
-  "repository": "https://github.com/armitage-labs/creem-skills",
+  "repository": "https://github.com/armitage-labs/creem",
   "license": "MIT",
   "keywords": [
     "payments",


### PR DESCRIPTION
## Why

The `creem-api` skill is **maintained in this repo** (`packages/docs/skills/creem-api/`) but **distributed from `armitage-labs/creem-skills`** — a hand-copied January snapshot that no CI job has ever updated.

The two have diverged by **924 lines**:

| File | Diverged lines |
|---|---|
| `REFERENCE.md` | 161 |
| `WEBHOOKS.md` | 400 |
| `WORKFLOWS.md` | 363 |

Most visibly, the published copy has **no `subscription.past_due`** — the event we shipped in July. Merchants who follow our documented install command get the January skill, and an AI reading a stale skill confidently builds a stale integration.

This was raised by a merchant in a customer interview on 2026-08-12. He was right, though not for the reason he thought: the skill isn't neglected, it's just never shipped.

## What this does

A marketplace manifest is only discoverable at the **repository root**, so this moves it there and lets this repo serve the marketplace directly — same repo as the SDKs and docs, same CI, so the skill can't drift from the platform again.

- `.claude-plugin/marketplace.json` moves to the root; `source` resolves to `./packages/docs/skills/creem-api`
- Drops `"pluginRoot": ".."` — the docs explicitly advise against `../` outside the marketplace root
- `plugin.json` `repository` → `armitage-labs/creem`
- Docs install command → `/plugin marketplace add armitage-labs/creem`
- CI runs `claude plugin validate` on both manifests, so a broken manifest or a moved plugin path can't silently ship an uninstallable skill

## Not a breaking change

The marketplace **name** stays `creem-skills`. Unchanged for existing users:

```
/plugin install creem-api@creem-skills
/plugin marketplace update creem-skills
/plugin disable|enable|uninstall creem-api@creem-skills
```

Only the one-time `marketplace add` target moves.

## Verification

`claude plugin validate` passes on both manifests, plus a real install from a local checkout:

```
✔ Successfully added marketplace: creem-skills
✔ Successfully installed plugin: creem-api@creem-skills
```

All four files (`SKILL.md`, `REFERENCE.md`, `WEBHOOKS.md`, `WORKFLOWS.md`) land in the plugin cache with frontmatter intact.

No changeset needed — `changeset-check` only watches `packages/*/src/**` and `packages/*/package.json`.

## Follow-up (separate PR, `armitage-labs/creem-skills`)

Replace that repo's `marketplace.json` with a single `git-subdir` entry pointing at `packages/docs/skills/creem-api` here. Everyone who already ran `/plugin marketplace add armitage-labs/creem-skills` then resolves to this tree on their next `/plugin marketplace update` — the stale copy self-heals and drift becomes structurally impossible.