### PR TITLE
docs(mcp): warn that "Connected" doesn't mean correctly configured

### DIFF
--- a/packages/docs/ai/for-agents/mcp-server.mdx
+++ b/packages/docs/ai/for-agents/mcp-server.mdx
@@ -109,11 +109,29 @@ This is a client-side allowlist, not a credential restriction — anyone who can
 | `--log-level` | `debug`, `info`, `warning`, `error` | `info` |
 | `--env` | Extra environment variables for the server | — |
 
+## Verifying it works
+
+<Warning>
+**A green "Connected" does not mean it's configured correctly.** `claude mcp list` — and the equivalent status in other clients — only confirms the server process started and completed the MCP handshake. It runs before any API call, so it passes even when the environment is wrong.
+
+A test key without `--server test` reports `✔ Connected` and then fails `401` on the first tool call.
+</Warning>
+
+Confirm with a real call instead. Ask your agent something harmless and read-only:
+
+```
+List my Creem products
+```
+
+If products come back, the key, environment and tools are all wired up. If you get a 401, see below.
+
 ## Troubleshooting
 
 <AccordionGroup>
   <Accordion title="Every call returns 401 Invalid API Key">
     You're using a test key without `--server test`, so requests go to production. Add the flag and restart your MCP client.
+
+    Note that your client will still have shown the server as connected — the health check can't see this.
   </Accordion>
 
   <Accordion title="The server doesn't start">


### PR DESCRIPTION
Follow-up to #167, from actually installing the server rather than trusting the page.

## What the test showed

I registered two MCP servers with the **same valid test key** — one with `--server test`, one without:

```
creem-smoketest: npx -y --package creem -- mcp start --api-key creem_test_… --server test  - ✔ Connected
creem-noflag:    npx -y --package creem -- mcp start --api-key creem_test_…                - ✔ Connected
```

Both green. The health check runs before any API call, so it only proves the process started and completed the MCP handshake. The misconfigured one fails `401` on its first tool call — after the client has already told the developer everything is fine.

That's worse than a hard failure. A green tick sends people looking at their agent, their prompt, their key — anywhere except the flag that's actually wrong.

## Change

- New **"Verifying it works"** section: states plainly that Connected ≠ configured, and gives a read-only check (*"List my Creem products"*) that exercises key + environment + tools in one go.
- The 401 accordion now notes the client will have shown the server as connected, so the symptom matches what the reader is looking at.

Docs-only. Also confirms the `claude mcp add` command from #167 works as written — that install path is now verified, not assumed.