### PR TITLE
docs: add trading tools and services to prohibited products

### DIFF
--- a/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
+++ b/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
@@ -130,6 +130,7 @@ We review accounts to ensure stores are legitimate and in compliance with our te
   - Multi-level marketing, pyramid, or IBO schemes
   - NFT & crypto asset products
   - In-game items, currencies, and virtual goods tied to third-party games
+  - Trading tools and services
   - Any other products that our providers and partners deem too risky
 </Accordion>
 


### PR DESCRIPTION
## Summary
- add **Trading tools and services** to the public prohibited products list
- keep detailed classification guidance internal

## Validation
- `git diff --check` passes
- the target page already fails its existing Prettier baseline; this PR introduces only the requested one-line policy change