### PR TITLE
docs(moderation): pricing is live, add usage-efficiency guidance

### DIFF
--- a/packages/docs/features/moderation.mdx
+++ b/packages/docs/features/moderation.mdx
@@ -345,24 +345,48 @@ If you see this error, the most likely causes are:
   </Step>
 </Steps>
 
+## Keep your usage efficient
+
+Billing is proportional to the text you send, so a few integration habits can
+cut your bill by half or more without weakening screening:
+
+- **Screen the user-supplied text, not your templates.** If your product wraps
+  user input in a reusable style or system template, screen only the part the
+  user controls — your own static boilerplate bills units on every call.
+- **Screen incrementally, not cumulatively.** For chat-style products, screen
+  each new user message as it arrives. Re-submitting the entire conversation
+  history on every turn re-bills everything you already screened.
+- **Don't add instructions for the moderator.** The Moderation API applies
+  Creem's content policies and does not accept custom policies or
+  instructions embedded in the prompt. A policy preamble inflates your bill
+  on every call, and explicit category language inside it can itself trigger
+  `deny` decisions on otherwise harmless requests.
+- **Avoid very large payloads.** Extremely large requests cannot be screened
+  reliably and may return `flag` rather than a real decision.
+
 ## Pricing
 
-The Moderation API is currently **free to use** while it is in its experimental
-phase. You don't need to worry about cost today — focus on integrating it
-correctly.
+Moderation API usage is billed at **$0.30 USD per 1,000 units** — the $30 per
+100,000 units we announced during the experimental phase. A unit covers up to
+1,000 characters of screened text, with a one-unit minimum per call. The
+`usage.units` field on every response tells you exactly what a call cost.
 
-When the product is officially released, the most likely launch price will be
-**$30 USD per 100,000 units**. Creem does not aim to make a profit margin on
-this product. We built the Moderation API because we want our merchants to
-succeed and because we are committed to a safe environment for everyone on the
-platform — pricing it is purely about covering the cost of running it.
+How billing works:
 
-<Note>
-  When official pricing rolls out, we **will not** retroactively charge for
-  usage that occurred during the experimental period. Anything you screen
-  today is on us. You can count on Creem's values of honest and fair pricing
-  — no surprise bills, no retroactive invoices.
-</Note>
+- **Fees are deducted from your payouts** as a separate line item
+  ("Moderation API usage fee") covering the units you screened since your
+  previous payout. There is no separate invoice and nothing is charged to a
+  card.
+- **Repeated prompts are free.** Screening results are cached — submitting a
+  prompt identical to a recently screened one returns the cached decision and
+  bills `0` units.
+- Usage from the experimental phase (before May 1, 2026) was never billed, as
+  promised.
+
+Creem does not aim to make a profit margin on this product. We built the
+Moderation API because we want our merchants to succeed and because we are
+committed to a safe environment for everyone on the platform — pricing covers
+the cost of running it.
 
 ## Related
 

--- a/packages/docs/guides/faq.mdx
+++ b/packages/docs/guides/faq.mdx
@@ -37,7 +37,7 @@ description: 'Answers to the most common questions about using Creem.'
 
     **You don't need it if** your product only does image upscaling, background removal, audio/music generation, text generation, or other non-generative tasks.
 
-    Integration is required starting May 1st, 2026. The API is currently free to use. See the [full documentation](/features/moderation) for code examples and a go-live checklist.
+    Integration is required starting May 1st, 2026. Usage is billed at $0.30 per 1,000 text units, deducted automatically from your payouts — see the [full documentation](/features/moderation) for pricing details, code examples, and a go-live checklist.
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
Moderation API billing is now live at the price announced during the experimental phase ($0.30 per 1,000 units, deducted from payouts).

- Replace the experimental-phase "free to use" pricing section with the live pricing and how fees are collected
- Add a short "Keep your usage efficient" section with integration tips
- Update the matching FAQ answer