### PR TITLE
docs(moderation): fix pricing paragraph rendering as LaTeX

### DIFF
--- a/packages/docs/features/moderation.mdx
+++ b/packages/docs/features/moderation.mdx
@@ -366,9 +366,8 @@ cut your bill by half or more without weakening screening:
 
 ## Pricing
 
-Moderation API usage is billed at **$0.30 USD per 1,000 units** — the $30 per
-100,000 units we announced during the experimental phase. A unit covers up to
-1,000 characters of screened text, with a one-unit minimum per call. The
+Moderation API usage is billed at **\$0.30 USD per 1,000 units**. A unit covers
+up to 1,000 characters of screened text, with a one-unit minimum per call. The
 `usage.units` field on every response tells you exactly what a call cost.
 
 How billing works:


### PR DESCRIPTION
The Pricing section on the Moderation page contained two unescaped dollar signs in the same paragraph, which Mintlify interprets as a LaTeX math delimiter pair and renders incorrectly.

- Drop the now-redundant experimental-phase price reference, leaving a single price mention
- Escape the remaining dollar sign as \$ (same convention used elsewhere in the docs)