### PR TITLE
docs: add Burundi, Chad, Republic of Congo, Eritrea and Iraq to unsupported purchase countries

### DIFF
--- a/packages/docs/merchant-of-record/supported-countries.mdx
+++ b/packages/docs/merchant-of-record/supported-countries.mdx
@@ -121,20 +121,25 @@ Some local bank payouts are subject to additional restrictions from our bank tra
 
 ### Unsupported Countries for Purchases
 
-<Accordion title="Unsupported countries (28 countries)">
+<Accordion title="Unsupported countries (32 countries)">
   <p>We cannot accept payments from customers or Merchants in the following countries:</p>
   <ul>
     <li>Afghanistan</li>
     <li>Antarctica</li>
     <li>Belarus</li>
     <li>Burma (Myanmar)</li>
+    <li>Burundi</li>
     <li>Central African Republic</li>
+    <li>Chad</li>
     <li>Cuba</li>
     <li>Crimea (Region of Ukraine)</li>
     <li>Democratic Republic of Congo</li>
+    <li>Republic of Congo</li>
     <li>Donetsk (Region of Ukraine)</li>
+    <li>Eritrea</li>
     <li>Haiti</li>
     <li>Iran</li>
+    <li>Iraq</li>
     <li>Kherson (Region of Ukraine)</li>
     <li>Libya</li>
     <li>Luhansk (Region of Ukraine)</li>


### PR DESCRIPTION
Adds 5 countries to the **Unsupported Countries for Purchases** list on `merchant-of-record/supported-countries`:

- Burundi
- Chad
- Republic of Congo
- Eritrea
- Iraq

Accordion count updated 28 -> 32 (note: previous count of 28 was already off by one; the list held 27 entries, now 32).

Entries inserted alphabetically. No other pages reference this list.