### PR TITLE
docs(mcp): document the MCP server and put it in the nav

### DIFF
--- a/packages/docs/ai/for-agents/mcp-server.mdx
+++ b/packages/docs/ai/for-agents/mcp-server.mdx
@@ -1,0 +1,136 @@
+---
+title: MCP Server
+description: Give your AI agent 49 tools that call the Creem API directly, over the Model Context Protocol.
+---
+
+The Creem TypeScript SDK ships an [MCP](https://modelcontextprotocol.io) server. Point Claude Code, Claude Desktop, Cursor or any MCP client at it and your agent can create products, open checkouts, manage subscriptions, issue refunds and inspect your store — by calling the real API, with your key.
+
+<Tip>
+**Skill files vs MCP server.** [Skill files](/ai/for-agents/skill-files) are reference material your agent *reads* — they teach it how Creem works. The MCP server is a set of tools your agent *runs* — it changes live data. Most teams want both.
+</Tip>
+
+## Requirements
+
+- **Node.js v22 or newer**
+- A Creem API key ([test or live](/getting-started/test-mode))
+
+Nothing to install: `npx` fetches the `creem` package on demand.
+
+## Quickstart
+
+```bash
+npx -y --package creem -- mcp start --api-key creem_test_your_key --server test
+```
+
+The server speaks MCP over stdio and exits when the client disconnects.
+
+<Warning>
+**Test-mode keys require `--server test`.** Without it the SDK targets production, and every tool call fails with `401 Unauthorized — Invalid API Key`, even though your key is valid. This is the single most common setup problem.
+</Warning>
+
+## Claude Code
+
+```bash
+claude mcp add creem -- npx -y --package creem -- mcp start --api-key creem_test_your_key --server test
+```
+
+## Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "Creem": {
+      "command": "npx",
+      "args": [
+        "-y", "--package", "creem", "--",
+        "mcp", "start",
+        "--api-key", "creem_test_your_key",
+        "--server", "test"
+      ]
+    }
+  }
+}
+```
+
+## Cursor
+
+Add the same block to `.cursor/mcp.json` in your project, or to `~/.cursor/mcp.json` for every project.
+
+## Available tools
+
+49 tools, covering the API surface.
+
+| Group | Count | Tools |
+|-------|-------|-------|
+| **Products** | 5 | `products-create`, `products-get`, `products-update`, `products-search`, `products-archive` |
+| **Checkouts** | 2 | `checkouts-create`, `checkouts-retrieve` |
+| **Customers** | 8 | `customers-create`, `customers-retrieve`, `customers-update`, `customers-list`, `customers-get-orders`, `customers-list-subscriptions`, `customers-list-licenses`, `customers-generate-billing-links` |
+| **Subscriptions** | 7 | `subscriptions-get`, `subscriptions-search`, `subscriptions-update`, `subscriptions-upgrade`, `subscriptions-cancel`, `subscriptions-pause`, `subscriptions-resume` |
+| **Transactions** | 3 | `transactions-get-by-id`, `transactions-search`, `transactions-refund` |
+| **Discounts** | 4 | `discounts-create`, `discounts-get`, `discounts-search`, `discounts-delete` |
+| **Licenses** | 4 | `licenses-activate`, `licenses-deactivate`, `licenses-validate`, `licenses-list-instances` |
+| **Customer credits** | 11 | `customer-credits-create-account`, `-get-account`, `-get-account-balance`, `-list-accounts`, `-list-entries`, `-credit-account`, `-debit-account`, `-freeze-account`, `-unfreeze-account`, `-reverse-transaction`, `-close-account` |
+| **Affiliates** | 3 | `affiliates-list`, `affiliates-retrieve`, `affiliates-list-commissions` |
+| **Stats** | 1 | `stats-get-summary` |
+| **Moderation** | 1 | `moderation-screen-prompt` |
+
+## Security
+
+<Warning>
+An API key grants an agent **every** tool, including destructive ones — `transactions-refund`, `subscriptions-cancel`, `products-archive`, `discounts-delete` and `customer-credits-debit-account`. There are no read-only or scoped keys today.
+</Warning>
+
+Two things to do about that:
+
+**Develop against test mode.** Use a test key while you build. Nothing you break is real.
+
+**Mount only the tools you need.** `--tool` is repeatable and limits what the server exposes:
+
+```bash
+npx -y --package creem -- mcp start \
+  --api-key creem_test_your_key --server test \
+  --tool products-search --tool customers-list --tool stats-get-summary
+```
+
+This is a client-side allowlist, not a credential restriction — anyone who can edit the config can remove it. Treat the API key itself as the real boundary.
+
+## Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--api-key` | Your Creem API key | — |
+| `--server` | `prod` or `test` — **use `test` for test keys** | `prod` |
+| `--server-url` | Override the API base URL entirely | — |
+| `--transport` | `stdio` or `sse` | `stdio` |
+| `--port` | Port, when `--transport sse` | `2718` |
+| `--tool` | Mount only this tool; repeatable | all 49 |
+| `--log-level` | `debug`, `info`, `warning`, `error` | `info` |
+| `--env` | Extra environment variables for the server | — |
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Every call returns 401 Invalid API Key">
+    You're using a test key without `--server test`, so requests go to production. Add the flag and restart your MCP client.
+  </Accordion>
+
+  <Accordion title="The server doesn't start">
+    Check `node --version` — v22 or newer is required. Then run the command directly in a terminal; MCP clients often swallow startup errors.
+  </Accordion>
+
+  <Accordion title="My agent can't see the tools">
+    Restart the MCP client after editing its config — most read it only at launch. Then confirm the server is listed and connected in your client's MCP settings.
+  </Accordion>
+
+  <Accordion title="I want to see what the agent is doing">
+    Start with `--log-level debug` and check your client's MCP logs.
+  </Accordion>
+</AccordionGroup>
+
+## Related
+
+- [Skill files](/ai/for-agents/skill-files) — reference material your agent reads
+- [CLI for agents](/ai/for-agents/cli) — scriptable, `--json` output
+- [TypeScript SDK](/code/sdks/typescript) — the package this server ships in

--- a/packages/docs/code/mcp.mdx
+++ b/packages/docs/code/mcp.mdx
@@ -1,8 +1,0 @@
----
-title: 'MCP'
-description: 'Model Context Protocol integration'
----
-
-# MCP
-
-Documentation coming soon.

--- a/packages/docs/code/sdks/ai-agents.mdx
+++ b/packages/docs/code/sdks/ai-agents.mdx
@@ -34,6 +34,12 @@ Then install the skill using either method:
   licenses.
 </Tip>
 
+<Note>
+  The skill teaches your assistant how Creem works. If you also want it to **act** — create products,
+  open checkouts, cancel subscriptions — add the [MCP server](/ai/for-agents/mcp-server), which
+  exposes 49 API tools from the same `creem` package.
+</Note>
+
 ---
 
 ## What is a Skill?

--- a/packages/docs/code/sdks/typescript.mdx
+++ b/packages/docs/code/sdks/typescript.mdx
@@ -21,7 +21,7 @@ The `creem` package is the official TypeScript SDK for the Creem API, providing:
 - **Configurable retry strategies** with backoff options
 - **Custom HTTP client** support
 - **Environment selection** for production and test environments
-- **MCP server support** for AI applications (Claude, Cursor)
+- **[MCP server](/ai/for-agents/mcp-server)** bundled in this package — 49 tools for Claude, Cursor and other MCP clients
 - **Debug logging** for development
 
 ---

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -73,6 +73,10 @@
     {
       "source": "/api-reference/endpoint/close-customer-credits-account",
       "destination": "/api-reference/endpoint/close-credits-account"
+    },
+    {
+      "source": "/code/mcp",
+      "destination": "/ai/for-agents/mcp-server"
     }
   ],
   "theme": "mint",
@@ -120,6 +124,7 @@
                 "group": "For Agents",
                 "pages": [
                   "ai/for-agents/skill-files",
+                  "ai/for-agents/mcp-server",
                   "ai/for-agents/cli",
                   "ai/for-agents/store-monitoring"
                 ]


### PR DESCRIPTION
## Why

The `creem` SDK has shipped an MCP server since March. The only docs page was `code/mcp.mdx` — *"Documentation coming soon."* — and it wasn't in `docs.json`, so nothing linked to it. The single discoverable mention was one bullet on the TypeScript SDK page.

Nine teams at a customer session this week asked whether we were *planning* an MCP. It's been installable the whole time.

## What

- **New page `ai/for-agents/mcp-server`**, in the nav directly after skill files — install for Claude Code / Claude Desktop / Cursor, all 49 tools by group, full flag reference, troubleshooting.
- **Leads with the `--server test` trap.** A valid test key without that flag hits production and returns `401 Invalid API Key` on every call, which reads as a broken product. Arguably `mcp start` should infer the environment from the key prefix — out of scope here, worth its own issue.
- **Security stated plainly:** one API key exposes all 49 tools, including `transactions-refund`, `subscriptions-cancel` and `customer-credits-debit-account`. No scoped keys exist; `--tool` is a client-side allowlist, not a boundary.
- Deletes the orphan stub and redirects `/code/mcp` → the new page.
- Cross-links from the TypeScript SDK page and the AI Agents page, drawing the line between the **skill** (reference the agent reads) and the **MCP server** (tools the agent runs) — people conflate these constantly.

## Verification

Facts came from the published package, not the source tree:

- `npx -y --package creem -- mcp start` over stdio → server reports `Creem` v1.6.0, advertises **exactly 49 tools**
- Authenticated read calls (`products-search`, `stats-get-summary`) return live data with `--server test`
- The same calls return `401` without it — that's how the warning got written
- Flag table taken from `mcp start --help`
- All internal links resolve to existing pages

## Note for reviewers

Separately, the `creem-api` **skill** plugin currently installs but contributes no skill — `SKILL.md` sits at the plugin root instead of `skills/<name>/SKILL.md`. That's a distinct P1 and gets its own PR; this one is docs-only and unaffected.