### PR TITLE
fix(docs): correct the webhook retry schedule to match the code

### DIFF
--- a/packages/docs/api-reference/introduction.mdx
+++ b/packages/docs/api-reference/introduction.mdx
@@ -132,7 +132,7 @@ await verifyWebhookSignature(rawBody, request.headers, {
 | `refund.created`                | A refund was issued                                        |
 | `dispute.created`               | A dispute was opened by a customer                         |
 
-**Retry policy:** If your endpoint doesn't respond with HTTP 200, Creem retries at 30 seconds, 1 minute, 5 minutes, and 1 hour. You can also resend events manually from the dashboard.
+**Retry policy:** If your endpoint doesn't respond with HTTP 200, Creem retries at 30 seconds, 5 minutes, 30 minutes, and 6 hours — 5 attempts in total, and never after 24 hours. The same event can arrive more than once, so keep your handler idempotent. You can also resend events manually from the dashboard.
 
 <Card title="Full Webhooks Guide" icon="webhook" href="/code/webhooks">
   Detailed setup instructions, signature verification, and event payload examples.

--- a/packages/docs/code/webhooks.mdx
+++ b/packages/docs/code/webhooks.mdx
@@ -12,7 +12,7 @@ Creem uses webhooks to push real-time notifications to you about your payments a
 - Automatically remove access to a user after a canceled subscription
 - Confirm that a payment has been received by the same customer that initiated it.
 
-In case webhooks are not successfully received by your endpoint, Creem automatically retries to send the request with a progressive backoff period of 30 seconds, 1 minute, 5 minutes and 1 hour. You can also resend webhook events manually from your Merchant dashboard under [Developers section](https://creem.io/dashboard/developers).
+In case webhooks are not successfully received by your endpoint, Creem automatically retries the request with a progressive backoff. There are 5 attempts in total — the initial delivery, then retries after 30 seconds, 5 minutes, 30 minutes and 6 hours. Events are not retried after 24 hours, even if attempts remain. Because the same event can be delivered more than once, your handler should be idempotent. You can also resend webhook events manually from your Merchant dashboard under [Developers section](https://creem.io/dashboard/developers).
 
 ## Steps to receive a webhook
 

--- a/packages/docs/skills/creem-api/WEBHOOKS.md
+++ b/packages/docs/skills/creem-api/WEBHOOKS.md
@@ -71,15 +71,22 @@ function verifySignature(rawBody: string, signature: string, secret: string): bo
 
 ## Retry Policy
 
-If your endpoint doesn't respond with HTTP 200, CREEM retries with exponential backoff:
+If your endpoint doesn't respond with HTTP 200, CREEM retries with progressive backoff. There are **5 attempts in total** — the initial delivery plus 4 retries:
 
-1. Initial attempt
-2. 30 seconds later
-3. 1 minute later
-4. 5 minutes later
-5. 1 hour later
+| Attempt | Sent after the previous one |
+| ------- | --------------------------- |
+| 1       | Initial delivery            |
+| 2       | 30 seconds                  |
+| 3       | 5 minutes                   |
+| 4       | 30 minutes                  |
+| 5       | 6 hours                     |
 
-After all retries fail, the event is marked as failed. You can manually resend from the dashboard.
+Events are **not retried after 24 hours**, even if attempts remain. Once retries are exhausted the event is marked failed, and you can resend it manually from the dashboard.
+
+Two things to design around:
+
+- Retries mean your handler **must be idempotent** — the same event `id` can arrive more than once.
+- The final retry can land roughly 6.5 hours after the event. Don't assume delivery within minutes, and anchor purchase time on `object.order.created_at` rather than when you received the event.
 
 ## Event Structure
 


### PR DESCRIPTION
## The bug

Three places documented the webhook retry schedule as **30s / 1min / 5min / 1hr**. That is not what the code does.

`apps/core/src/modules/outbound-webhook/webhook.constants.ts` (backend):

| Attempt | Delay after previous |
|---|---|
| 1 | initial delivery |
| 2 | 30 seconds |
| 3 | 5 minutes |
| 4 | 30 minutes |
| 5 | 6 hours |

`WEBHOOK_MAX_ATTEMPTS = 5`, and `WEBHOOK_MAX_AGE_MS = 24h` — delivery is abandoned after a day even if attempts remain.

## Why it matters

Two facts were documented nowhere:

- **The 24-hour ceiling.**
- **The last retry can land ~6.5 hours after the event.** Merchants read "1 hour" and sized their expectations to "delivered within the hour," so a late delivery looked like a platform failure.

A merchant reported this in a customer interview on 2026-08-12. His words: *"did I break something or did you guys break something?"* He had observed roughly +1min / +6min / +30min in test mode — his observations matched the **code**, and both documents were wrong.

## Changes

Corrected in all three places (the third wasn't in the original report — found by sweeping):

- `packages/docs/skills/creem-api/WEBHOOKS.md` — the AI skill
- `packages/docs/code/webhooks.mdx` — the webhooks guide
- `packages/docs/api-reference/introduction.mdx` — the API reference

Also adds the consequence that follows from retries and was never stated: **the same event `id` can arrive more than once, so handlers must be idempotent.** And a pointer to anchor purchase time on `object.order.created_at` rather than receipt time.

## Related

- armitage-labs/creem#165 — serves the marketplace from the repo root so merchants stop installing a stale skill
- `pugpay-monorepo` — separate PR fixes the dashboard's "Send test event" dropping `license_keys[]`

## Follow-up worth doing

Nothing prevents this from drifting again. `packages/webhook-types/src/events.ts` is public, in this repo, and machine-readable; a CI check asserting the docs' event list and retry constants match source would have caught this. Same pattern as the backend's existing exhaustive `Record<WebhookEventType, string>` test.