### PR TITLE
docs(api): document affiliate invitation endpoints and API flow guide

### DIFF
--- a/packages/creem-sdk/openapi.json
+++ b/packages/creem-sdk/openapi.json
@@ -80,7 +80,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -137,7 +139,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -183,7 +187,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -238,7 +244,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -282,7 +290,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -360,7 +370,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -428,7 +440,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -496,7 +510,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -564,7 +580,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -621,7 +639,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -666,7 +686,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -710,7 +732,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -757,7 +781,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -804,7 +830,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Subscriptions"],
+        "tags": [
+          "Subscriptions"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -882,7 +910,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Subscriptions"],
+        "tags": [
+          "Subscriptions"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -939,7 +969,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Subscriptions"],
+        "tags": [
+          "Subscriptions"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -996,7 +1028,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Subscriptions"],
+        "tags": [
+          "Subscriptions"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1053,7 +1087,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Subscriptions"],
+        "tags": [
+          "Subscriptions"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1099,7 +1135,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Subscriptions"],
+        "tags": [
+          "Subscriptions"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1145,7 +1183,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Subscriptions"],
+        "tags": [
+          "Subscriptions"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1192,7 +1232,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Checkouts"],
+        "tags": [
+          "Checkouts"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1237,7 +1279,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Checkouts"],
+        "tags": [
+          "Checkouts"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1284,7 +1328,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Licenses"],
+        "tags": [
+          "Licenses"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1331,7 +1377,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Licenses"],
+        "tags": [
+          "Licenses"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1378,7 +1426,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Licenses"],
+        "tags": [
+          "Licenses"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1465,7 +1515,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Licenses"],
+        "tags": [
+          "Licenses"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1537,7 +1589,10 @@
             "in": "query",
             "description": "Filter by discount status.",
             "schema": {
-              "enum": ["active", "deleted"],
+              "enum": [
+                "active",
+                "deleted"
+              ],
               "type": "string"
             }
           },
@@ -1547,7 +1602,10 @@
             "in": "query",
             "description": "Filter by discount type.",
             "schema": {
-              "enum": ["percentage", "fixed"],
+              "enum": [
+                "percentage",
+                "fixed"
+              ],
               "type": "string"
             }
           },
@@ -1593,7 +1651,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Discounts"],
+        "tags": [
+          "Discounts"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1650,7 +1710,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Discounts"],
+        "tags": [
+          "Discounts"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1695,7 +1757,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Discounts"],
+        "tags": [
+          "Discounts"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1741,7 +1805,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Discounts"],
+        "tags": [
+          "Discounts"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1788,7 +1854,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Transactions"],
+        "tags": [
+          "Transactions"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1896,7 +1964,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Transactions"],
+        "tags": [
+          "Transactions"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1935,7 +2005,11 @@
             "in": "query",
             "description": "Groups time-series data into buckets of this size. Requires startDate and endDate. Returns a periods array with one entry per bucket containing grossRevenue and netRevenue.",
             "schema": {
-              "enum": ["day", "week", "month"],
+              "enum": [
+                "day",
+                "week",
+                "month"
+              ],
               "type": "string"
             }
           },
@@ -1944,7 +2018,10 @@
             "required": true,
             "in": "query",
             "schema": {
-              "enum": ["EUR", "USD"],
+              "enum": [
+                "EUR",
+                "USD"
+              ],
               "type": "string"
             }
           }
@@ -1970,7 +2047,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Stats"],
+        "tags": [
+          "Stats"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2017,7 +2096,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Moderation"],
+        "tags": [
+          "Moderation"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2065,7 +2146,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Refunds"],
+        "tags": [
+          "Refunds"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2112,7 +2195,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2207,7 +2292,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2253,7 +2340,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2309,7 +2398,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2404,7 +2495,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2460,7 +2553,9 @@
             }
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2516,7 +2611,9 @@
             }
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2582,7 +2679,9 @@
             }
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2648,7 +2747,9 @@
             }
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2704,7 +2805,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2760,7 +2863,139 @@
             }
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/v1/affiliates/invites": {
+      "post": {
+        "operationId": "createAffiliateInvite",
+        "x-speakeasy-name-override": "createInvite",
+        "summary": "Create an affiliate invitation",
+        "description": "Invite someone to your affiliate program by email. They receive an invitation email and become an active affiliate once they accept. If `program_id` is omitted, the invitation is created for your store's affiliate program.",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "description": "Affiliate invitation payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAffiliateInviteRequestEntity"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully created the affiliate invitation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffiliateInviteEntity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing API key"
+          },
+          "404": {
+            "description": "Not Found - Resource does not exist"
+          },
+          "409": {
+            "description": "Conflict - an invitation has already been sent to this email address"
+          }
+        },
+        "tags": [
+          "Affiliates"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "get": {
+        "operationId": "listAffiliateInvites",
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "page_number",
+              "in": "parameters",
+              "type": "page"
+            },
+            {
+              "name": "page_size",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "numPages": "$.pagination.total_pages",
+            "results": "$.items"
+          }
+        },
+        "x-speakeasy-name-override": "listInvites",
+        "summary": "List affiliate invitations",
+        "description": "Retrieve a paginated list of the invitations you have sent, with their status (`pending` until accepted, `accepted` once the affiliate has joined).",
+        "parameters": [
+          {
+            "name": "page_number",
+            "required": false,
+            "in": "query",
+            "description": "The page number for pagination.",
+            "schema": {
+              "default": 1,
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "page_size",
+            "required": false,
+            "in": "query",
+            "description": "The number of items per page.",
+            "schema": {
+              "default": 50,
+              "example": 50,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved affiliate invitations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffiliateInviteListEntity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing API key"
+          },
+          "404": {
+            "description": "Not Found - Resource does not exist"
+          }
+        },
+        "tags": [
+          "Affiliates"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2838,7 +3073,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Affiliates"],
+        "tags": [
+          "Affiliates"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2884,7 +3121,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Affiliates"],
+        "tags": [
+          "Affiliates"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2980,7 +3219,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Affiliates"],
+        "tags": [
+          "Affiliates"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -3030,17 +3271,29 @@
       "ProductStatus": {
         "type": "string",
         "description": "Lifecycle status of the product: `active` or `archived`.",
-        "enum": ["active", "archived"]
+        "enum": [
+          "active",
+          "archived"
+        ]
       },
       "EnvironmentMode": {
         "type": "string",
         "description": "String representing the environment.",
-        "enum": ["test", "prod", "sandbox"]
+        "enum": [
+          "test",
+          "prod",
+          "sandbox"
+        ]
       },
       "ProductFeatureType": {
         "type": "string",
         "description": "The type of the feature: `custom` (private note), `file` (downloadable files), `licenseKey` (license key), or `customerCredits` (customer credit grant).",
-        "enum": ["custom", "file", "licenseKey", "customerCredits"]
+        "enum": [
+          "custom",
+          "file",
+          "licenseKey",
+          "customerCredits"
+        ]
       },
       "FeatureEntity": {
         "type": "object",
@@ -3060,12 +3313,19 @@
             "example": "Access to premium course materials."
           }
         },
-        "required": ["id", "type", "description"]
+        "required": [
+          "id",
+          "type",
+          "description"
+        ]
       },
       "ProductBillingType": {
         "type": "string",
         "description": "Indicates the billing method for the customer. It can either be a `recurring` billing cycle or a `onetime` payment.",
-        "enum": ["recurring", "onetime"]
+        "enum": [
+          "recurring",
+          "onetime"
+        ]
       },
       "ProductBillingPeriod": {
         "type": "string",
@@ -3082,17 +3342,27 @@
       "TaxMode": {
         "type": "string",
         "description": "Specifies the tax calculation mode for the transaction. If set to \"inclusive,\" the tax is included in the price. If set to \"exclusive,\" the tax is added on top of the price.",
-        "enum": ["inclusive", "exclusive"]
+        "enum": [
+          "inclusive",
+          "exclusive"
+        ]
       },
       "TaxCategory": {
         "type": "string",
         "description": "Categorizes the type of product or service for tax purposes. This helps determine the applicable tax rules based on the nature of the item or service.",
-        "enum": ["saas", "digital-goods-service", "ebooks"]
+        "enum": [
+          "saas",
+          "digital-goods-service",
+          "ebooks"
+        ]
       },
       "CustomFieldType": {
         "type": "string",
         "description": "The type of the field.",
-        "enum": ["text", "checkbox"]
+        "enum": [
+          "text",
+          "checkbox"
+        ]
       },
       "Text": {
         "type": "object",
@@ -3169,7 +3439,11 @@
             ]
           }
         },
-        "required": ["type", "key", "label"]
+        "required": [
+          "type",
+          "key",
+          "label"
+        ]
       },
       "ProductEntity": {
         "type": "object",
@@ -3201,7 +3475,9 @@
           },
           "image_urls": {
             "description": "Ordered list of product image URLs. The first entry is the cover image (mirrored in image_url).",
-            "example": ["https://example.com/image.jpg"],
+            "example": [
+              "https://example.com/image.jpg"
+            ],
             "type": "array",
             "items": {
               "type": "string"
@@ -3324,7 +3600,13 @@
             "nullable": true
           }
         },
-        "required": ["total_records", "total_pages", "current_page", "next_page", "prev_page"]
+        "required": [
+          "total_records",
+          "total_pages",
+          "current_page",
+          "next_page",
+          "prev_page"
+        ]
       },
       "ProductListEntity": {
         "type": "object",
@@ -3345,17 +3627,26 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "ProductCurrency": {
         "type": "string",
         "description": "Three-letter uppercase ISO 4217 currency code. Must be one of Creem's supported currencies.",
-        "enum": ["EUR", "USD"]
+        "enum": [
+          "EUR",
+          "USD"
+        ]
       },
       "ProductRequestBillingType": {
         "type": "string",
         "description": "Billing method for the product: `recurring` subscription or `onetime` payment.",
-        "enum": ["recurring", "onetime"]
+        "enum": [
+          "recurring",
+          "onetime"
+        ]
       },
       "ProductRequestBillingPeriod": {
         "type": "string",
@@ -3372,7 +3663,10 @@
       "CustomFieldRequestType": {
         "type": "string",
         "description": "The type of the field.",
-        "enum": ["text", "checkbox"]
+        "enum": [
+          "text",
+          "checkbox"
+        ]
       },
       "TextFieldConfig": {
         "type": "object",
@@ -3439,7 +3733,11 @@
             ]
           }
         },
-        "required": ["type", "key", "label"]
+        "required": [
+          "type",
+          "key",
+          "label"
+        ]
       },
       "CreateProductRequestEntity": {
         "type": "object",
@@ -3459,7 +3757,10 @@
           },
           "image_urls": {
             "description": "Ordered list of product image URLs (max 8). The first entry is the cover image; when provided it takes precedence over image_url.",
-            "example": ["https://picsum.photos/200/300", "https://picsum.photos/200/301"],
+            "example": [
+              "https://picsum.photos/200/300",
+              "https://picsum.photos/200/301"
+            ],
             "type": "array",
             "items": {
               "type": "string"
@@ -3526,7 +3827,13 @@
             "default": false
           }
         },
-        "required": ["name", "description", "price", "currency", "billing_type"]
+        "required": [
+          "name",
+          "description",
+          "price",
+          "currency",
+          "billing_type"
+        ]
       },
       "UpdateProductRequestEntity": {
         "type": "object",
@@ -3544,7 +3851,7 @@
             "description": "URL of the product image"
           },
           "image_urls": {
-            "description": "Ordered list of product image URLs (max 8). The first entry is the cover image; when provided it takes precedence over image_url. An empty list removes all images.",
+            "description": "Ordered list of product image URLs (max 8). The first entry is the cover image; when provided it takes precedence over image_url. An empty list — or an explicit `null` — removes all images. Omit to leave the gallery unchanged.",
             "type": "array",
             "items": {
               "type": "string"
@@ -3580,7 +3887,7 @@
           },
           "suggested_price": {
             "type": "integer",
-            "description": "Suggested amount in cents when pay_what_you_want is enabled."
+            "description": "Suggested amount in cents when pay_what_you_want is enabled. Omit to leave unchanged; send `null` to clear it."
           }
         }
       },
@@ -3638,7 +3945,15 @@
             "example": "2023-01-01T00:00:00Z"
           }
         },
-        "required": ["id", "mode", "object", "email", "country", "created_at", "updated_at"]
+        "required": [
+          "id",
+          "mode",
+          "object",
+          "email",
+          "country",
+          "created_at",
+          "updated_at"
+        ]
       },
       "CustomerListEntity": {
         "type": "object",
@@ -3659,17 +3974,26 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "OrderStatus": {
         "type": "string",
         "description": "Current status of the order.",
-        "enum": ["pending", "paid"]
+        "enum": [
+          "pending",
+          "paid"
+        ]
       },
       "OrderType": {
         "type": "string",
         "description": "The type of order. This can specify whether it's a regular purchase, subscription, etc.",
-        "enum": ["recurring", "onetime"]
+        "enum": [
+          "recurring",
+          "onetime"
+        ]
       },
       "OrderEntity": {
         "type": "object",
@@ -3817,7 +4141,10 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "SubscriptionItemEntity": {
         "type": "object",
@@ -3847,12 +4174,18 @@
             "nullable": true
           }
         },
-        "required": ["id", "mode", "object"]
+        "required": [
+          "id",
+          "mode",
+          "object"
+        ]
       },
       "SubscriptionCollectionMethod": {
         "type": "string",
         "description": "The method used for collecting payments for the subscription.",
-        "enum": ["charge_automatically"]
+        "enum": [
+          "charge_automatically"
+        ]
       },
       "SubscriptionStatus": {
         "type": "string",
@@ -3870,7 +4203,10 @@
       "TransactionType": {
         "type": "string",
         "description": "The type of transaction. payment(one time payments) and invoice(subscription)",
-        "enum": ["payment", "invoice"]
+        "enum": [
+          "payment",
+          "invoice"
+        ]
       },
       "TransactionStatus": {
         "type": "string",
@@ -3981,7 +4317,16 @@
             "description": "Creation date of the order as timestamp"
           }
         },
-        "required": ["id", "mode", "object", "amount", "currency", "type", "status", "created_at"]
+        "required": [
+          "id",
+          "mode",
+          "object",
+          "amount",
+          "currency",
+          "type",
+          "status",
+          "created_at"
+        ]
       },
       "SubscriptionEntity": {
         "type": "object",
@@ -4110,14 +4455,21 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["percentage", "fixed"]
+                "enum": [
+                  "percentage",
+                  "fixed"
+                ]
               },
               "amount": {
                 "type": "number"
               },
               "duration": {
                 "type": "string",
-                "enum": ["forever", "once", "repeating"]
+                "enum": [
+                  "forever",
+                  "once",
+                  "repeating"
+                ]
               },
               "durationInMonths": {
                 "type": "number"
@@ -4165,12 +4517,20 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "LicenseStatus": {
         "type": "string",
         "description": "The current status of the license key.",
-        "enum": ["inactive", "active", "expired", "disabled"]
+        "enum": [
+          "inactive",
+          "active",
+          "expired",
+          "disabled"
+        ]
       },
       "LicenseInstanceEntity": {
         "type": "object",
@@ -4195,7 +4555,10 @@
           "status": {
             "type": "string",
             "description": "The status of the license instance.",
-            "enum": ["active", "deactivated"],
+            "enum": [
+              "active",
+              "deactivated"
+            ],
             "example": "active"
           },
           "created_at": {
@@ -4205,7 +4568,14 @@
             "example": "2023-09-13T00:00:00Z"
           }
         },
-        "required": ["id", "mode", "object", "name", "status", "created_at"]
+        "required": [
+          "id",
+          "mode",
+          "object",
+          "name",
+          "status",
+          "created_at"
+        ]
       },
       "LicenseEntity": {
         "type": "object",
@@ -4299,7 +4669,10 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "CreateCustomerRequestEntity": {
         "type": "object",
@@ -4323,7 +4696,10 @@
             "additionalProperties": true
           }
         },
-        "required": ["email", "name"]
+        "required": [
+          "email",
+          "name"
+        ]
       },
       "UpdateCustomerRequestEntity": {
         "type": "object",
@@ -4340,14 +4716,16 @@
           },
           "metadata": {
             "type": "object",
-            "description": "Additional metadata for the customer.",
+            "description": "Additional metadata for the customer. Omit to leave unchanged; send `null` to clear it.",
             "example": {
               "key": "value"
             },
             "additionalProperties": true
           }
         },
-        "required": ["customer_id"]
+        "required": [
+          "customer_id"
+        ]
       },
       "CreateCustomerPortalLinkRequestEntity": {
         "type": "object",
@@ -4357,7 +4735,9 @@
             "description": "Unique identifier of the customer."
           }
         },
-        "required": ["customer_id"]
+        "required": [
+          "customer_id"
+        ]
       },
       "CustomerLinksEntity": {
         "type": "object",
@@ -4367,7 +4747,9 @@
             "description": "Customer portal link."
           }
         },
-        "required": ["customer_portal_link"]
+        "required": [
+          "customer_portal_link"
+        ]
       },
       "CancelSubscriptionRequestEntity": {
         "type": "object",
@@ -4375,13 +4757,19 @@
           "mode": {
             "type": "string",
             "description": "The mode of cancellation (immediate or scheduled), default can be configured in the store billing settings.",
-            "enum": ["immediate", "scheduled"],
+            "enum": [
+              "immediate",
+              "scheduled"
+            ],
             "example": "immediate"
           },
           "onExecute": {
             "type": "string",
             "description": "The action to execute when canceling (cancel or pause) when mode is scheduled, ignored when mode is immediate or not provided",
-            "enum": ["cancel", "pause"],
+            "enum": [
+              "cancel",
+              "pause"
+            ],
             "example": "cancel"
           }
         }
@@ -4420,7 +4808,11 @@
           "update_behavior": {
             "type": "string",
             "description": "The update behavior for the subscription (defaults to proration)",
-            "enum": ["proration-charge-immediately", "proration-charge", "proration-none"],
+            "enum": [
+              "proration-charge-immediately",
+              "proration-charge",
+              "proration-none"
+            ],
             "default": "proration-charge"
           }
         }
@@ -4436,11 +4828,17 @@
           "update_behavior": {
             "type": "string",
             "description": "The update behavior for the subscription (defaults to proration-charge-immediately)",
-            "enum": ["proration-charge-immediately", "proration-charge", "proration-none"],
+            "enum": [
+              "proration-charge-immediately",
+              "proration-charge",
+              "proration-none"
+            ],
             "default": "proration-charge-immediately"
           }
         },
-        "required": ["product_id"]
+        "required": [
+          "product_id"
+        ]
       },
       "FeatureFileEntity": {
         "type": "object",
@@ -4471,7 +4869,13 @@
             "example": 1024000
           }
         },
-        "required": ["id", "file_name", "url", "type", "size"]
+        "required": [
+          "id",
+          "file_name",
+          "url",
+          "type",
+          "size"
+        ]
       },
       "FileFeatureEntity": {
         "type": "object",
@@ -4484,7 +4888,9 @@
             }
           }
         },
-        "required": ["files"]
+        "required": [
+          "files"
+        ]
       },
       "CustomerCreditsFeatureEntity": {
         "type": "object",
@@ -4501,7 +4907,9 @@
             "nullable": true
           }
         },
-        "required": ["amount"]
+        "required": [
+          "amount"
+        ]
       },
       "ProductFeatureEntity": {
         "type": "object",
@@ -4585,7 +4993,12 @@
           "status": {
             "type": "string",
             "description": "Status of the checkout.",
-            "enum": ["pending", "processing", "completed", "expired"],
+            "enum": [
+              "pending",
+              "processing",
+              "completed",
+              "expired"
+            ],
             "example": "completed"
           },
           "request_id": {
@@ -4704,14 +5117,21 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["percentage", "fixed"]
+                "enum": [
+                  "percentage",
+                  "fixed"
+                ]
               },
               "amount": {
                 "type": "number"
               },
               "duration": {
                 "type": "string",
-                "enum": ["forever", "once", "repeating"]
+                "enum": [
+                  "forever",
+                  "once",
+                  "repeating"
+                ]
               },
               "durationInMonths": {
                 "type": "number"
@@ -4719,7 +5139,13 @@
             }
           }
         },
-        "required": ["id", "mode", "object", "status", "product"]
+        "required": [
+          "id",
+          "mode",
+          "object",
+          "status",
+          "product"
+        ]
       },
       "CustomerRequestEntity": {
         "type": "object",
@@ -4733,6 +5159,11 @@
             "type": "string",
             "description": "Customer email address. You may only specify one of these parameters: id, email.",
             "example": "user@example.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "Customer full name. Used to prefill the name field on the checkout page.",
+            "example": "John Doe"
           }
         }
       },
@@ -4762,6 +5193,11 @@
             "type": "string",
             "description": "Prefill the checkout session with a discount code.",
             "example": "SUMMER2024"
+          },
+          "affiliate_code": {
+            "type": "string",
+            "description": "Attribute this checkout to an affiliate using the affiliate's referral code (the unique code from their referral link). Use this to manually credit a sale to a specific affiliate when you already hold their code on your backend, instead of relying on referral-link clicks/cookies. The code must belong to an active affiliate of this store; an invalid, inactive, or foreign-store code is rejected.",
+            "example": "aff_abc123"
           },
           "customer": {
             "description": "Customer data for checkout session. This will prefill the customer info on the checkout page.",
@@ -4801,7 +5237,9 @@
             "additionalProperties": true
           }
         },
-        "required": ["product_id"]
+        "required": [
+          "product_id"
+        ]
       },
       "ActivateLicenseRequestEntity": {
         "type": "object",
@@ -4815,7 +5253,10 @@
             "description": "A label for the new instance to identify it in Creem."
           }
         },
-        "required": ["key", "instance_name"]
+        "required": [
+          "key",
+          "instance_name"
+        ]
       },
       "DeactivateLicenseRequestEntity": {
         "type": "object",
@@ -4829,7 +5270,10 @@
             "description": "Id of the instance to deactivate."
           }
         },
-        "required": ["key", "instance_id"]
+        "required": [
+          "key",
+          "instance_id"
+        ]
       },
       "ValidateLicenseRequestEntity": {
         "type": "object",
@@ -4843,7 +5287,10 @@
             "description": "Id of the instance to validate."
           }
         },
-        "required": ["key", "instance_id"]
+        "required": [
+          "key",
+          "instance_id"
+        ]
       },
       "LicenseInstanceListEntity": {
         "type": "object",
@@ -4864,7 +5311,10 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "DiscountEntity": {
         "type": "object",
@@ -4884,7 +5334,13 @@
           "status": {
             "type": "string",
             "description": "The status of the discount (e.g., active, inactive).",
-            "enum": ["deleted", "active", "draft", "expired", "scheduled"],
+            "enum": [
+              "deleted",
+              "active",
+              "draft",
+              "expired",
+              "scheduled"
+            ],
             "example": "active"
           },
           "name": {
@@ -4900,7 +5356,10 @@
           "type": {
             "type": "string",
             "description": "The type of the discount, either \"percentage\" or \"fixed\".",
-            "enum": ["percentage", "fixed"],
+            "enum": [
+              "percentage",
+              "fixed"
+            ],
             "example": "percentage"
           },
           "amount": {
@@ -4932,7 +5391,11 @@
           "duration": {
             "type": "string",
             "description": "The duration type for the discount.",
-            "enum": ["forever", "once", "repeating"],
+            "enum": [
+              "forever",
+              "once",
+              "repeating"
+            ],
             "example": "repeating"
           },
           "duration_in_months": {
@@ -4942,7 +5405,10 @@
           },
           "applies_to_products": {
             "description": "The list of product IDs to which this discount applies.",
-            "example": ["prod_123", "prod_456"],
+            "example": [
+              "prod_123",
+              "prod_456"
+            ],
             "type": "array",
             "items": {
               "type": "string"
@@ -4954,7 +5420,15 @@
             "example": 15
           }
         },
-        "required": ["id", "mode", "object", "status", "name", "code", "type"]
+        "required": [
+          "id",
+          "mode",
+          "object",
+          "status",
+          "name",
+          "code",
+          "type"
+        ]
       },
       "DiscountListEntity": {
         "type": "object",
@@ -4975,17 +5449,27 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "DiscountType": {
         "type": "string",
         "description": "The type of the discount, either \"percentage\" or \"fixed\".",
-        "enum": ["percentage", "fixed"]
+        "enum": [
+          "percentage",
+          "fixed"
+        ]
       },
       "CouponDurationType": {
         "type": "string",
         "description": "The duration type for the discount.",
-        "enum": ["forever", "once", "repeating"]
+        "enum": [
+          "forever",
+          "once",
+          "repeating"
+        ]
       },
       "CreateDiscountRequestEntity": {
         "type": "object",
@@ -5040,14 +5524,22 @@
           },
           "applies_to_products": {
             "description": "The list of product IDs to which this discount applies.",
-            "example": ["prod_123", "prod_456"],
+            "example": [
+              "prod_123",
+              "prod_456"
+            ],
             "type": "array",
             "items": {
               "type": "string"
             }
           }
         },
-        "required": ["name", "type", "duration", "applies_to_products"]
+        "required": [
+          "name",
+          "type",
+          "duration",
+          "applies_to_products"
+        ]
       },
       "TransactionListEntity": {
         "type": "object",
@@ -5068,7 +5560,10 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "StatsMetricTotalsEntity": {
         "type": "object",
@@ -5150,7 +5645,11 @@
             "example": 122173
           }
         },
-        "required": ["timestamp", "grossRevenue", "netRevenue"]
+        "required": [
+          "timestamp",
+          "grossRevenue",
+          "netRevenue"
+        ]
       },
       "StatsSummaryEntity": {
         "type": "object",
@@ -5213,7 +5712,9 @@
             }
           }
         },
-        "required": ["totals"]
+        "required": [
+          "totals"
+        ]
       },
       "ScreenPromptRequest": {
         "type": "object",
@@ -5227,7 +5728,9 @@
             "description": "An optional identifier to associate this request with."
           }
         },
-        "required": ["prompt"]
+        "required": [
+          "prompt"
+        ]
       },
       "UsageEntity": {
         "type": "object",
@@ -5237,7 +5740,9 @@
             "description": "Number of units consumed by this call."
           }
         },
-        "required": ["units"]
+        "required": [
+          "units"
+        ]
       },
       "ScreenPromptResponse": {
         "type": "object",
@@ -5262,7 +5767,11 @@
           "decision": {
             "type": "string",
             "description": "The moderation decision.",
-            "enum": ["allow", "deny", "flag"]
+            "enum": [
+              "allow",
+              "deny",
+              "flag"
+            ]
           },
           "usage": {
             "description": "Usage information for this call.",
@@ -5273,7 +5782,13 @@
             ]
           }
         },
-        "required": ["id", "object", "prompt", "decision", "usage"]
+        "required": [
+          "id",
+          "object",
+          "prompt",
+          "decision",
+          "usage"
+        ]
       },
       "CreateRefundRequestEntity": {
         "type": "object",
@@ -5284,12 +5799,20 @@
             "example": "tran_1234567890"
           }
         },
-        "required": ["transaction_id"]
+        "required": [
+          "transaction_id"
+        ]
       },
       "RefundStatus": {
         "type": "string",
         "description": "Status of the refund. `pending` and `requiresAction` represent non-terminal provider processing states.",
-        "enum": ["pending", "requiresAction", "succeeded", "failed", "canceled"]
+        "enum": [
+          "pending",
+          "requiresAction",
+          "succeeded",
+          "failed",
+          "canceled"
+        ]
       },
       "RefundResponseEntity": {
         "type": "object",
@@ -5299,7 +5822,9 @@
             "$ref": "#/components/schemas/RefundStatus"
           }
         },
-        "required": ["status"]
+        "required": [
+          "status"
+        ]
       },
       "CreateAccountDto": {
         "type": "object",
@@ -5327,7 +5852,9 @@
             "example": "300"
           }
         },
-        "required": ["customer_id"]
+        "required": [
+          "customer_id"
+        ]
       },
       "AccountResponseDto": {
         "type": "object",
@@ -5359,7 +5886,11 @@
           "status": {
             "type": "string",
             "description": "Account status",
-            "enum": ["active", "frozen", "closed"]
+            "enum": [
+              "active",
+              "frozen",
+              "closed"
+            ]
           },
           "created_at": {
             "type": "string",
@@ -5401,7 +5932,11 @@
             "description": "Whether more items exist beyond this page"
           }
         },
-        "required": ["object", "data", "has_more"]
+        "required": [
+          "object",
+          "data",
+          "has_more"
+        ]
       },
       "BalanceResponseDto": {
         "type": "object",
@@ -5420,7 +5955,9 @@
             "description": "Point-in-time the balance was computed at (present for at-time queries)"
           }
         },
-        "required": ["balance"]
+        "required": [
+          "balance"
+        ]
       },
       "EntryResponseDto": {
         "type": "object",
@@ -5443,7 +5980,10 @@
           "side": {
             "type": "string",
             "description": "Debit or credit side",
-            "enum": ["debit", "credit"]
+            "enum": [
+              "debit",
+              "credit"
+            ]
           },
           "amount": {
             "type": "string",
@@ -5455,7 +5995,14 @@
             "description": "Creation timestamp"
           }
         },
-        "required": ["id", "transaction_id", "account_id", "side", "amount", "created_at"]
+        "required": [
+          "id",
+          "transaction_id",
+          "account_id",
+          "side",
+          "amount",
+          "created_at"
+        ]
       },
       "EntryListResponseDto": {
         "type": "object",
@@ -5477,7 +6024,11 @@
             "description": "Whether more items exist beyond this page"
           }
         },
-        "required": ["object", "data", "has_more"]
+        "required": [
+          "object",
+          "data",
+          "has_more"
+        ]
       },
       "CustomerCreditsErrorDetailDto": {
         "type": "object",
@@ -5516,7 +6067,12 @@
             "example": "req_abc123def456"
           }
         },
-        "required": ["type", "code", "message", "request_id"]
+        "required": [
+          "type",
+          "code",
+          "message",
+          "request_id"
+        ]
       },
       "CustomerCreditsErrorResponseDto": {
         "type": "object",
@@ -5530,7 +6086,9 @@
             ]
           }
         },
-        "required": ["error"]
+        "required": [
+          "error"
+        ]
       },
       "CreditDebitRequestDto": {
         "type": "object",
@@ -5551,7 +6109,11 @@
             "example": "idem_abc123"
           }
         },
-        "required": ["amount", "reference", "idempotency_key"]
+        "required": [
+          "amount",
+          "reference",
+          "idempotency_key"
+        ]
       },
       "TransactionResponseDto": {
         "type": "object",
@@ -5592,7 +6154,14 @@
             "description": "Creation timestamp"
           }
         },
-        "required": ["id", "store_id", "reference", "idempotency_key", "entries", "created_at"]
+        "required": [
+          "id",
+          "store_id",
+          "reference",
+          "idempotency_key",
+          "entries",
+          "created_at"
+        ]
       },
       "ReverseTransactionRequestDto": {
         "type": "object",
@@ -5603,7 +6172,103 @@
             "example": "cct_abc123"
           }
         },
-        "required": ["transaction_id"]
+        "required": [
+          "transaction_id"
+        ]
+      },
+      "CreateAffiliateInviteRequestEntity": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "The email address to send the affiliate invitation to.",
+            "example": "partner@example.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name of the affiliate being invited.",
+            "example": "Jane Partner"
+          },
+          "program_id": {
+            "type": "string",
+            "description": "The ID of the affiliate program to invite into. Optional: when omitted, the invitation falls back to the store's affiliate program. Provide this only if your store runs more than one program.",
+            "example": "prog_1234567890",
+            "nullable": true
+          }
+        },
+        "required": [
+          "email",
+          "name"
+        ]
+      },
+      "AffiliateInviteEntity": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the object."
+          },
+          "mode": {
+            "$ref": "#/components/schemas/EnvironmentMode"
+          },
+          "object": {
+            "type": "string",
+            "description": "String representing the object's type. Objects of the same type share the same value.",
+            "example": "affiliate-invite"
+          },
+          "email": {
+            "type": "string",
+            "description": "The email address the affiliate was invited with.",
+            "example": "partner@example.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name the affiliate was invited with.",
+            "example": "Jane Partner",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "description": "The lifecycle status of the invitation: `pending` while the invitee has not yet accepted, `accepted` once they have joined the program.",
+            "example": "pending"
+          },
+          "created_at": {
+            "type": "number",
+            "description": "Creation date of the invitation as a timestamp."
+          }
+        },
+        "required": [
+          "id",
+          "mode",
+          "object",
+          "email",
+          "status",
+          "created_at"
+        ]
+      },
+      "AffiliateInviteListEntity": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "List of affiliate invitation items",
+            "items": {
+              "$ref": "#/components/schemas/AffiliateInviteEntity"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "description": "Pagination details for the list",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationEntity"
+              }
+            ]
+          }
+        },
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "AffiliateEntity": {
         "type": "object",
@@ -5700,12 +6365,19 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "CommissionStatus": {
         "type": "string",
         "description": "The settlement status of the commission. `pending` while on hold, `approved` once cleared and available, `paid` once settled by a payout.",
-        "enum": ["pending", "approved", "paid"]
+        "enum": [
+          "pending",
+          "approved",
+          "paid"
+        ]
       },
       "CommissionEntity": {
         "type": "object",
@@ -5782,7 +6454,10 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "WebhookSubscriptionEntity": {
         "type": "object",
@@ -5905,14 +6580,21 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["percentage", "fixed"]
+                "enum": [
+                  "percentage",
+                  "fixed"
+                ]
               },
               "amount": {
                 "type": "number"
               },
               "duration": {
                 "type": "string",
-                "enum": ["forever", "once", "repeating"]
+                "enum": [
+                  "forever",
+                  "once",
+                  "repeating"
+                ]
               },
               "durationInMonths": {
                 "type": "number"
@@ -5952,7 +6634,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["checkout.completed"]
+            "enum": [
+              "checkout.completed"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -5967,13 +6651,23 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "RefundReason": {
         "type": "string",
         "description": "Reason for the refund.",
-        "enum": ["duplicate", "fraudulent", "requested_by_customer", "other"]
+        "enum": [
+          "duplicate",
+          "fraudulent",
+          "requested_by_customer",
+          "other"
+        ]
       },
       "RefundEntity": {
         "type": "object",
@@ -6085,7 +6779,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["refund.created"]
+            "enum": [
+              "refund.created"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6100,7 +6796,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "DisputeEntity": {
@@ -6184,7 +6885,15 @@
             "description": "Creation date of the dispute as timestamp"
           }
         },
-        "required": ["id", "mode", "object", "amount", "currency", "transaction", "created_at"]
+        "required": [
+          "id",
+          "mode",
+          "object",
+          "amount",
+          "currency",
+          "transaction",
+          "created_at"
+        ]
       },
       "WebhookDisputeCreatedEventEntity": {
         "type": "object",
@@ -6196,7 +6905,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["dispute.created"]
+            "enum": [
+              "dispute.created"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6211,7 +6922,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionActiveEventEntity": {
@@ -6224,7 +6940,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.active"]
+            "enum": [
+              "subscription.active"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6239,7 +6957,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionTrialingEventEntity": {
@@ -6252,7 +6975,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.trialing"]
+            "enum": [
+              "subscription.trialing"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6267,7 +6992,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionCanceledEventEntity": {
@@ -6280,7 +7010,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.canceled"]
+            "enum": [
+              "subscription.canceled"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6295,7 +7027,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionScheduledCancelEventEntity": {
@@ -6308,7 +7045,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.scheduled_cancel"]
+            "enum": [
+              "subscription.scheduled_cancel"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6323,7 +7062,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionPaidEventEntity": {
@@ -6336,7 +7080,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.paid"]
+            "enum": [
+              "subscription.paid"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6351,7 +7097,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionExpiredEventEntity": {
@@ -6364,7 +7115,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.expired"]
+            "enum": [
+              "subscription.expired"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6379,7 +7132,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionUnpaidEventEntity": {
@@ -6392,7 +7150,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.unpaid"]
+            "enum": [
+              "subscription.unpaid"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6407,7 +7167,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionUpdateEventEntity": {
@@ -6420,7 +7185,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.update"]
+            "enum": [
+              "subscription.update"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6435,7 +7202,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionPastDueEventEntity": {
@@ -6448,7 +7220,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.past_due"]
+            "enum": [
+              "subscription.past_due"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6463,7 +7237,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionPausedEventEntity": {
@@ -6476,7 +7255,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.paused"]
+            "enum": [
+              "subscription.paused"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6491,7 +7272,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookEventEntity": {

--- a/packages/docs/api-reference/endpoint/create-affiliate-invite.mdx
+++ b/packages/docs/api-reference/endpoint/create-affiliate-invite.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Create an affiliate invitation'
+description: 'Invite someone to your affiliate program by email. They receive an invitation email and become an active affiliate once they accept. If `program_id` is omitted, the invitation is created for your store''s affiliate program.'
+openapi: post /v1/affiliates/invites
+---

--- a/packages/docs/api-reference/endpoint/list-affiliate-invites.mdx
+++ b/packages/docs/api-reference/endpoint/list-affiliate-invites.mdx
@@ -1,0 +1,5 @@
+---
+title: 'List affiliate invitations'
+description: 'Retrieve a paginated list of the invitations you have sent, with their status (`pending` until accepted, `accepted` once the affiliate has joined).'
+openapi: get /v1/affiliates/invites
+---

--- a/packages/docs/api-reference/openapi.json
+++ b/packages/docs/api-reference/openapi.json
@@ -80,7 +80,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -137,7 +139,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -183,7 +187,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -238,7 +244,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -282,7 +290,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -360,7 +370,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -428,7 +440,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -496,7 +510,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -564,7 +580,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -621,7 +639,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -666,7 +686,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -710,7 +732,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -757,7 +781,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -804,7 +830,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Subscriptions"],
+        "tags": [
+          "Subscriptions"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -882,7 +910,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Subscriptions"],
+        "tags": [
+          "Subscriptions"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -939,7 +969,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Subscriptions"],
+        "tags": [
+          "Subscriptions"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -996,7 +1028,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Subscriptions"],
+        "tags": [
+          "Subscriptions"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1053,7 +1087,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Subscriptions"],
+        "tags": [
+          "Subscriptions"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1099,7 +1135,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Subscriptions"],
+        "tags": [
+          "Subscriptions"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1145,7 +1183,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Subscriptions"],
+        "tags": [
+          "Subscriptions"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1192,7 +1232,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Checkouts"],
+        "tags": [
+          "Checkouts"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1237,7 +1279,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Checkouts"],
+        "tags": [
+          "Checkouts"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1284,7 +1328,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Licenses"],
+        "tags": [
+          "Licenses"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1331,7 +1377,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Licenses"],
+        "tags": [
+          "Licenses"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1378,7 +1426,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Licenses"],
+        "tags": [
+          "Licenses"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1465,7 +1515,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Licenses"],
+        "tags": [
+          "Licenses"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1537,7 +1589,10 @@
             "in": "query",
             "description": "Filter by discount status.",
             "schema": {
-              "enum": ["active", "deleted"],
+              "enum": [
+                "active",
+                "deleted"
+              ],
               "type": "string"
             }
           },
@@ -1547,7 +1602,10 @@
             "in": "query",
             "description": "Filter by discount type.",
             "schema": {
-              "enum": ["percentage", "fixed"],
+              "enum": [
+                "percentage",
+                "fixed"
+              ],
               "type": "string"
             }
           },
@@ -1593,7 +1651,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Discounts"],
+        "tags": [
+          "Discounts"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1650,7 +1710,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Discounts"],
+        "tags": [
+          "Discounts"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1695,7 +1757,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Discounts"],
+        "tags": [
+          "Discounts"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1741,7 +1805,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Discounts"],
+        "tags": [
+          "Discounts"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1788,7 +1854,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Transactions"],
+        "tags": [
+          "Transactions"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1896,7 +1964,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Transactions"],
+        "tags": [
+          "Transactions"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -1935,7 +2005,11 @@
             "in": "query",
             "description": "Groups time-series data into buckets of this size. Requires startDate and endDate. Returns a periods array with one entry per bucket containing grossRevenue and netRevenue.",
             "schema": {
-              "enum": ["day", "week", "month"],
+              "enum": [
+                "day",
+                "week",
+                "month"
+              ],
               "type": "string"
             }
           },
@@ -1944,7 +2018,10 @@
             "required": true,
             "in": "query",
             "schema": {
-              "enum": ["EUR", "USD"],
+              "enum": [
+                "EUR",
+                "USD"
+              ],
               "type": "string"
             }
           }
@@ -1970,7 +2047,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Stats"],
+        "tags": [
+          "Stats"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2017,7 +2096,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Moderation"],
+        "tags": [
+          "Moderation"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2065,7 +2146,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Refunds"],
+        "tags": [
+          "Refunds"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2112,7 +2195,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2207,7 +2292,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2253,7 +2340,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2309,7 +2398,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2404,7 +2495,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2460,7 +2553,9 @@
             }
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2516,7 +2611,9 @@
             }
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2582,7 +2679,9 @@
             }
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2648,7 +2747,9 @@
             }
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2704,7 +2805,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2760,7 +2863,139 @@
             }
           }
         },
-        "tags": ["Customer Credits - Accounts (Experimental)"],
+        "tags": [
+          "Customer Credits - Accounts (Experimental)"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/v1/affiliates/invites": {
+      "post": {
+        "operationId": "createAffiliateInvite",
+        "x-speakeasy-name-override": "createInvite",
+        "summary": "Create an affiliate invitation",
+        "description": "Invite someone to your affiliate program by email. They receive an invitation email and become an active affiliate once they accept. If `program_id` is omitted, the invitation is created for your store's affiliate program.",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "description": "Affiliate invitation payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAffiliateInviteRequestEntity"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully created the affiliate invitation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffiliateInviteEntity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing API key"
+          },
+          "404": {
+            "description": "Not Found - Resource does not exist"
+          },
+          "409": {
+            "description": "Conflict - an invitation has already been sent to this email address"
+          }
+        },
+        "tags": [
+          "Affiliates"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "get": {
+        "operationId": "listAffiliateInvites",
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "page_number",
+              "in": "parameters",
+              "type": "page"
+            },
+            {
+              "name": "page_size",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "numPages": "$.pagination.total_pages",
+            "results": "$.items"
+          }
+        },
+        "x-speakeasy-name-override": "listInvites",
+        "summary": "List affiliate invitations",
+        "description": "Retrieve a paginated list of the invitations you have sent, with their status (`pending` until accepted, `accepted` once the affiliate has joined).",
+        "parameters": [
+          {
+            "name": "page_number",
+            "required": false,
+            "in": "query",
+            "description": "The page number for pagination.",
+            "schema": {
+              "default": 1,
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "page_size",
+            "required": false,
+            "in": "query",
+            "description": "The number of items per page.",
+            "schema": {
+              "default": 50,
+              "example": 50,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved affiliate invitations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffiliateInviteListEntity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing API key"
+          },
+          "404": {
+            "description": "Not Found - Resource does not exist"
+          }
+        },
+        "tags": [
+          "Affiliates"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2838,7 +3073,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Affiliates"],
+        "tags": [
+          "Affiliates"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2884,7 +3121,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Affiliates"],
+        "tags": [
+          "Affiliates"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -2980,7 +3219,9 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": ["Affiliates"],
+        "tags": [
+          "Affiliates"
+        ],
         "security": [
           {
             "ApiKey": []
@@ -3030,17 +3271,29 @@
       "ProductStatus": {
         "type": "string",
         "description": "Lifecycle status of the product: `active` or `archived`.",
-        "enum": ["active", "archived"]
+        "enum": [
+          "active",
+          "archived"
+        ]
       },
       "EnvironmentMode": {
         "type": "string",
         "description": "String representing the environment.",
-        "enum": ["test", "prod", "sandbox"]
+        "enum": [
+          "test",
+          "prod",
+          "sandbox"
+        ]
       },
       "ProductFeatureType": {
         "type": "string",
         "description": "The type of the feature: `custom` (private note), `file` (downloadable files), `licenseKey` (license key), or `customerCredits` (customer credit grant).",
-        "enum": ["custom", "file", "licenseKey", "customerCredits"]
+        "enum": [
+          "custom",
+          "file",
+          "licenseKey",
+          "customerCredits"
+        ]
       },
       "FeatureEntity": {
         "type": "object",
@@ -3060,12 +3313,19 @@
             "example": "Access to premium course materials."
           }
         },
-        "required": ["id", "type", "description"]
+        "required": [
+          "id",
+          "type",
+          "description"
+        ]
       },
       "ProductBillingType": {
         "type": "string",
         "description": "Indicates the billing method for the customer. It can either be a `recurring` billing cycle or a `onetime` payment.",
-        "enum": ["recurring", "onetime"]
+        "enum": [
+          "recurring",
+          "onetime"
+        ]
       },
       "ProductBillingPeriod": {
         "type": "string",
@@ -3082,17 +3342,27 @@
       "TaxMode": {
         "type": "string",
         "description": "Specifies the tax calculation mode for the transaction. If set to \"inclusive,\" the tax is included in the price. If set to \"exclusive,\" the tax is added on top of the price.",
-        "enum": ["inclusive", "exclusive"]
+        "enum": [
+          "inclusive",
+          "exclusive"
+        ]
       },
       "TaxCategory": {
         "type": "string",
         "description": "Categorizes the type of product or service for tax purposes. This helps determine the applicable tax rules based on the nature of the item or service.",
-        "enum": ["saas", "digital-goods-service", "ebooks"]
+        "enum": [
+          "saas",
+          "digital-goods-service",
+          "ebooks"
+        ]
       },
       "CustomFieldType": {
         "type": "string",
         "description": "The type of the field.",
-        "enum": ["text", "checkbox"]
+        "enum": [
+          "text",
+          "checkbox"
+        ]
       },
       "Text": {
         "type": "object",
@@ -3169,7 +3439,11 @@
             ]
           }
         },
-        "required": ["type", "key", "label"]
+        "required": [
+          "type",
+          "key",
+          "label"
+        ]
       },
       "ProductEntity": {
         "type": "object",
@@ -3201,7 +3475,9 @@
           },
           "image_urls": {
             "description": "Ordered list of product image URLs. The first entry is the cover image (mirrored in image_url).",
-            "example": ["https://example.com/image.jpg"],
+            "example": [
+              "https://example.com/image.jpg"
+            ],
             "type": "array",
             "items": {
               "type": "string"
@@ -3324,7 +3600,13 @@
             "nullable": true
           }
         },
-        "required": ["total_records", "total_pages", "current_page", "next_page", "prev_page"]
+        "required": [
+          "total_records",
+          "total_pages",
+          "current_page",
+          "next_page",
+          "prev_page"
+        ]
       },
       "ProductListEntity": {
         "type": "object",
@@ -3345,17 +3627,26 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "ProductCurrency": {
         "type": "string",
         "description": "Three-letter uppercase ISO 4217 currency code. Must be one of Creem's supported currencies.",
-        "enum": ["EUR", "USD"]
+        "enum": [
+          "EUR",
+          "USD"
+        ]
       },
       "ProductRequestBillingType": {
         "type": "string",
         "description": "Billing method for the product: `recurring` subscription or `onetime` payment.",
-        "enum": ["recurring", "onetime"]
+        "enum": [
+          "recurring",
+          "onetime"
+        ]
       },
       "ProductRequestBillingPeriod": {
         "type": "string",
@@ -3372,7 +3663,10 @@
       "CustomFieldRequestType": {
         "type": "string",
         "description": "The type of the field.",
-        "enum": ["text", "checkbox"]
+        "enum": [
+          "text",
+          "checkbox"
+        ]
       },
       "TextFieldConfig": {
         "type": "object",
@@ -3439,7 +3733,11 @@
             ]
           }
         },
-        "required": ["type", "key", "label"]
+        "required": [
+          "type",
+          "key",
+          "label"
+        ]
       },
       "CreateProductRequestEntity": {
         "type": "object",
@@ -3459,7 +3757,10 @@
           },
           "image_urls": {
             "description": "Ordered list of product image URLs (max 8). The first entry is the cover image; when provided it takes precedence over image_url.",
-            "example": ["https://picsum.photos/200/300", "https://picsum.photos/200/301"],
+            "example": [
+              "https://picsum.photos/200/300",
+              "https://picsum.photos/200/301"
+            ],
             "type": "array",
             "items": {
               "type": "string"
@@ -3526,7 +3827,13 @@
             "default": false
           }
         },
-        "required": ["name", "description", "price", "currency", "billing_type"]
+        "required": [
+          "name",
+          "description",
+          "price",
+          "currency",
+          "billing_type"
+        ]
       },
       "UpdateProductRequestEntity": {
         "type": "object",
@@ -3544,7 +3851,7 @@
             "description": "URL of the product image"
           },
           "image_urls": {
-            "description": "Ordered list of product image URLs (max 8). The first entry is the cover image; when provided it takes precedence over image_url. An empty list removes all images.",
+            "description": "Ordered list of product image URLs (max 8). The first entry is the cover image; when provided it takes precedence over image_url. An empty list — or an explicit `null` — removes all images. Omit to leave the gallery unchanged.",
             "type": "array",
             "items": {
               "type": "string"
@@ -3580,7 +3887,7 @@
           },
           "suggested_price": {
             "type": "integer",
-            "description": "Suggested amount in cents when pay_what_you_want is enabled."
+            "description": "Suggested amount in cents when pay_what_you_want is enabled. Omit to leave unchanged; send `null` to clear it."
           }
         }
       },
@@ -3638,7 +3945,15 @@
             "example": "2023-01-01T00:00:00Z"
           }
         },
-        "required": ["id", "mode", "object", "email", "country", "created_at", "updated_at"]
+        "required": [
+          "id",
+          "mode",
+          "object",
+          "email",
+          "country",
+          "created_at",
+          "updated_at"
+        ]
       },
       "CustomerListEntity": {
         "type": "object",
@@ -3659,17 +3974,26 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "OrderStatus": {
         "type": "string",
         "description": "Current status of the order.",
-        "enum": ["pending", "paid"]
+        "enum": [
+          "pending",
+          "paid"
+        ]
       },
       "OrderType": {
         "type": "string",
         "description": "The type of order. This can specify whether it's a regular purchase, subscription, etc.",
-        "enum": ["recurring", "onetime"]
+        "enum": [
+          "recurring",
+          "onetime"
+        ]
       },
       "OrderEntity": {
         "type": "object",
@@ -3817,7 +4141,10 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "SubscriptionItemEntity": {
         "type": "object",
@@ -3847,12 +4174,18 @@
             "nullable": true
           }
         },
-        "required": ["id", "mode", "object"]
+        "required": [
+          "id",
+          "mode",
+          "object"
+        ]
       },
       "SubscriptionCollectionMethod": {
         "type": "string",
         "description": "The method used for collecting payments for the subscription.",
-        "enum": ["charge_automatically"]
+        "enum": [
+          "charge_automatically"
+        ]
       },
       "SubscriptionStatus": {
         "type": "string",
@@ -3870,7 +4203,10 @@
       "TransactionType": {
         "type": "string",
         "description": "The type of transaction. payment(one time payments) and invoice(subscription)",
-        "enum": ["payment", "invoice"]
+        "enum": [
+          "payment",
+          "invoice"
+        ]
       },
       "TransactionStatus": {
         "type": "string",
@@ -3981,7 +4317,16 @@
             "description": "Creation date of the order as timestamp"
           }
         },
-        "required": ["id", "mode", "object", "amount", "currency", "type", "status", "created_at"]
+        "required": [
+          "id",
+          "mode",
+          "object",
+          "amount",
+          "currency",
+          "type",
+          "status",
+          "created_at"
+        ]
       },
       "SubscriptionEntity": {
         "type": "object",
@@ -4110,14 +4455,21 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["percentage", "fixed"]
+                "enum": [
+                  "percentage",
+                  "fixed"
+                ]
               },
               "amount": {
                 "type": "number"
               },
               "duration": {
                 "type": "string",
-                "enum": ["forever", "once", "repeating"]
+                "enum": [
+                  "forever",
+                  "once",
+                  "repeating"
+                ]
               },
               "durationInMonths": {
                 "type": "number"
@@ -4165,12 +4517,20 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "LicenseStatus": {
         "type": "string",
         "description": "The current status of the license key.",
-        "enum": ["inactive", "active", "expired", "disabled"]
+        "enum": [
+          "inactive",
+          "active",
+          "expired",
+          "disabled"
+        ]
       },
       "LicenseInstanceEntity": {
         "type": "object",
@@ -4195,7 +4555,10 @@
           "status": {
             "type": "string",
             "description": "The status of the license instance.",
-            "enum": ["active", "deactivated"],
+            "enum": [
+              "active",
+              "deactivated"
+            ],
             "example": "active"
           },
           "created_at": {
@@ -4205,7 +4568,14 @@
             "example": "2023-09-13T00:00:00Z"
           }
         },
-        "required": ["id", "mode", "object", "name", "status", "created_at"]
+        "required": [
+          "id",
+          "mode",
+          "object",
+          "name",
+          "status",
+          "created_at"
+        ]
       },
       "LicenseEntity": {
         "type": "object",
@@ -4299,7 +4669,10 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "CreateCustomerRequestEntity": {
         "type": "object",
@@ -4323,7 +4696,10 @@
             "additionalProperties": true
           }
         },
-        "required": ["email", "name"]
+        "required": [
+          "email",
+          "name"
+        ]
       },
       "UpdateCustomerRequestEntity": {
         "type": "object",
@@ -4340,14 +4716,16 @@
           },
           "metadata": {
             "type": "object",
-            "description": "Additional metadata for the customer.",
+            "description": "Additional metadata for the customer. Omit to leave unchanged; send `null` to clear it.",
             "example": {
               "key": "value"
             },
             "additionalProperties": true
           }
         },
-        "required": ["customer_id"]
+        "required": [
+          "customer_id"
+        ]
       },
       "CreateCustomerPortalLinkRequestEntity": {
         "type": "object",
@@ -4357,7 +4735,9 @@
             "description": "Unique identifier of the customer."
           }
         },
-        "required": ["customer_id"]
+        "required": [
+          "customer_id"
+        ]
       },
       "CustomerLinksEntity": {
         "type": "object",
@@ -4367,7 +4747,9 @@
             "description": "Customer portal link."
           }
         },
-        "required": ["customer_portal_link"]
+        "required": [
+          "customer_portal_link"
+        ]
       },
       "CancelSubscriptionRequestEntity": {
         "type": "object",
@@ -4375,13 +4757,19 @@
           "mode": {
             "type": "string",
             "description": "The mode of cancellation (immediate or scheduled), default can be configured in the store billing settings.",
-            "enum": ["immediate", "scheduled"],
+            "enum": [
+              "immediate",
+              "scheduled"
+            ],
             "example": "immediate"
           },
           "onExecute": {
             "type": "string",
             "description": "The action to execute when canceling (cancel or pause) when mode is scheduled, ignored when mode is immediate or not provided",
-            "enum": ["cancel", "pause"],
+            "enum": [
+              "cancel",
+              "pause"
+            ],
             "example": "cancel"
           }
         }
@@ -4420,7 +4808,11 @@
           "update_behavior": {
             "type": "string",
             "description": "The update behavior for the subscription (defaults to proration)",
-            "enum": ["proration-charge-immediately", "proration-charge", "proration-none"],
+            "enum": [
+              "proration-charge-immediately",
+              "proration-charge",
+              "proration-none"
+            ],
             "default": "proration-charge"
           }
         }
@@ -4436,11 +4828,17 @@
           "update_behavior": {
             "type": "string",
             "description": "The update behavior for the subscription (defaults to proration-charge-immediately)",
-            "enum": ["proration-charge-immediately", "proration-charge", "proration-none"],
+            "enum": [
+              "proration-charge-immediately",
+              "proration-charge",
+              "proration-none"
+            ],
             "default": "proration-charge-immediately"
           }
         },
-        "required": ["product_id"]
+        "required": [
+          "product_id"
+        ]
       },
       "FeatureFileEntity": {
         "type": "object",
@@ -4471,7 +4869,13 @@
             "example": 1024000
           }
         },
-        "required": ["id", "file_name", "url", "type", "size"]
+        "required": [
+          "id",
+          "file_name",
+          "url",
+          "type",
+          "size"
+        ]
       },
       "FileFeatureEntity": {
         "type": "object",
@@ -4484,7 +4888,9 @@
             }
           }
         },
-        "required": ["files"]
+        "required": [
+          "files"
+        ]
       },
       "CustomerCreditsFeatureEntity": {
         "type": "object",
@@ -4501,7 +4907,9 @@
             "nullable": true
           }
         },
-        "required": ["amount"]
+        "required": [
+          "amount"
+        ]
       },
       "ProductFeatureEntity": {
         "type": "object",
@@ -4585,7 +4993,12 @@
           "status": {
             "type": "string",
             "description": "Status of the checkout.",
-            "enum": ["pending", "processing", "completed", "expired"],
+            "enum": [
+              "pending",
+              "processing",
+              "completed",
+              "expired"
+            ],
             "example": "completed"
           },
           "request_id": {
@@ -4704,14 +5117,21 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["percentage", "fixed"]
+                "enum": [
+                  "percentage",
+                  "fixed"
+                ]
               },
               "amount": {
                 "type": "number"
               },
               "duration": {
                 "type": "string",
-                "enum": ["forever", "once", "repeating"]
+                "enum": [
+                  "forever",
+                  "once",
+                  "repeating"
+                ]
               },
               "durationInMonths": {
                 "type": "number"
@@ -4719,7 +5139,13 @@
             }
           }
         },
-        "required": ["id", "mode", "object", "status", "product"]
+        "required": [
+          "id",
+          "mode",
+          "object",
+          "status",
+          "product"
+        ]
       },
       "CustomerRequestEntity": {
         "type": "object",
@@ -4733,6 +5159,11 @@
             "type": "string",
             "description": "Customer email address. You may only specify one of these parameters: id, email.",
             "example": "user@example.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "Customer full name. Used to prefill the name field on the checkout page.",
+            "example": "John Doe"
           }
         }
       },
@@ -4762,6 +5193,11 @@
             "type": "string",
             "description": "Prefill the checkout session with a discount code.",
             "example": "SUMMER2024"
+          },
+          "affiliate_code": {
+            "type": "string",
+            "description": "Attribute this checkout to an affiliate using the affiliate's referral code (the unique code from their referral link). Use this to manually credit a sale to a specific affiliate when you already hold their code on your backend, instead of relying on referral-link clicks/cookies. The code must belong to an active affiliate of this store; an invalid, inactive, or foreign-store code is rejected.",
+            "example": "aff_abc123"
           },
           "customer": {
             "description": "Customer data for checkout session. This will prefill the customer info on the checkout page.",
@@ -4801,7 +5237,9 @@
             "additionalProperties": true
           }
         },
-        "required": ["product_id"]
+        "required": [
+          "product_id"
+        ]
       },
       "ActivateLicenseRequestEntity": {
         "type": "object",
@@ -4815,7 +5253,10 @@
             "description": "A label for the new instance to identify it in Creem."
           }
         },
-        "required": ["key", "instance_name"]
+        "required": [
+          "key",
+          "instance_name"
+        ]
       },
       "DeactivateLicenseRequestEntity": {
         "type": "object",
@@ -4829,7 +5270,10 @@
             "description": "Id of the instance to deactivate."
           }
         },
-        "required": ["key", "instance_id"]
+        "required": [
+          "key",
+          "instance_id"
+        ]
       },
       "ValidateLicenseRequestEntity": {
         "type": "object",
@@ -4843,7 +5287,10 @@
             "description": "Id of the instance to validate."
           }
         },
-        "required": ["key", "instance_id"]
+        "required": [
+          "key",
+          "instance_id"
+        ]
       },
       "LicenseInstanceListEntity": {
         "type": "object",
@@ -4864,7 +5311,10 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "DiscountEntity": {
         "type": "object",
@@ -4884,7 +5334,13 @@
           "status": {
             "type": "string",
             "description": "The status of the discount (e.g., active, inactive).",
-            "enum": ["deleted", "active", "draft", "expired", "scheduled"],
+            "enum": [
+              "deleted",
+              "active",
+              "draft",
+              "expired",
+              "scheduled"
+            ],
             "example": "active"
           },
           "name": {
@@ -4900,7 +5356,10 @@
           "type": {
             "type": "string",
             "description": "The type of the discount, either \"percentage\" or \"fixed\".",
-            "enum": ["percentage", "fixed"],
+            "enum": [
+              "percentage",
+              "fixed"
+            ],
             "example": "percentage"
           },
           "amount": {
@@ -4932,7 +5391,11 @@
           "duration": {
             "type": "string",
             "description": "The duration type for the discount.",
-            "enum": ["forever", "once", "repeating"],
+            "enum": [
+              "forever",
+              "once",
+              "repeating"
+            ],
             "example": "repeating"
           },
           "duration_in_months": {
@@ -4942,7 +5405,10 @@
           },
           "applies_to_products": {
             "description": "The list of product IDs to which this discount applies.",
-            "example": ["prod_123", "prod_456"],
+            "example": [
+              "prod_123",
+              "prod_456"
+            ],
             "type": "array",
             "items": {
               "type": "string"
@@ -4954,7 +5420,15 @@
             "example": 15
           }
         },
-        "required": ["id", "mode", "object", "status", "name", "code", "type"]
+        "required": [
+          "id",
+          "mode",
+          "object",
+          "status",
+          "name",
+          "code",
+          "type"
+        ]
       },
       "DiscountListEntity": {
         "type": "object",
@@ -4975,17 +5449,27 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "DiscountType": {
         "type": "string",
         "description": "The type of the discount, either \"percentage\" or \"fixed\".",
-        "enum": ["percentage", "fixed"]
+        "enum": [
+          "percentage",
+          "fixed"
+        ]
       },
       "CouponDurationType": {
         "type": "string",
         "description": "The duration type for the discount.",
-        "enum": ["forever", "once", "repeating"]
+        "enum": [
+          "forever",
+          "once",
+          "repeating"
+        ]
       },
       "CreateDiscountRequestEntity": {
         "type": "object",
@@ -5040,14 +5524,22 @@
           },
           "applies_to_products": {
             "description": "The list of product IDs to which this discount applies.",
-            "example": ["prod_123", "prod_456"],
+            "example": [
+              "prod_123",
+              "prod_456"
+            ],
             "type": "array",
             "items": {
               "type": "string"
             }
           }
         },
-        "required": ["name", "type", "duration", "applies_to_products"]
+        "required": [
+          "name",
+          "type",
+          "duration",
+          "applies_to_products"
+        ]
       },
       "TransactionListEntity": {
         "type": "object",
@@ -5068,7 +5560,10 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "StatsMetricTotalsEntity": {
         "type": "object",
@@ -5150,7 +5645,11 @@
             "example": 122173
           }
         },
-        "required": ["timestamp", "grossRevenue", "netRevenue"]
+        "required": [
+          "timestamp",
+          "grossRevenue",
+          "netRevenue"
+        ]
       },
       "StatsSummaryEntity": {
         "type": "object",
@@ -5213,7 +5712,9 @@
             }
           }
         },
-        "required": ["totals"]
+        "required": [
+          "totals"
+        ]
       },
       "ScreenPromptRequest": {
         "type": "object",
@@ -5227,7 +5728,9 @@
             "description": "An optional identifier to associate this request with."
           }
         },
-        "required": ["prompt"]
+        "required": [
+          "prompt"
+        ]
       },
       "UsageEntity": {
         "type": "object",
@@ -5237,7 +5740,9 @@
             "description": "Number of units consumed by this call."
           }
         },
-        "required": ["units"]
+        "required": [
+          "units"
+        ]
       },
       "ScreenPromptResponse": {
         "type": "object",
@@ -5262,7 +5767,11 @@
           "decision": {
             "type": "string",
             "description": "The moderation decision.",
-            "enum": ["allow", "deny", "flag"]
+            "enum": [
+              "allow",
+              "deny",
+              "flag"
+            ]
           },
           "usage": {
             "description": "Usage information for this call.",
@@ -5273,7 +5782,13 @@
             ]
           }
         },
-        "required": ["id", "object", "prompt", "decision", "usage"]
+        "required": [
+          "id",
+          "object",
+          "prompt",
+          "decision",
+          "usage"
+        ]
       },
       "CreateRefundRequestEntity": {
         "type": "object",
@@ -5284,12 +5799,20 @@
             "example": "tran_1234567890"
           }
         },
-        "required": ["transaction_id"]
+        "required": [
+          "transaction_id"
+        ]
       },
       "RefundStatus": {
         "type": "string",
         "description": "Status of the refund. `pending` and `requiresAction` represent non-terminal provider processing states.",
-        "enum": ["pending", "requiresAction", "succeeded", "failed", "canceled"]
+        "enum": [
+          "pending",
+          "requiresAction",
+          "succeeded",
+          "failed",
+          "canceled"
+        ]
       },
       "RefundResponseEntity": {
         "type": "object",
@@ -5299,7 +5822,9 @@
             "$ref": "#/components/schemas/RefundStatus"
           }
         },
-        "required": ["status"]
+        "required": [
+          "status"
+        ]
       },
       "CreateAccountDto": {
         "type": "object",
@@ -5327,7 +5852,9 @@
             "example": "300"
           }
         },
-        "required": ["customer_id"]
+        "required": [
+          "customer_id"
+        ]
       },
       "AccountResponseDto": {
         "type": "object",
@@ -5359,7 +5886,11 @@
           "status": {
             "type": "string",
             "description": "Account status",
-            "enum": ["active", "frozen", "closed"]
+            "enum": [
+              "active",
+              "frozen",
+              "closed"
+            ]
           },
           "created_at": {
             "type": "string",
@@ -5401,7 +5932,11 @@
             "description": "Whether more items exist beyond this page"
           }
         },
-        "required": ["object", "data", "has_more"]
+        "required": [
+          "object",
+          "data",
+          "has_more"
+        ]
       },
       "BalanceResponseDto": {
         "type": "object",
@@ -5420,7 +5955,9 @@
             "description": "Point-in-time the balance was computed at (present for at-time queries)"
           }
         },
-        "required": ["balance"]
+        "required": [
+          "balance"
+        ]
       },
       "EntryResponseDto": {
         "type": "object",
@@ -5443,7 +5980,10 @@
           "side": {
             "type": "string",
             "description": "Debit or credit side",
-            "enum": ["debit", "credit"]
+            "enum": [
+              "debit",
+              "credit"
+            ]
           },
           "amount": {
             "type": "string",
@@ -5455,7 +5995,14 @@
             "description": "Creation timestamp"
           }
         },
-        "required": ["id", "transaction_id", "account_id", "side", "amount", "created_at"]
+        "required": [
+          "id",
+          "transaction_id",
+          "account_id",
+          "side",
+          "amount",
+          "created_at"
+        ]
       },
       "EntryListResponseDto": {
         "type": "object",
@@ -5477,7 +6024,11 @@
             "description": "Whether more items exist beyond this page"
           }
         },
-        "required": ["object", "data", "has_more"]
+        "required": [
+          "object",
+          "data",
+          "has_more"
+        ]
       },
       "CustomerCreditsErrorDetailDto": {
         "type": "object",
@@ -5516,7 +6067,12 @@
             "example": "req_abc123def456"
           }
         },
-        "required": ["type", "code", "message", "request_id"]
+        "required": [
+          "type",
+          "code",
+          "message",
+          "request_id"
+        ]
       },
       "CustomerCreditsErrorResponseDto": {
         "type": "object",
@@ -5530,7 +6086,9 @@
             ]
           }
         },
-        "required": ["error"]
+        "required": [
+          "error"
+        ]
       },
       "CreditDebitRequestDto": {
         "type": "object",
@@ -5551,7 +6109,11 @@
             "example": "idem_abc123"
           }
         },
-        "required": ["amount", "reference", "idempotency_key"]
+        "required": [
+          "amount",
+          "reference",
+          "idempotency_key"
+        ]
       },
       "TransactionResponseDto": {
         "type": "object",
@@ -5592,7 +6154,14 @@
             "description": "Creation timestamp"
           }
         },
-        "required": ["id", "store_id", "reference", "idempotency_key", "entries", "created_at"]
+        "required": [
+          "id",
+          "store_id",
+          "reference",
+          "idempotency_key",
+          "entries",
+          "created_at"
+        ]
       },
       "ReverseTransactionRequestDto": {
         "type": "object",
@@ -5603,7 +6172,103 @@
             "example": "cct_abc123"
           }
         },
-        "required": ["transaction_id"]
+        "required": [
+          "transaction_id"
+        ]
+      },
+      "CreateAffiliateInviteRequestEntity": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "The email address to send the affiliate invitation to.",
+            "example": "partner@example.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name of the affiliate being invited.",
+            "example": "Jane Partner"
+          },
+          "program_id": {
+            "type": "string",
+            "description": "The ID of the affiliate program to invite into. Optional: when omitted, the invitation falls back to the store's affiliate program. Provide this only if your store runs more than one program.",
+            "example": "prog_1234567890",
+            "nullable": true
+          }
+        },
+        "required": [
+          "email",
+          "name"
+        ]
+      },
+      "AffiliateInviteEntity": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the object."
+          },
+          "mode": {
+            "$ref": "#/components/schemas/EnvironmentMode"
+          },
+          "object": {
+            "type": "string",
+            "description": "String representing the object's type. Objects of the same type share the same value.",
+            "example": "affiliate-invite"
+          },
+          "email": {
+            "type": "string",
+            "description": "The email address the affiliate was invited with.",
+            "example": "partner@example.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name the affiliate was invited with.",
+            "example": "Jane Partner",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "description": "The lifecycle status of the invitation: `pending` while the invitee has not yet accepted, `accepted` once they have joined the program.",
+            "example": "pending"
+          },
+          "created_at": {
+            "type": "number",
+            "description": "Creation date of the invitation as a timestamp."
+          }
+        },
+        "required": [
+          "id",
+          "mode",
+          "object",
+          "email",
+          "status",
+          "created_at"
+        ]
+      },
+      "AffiliateInviteListEntity": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "List of affiliate invitation items",
+            "items": {
+              "$ref": "#/components/schemas/AffiliateInviteEntity"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "description": "Pagination details for the list",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationEntity"
+              }
+            ]
+          }
+        },
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "AffiliateEntity": {
         "type": "object",
@@ -5700,12 +6365,19 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "CommissionStatus": {
         "type": "string",
         "description": "The settlement status of the commission. `pending` while on hold, `approved` once cleared and available, `paid` once settled by a payout.",
-        "enum": ["pending", "approved", "paid"]
+        "enum": [
+          "pending",
+          "approved",
+          "paid"
+        ]
       },
       "CommissionEntity": {
         "type": "object",
@@ -5782,7 +6454,10 @@
             ]
           }
         },
-        "required": ["items", "pagination"]
+        "required": [
+          "items",
+          "pagination"
+        ]
       },
       "WebhookSubscriptionEntity": {
         "type": "object",
@@ -5905,14 +6580,21 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["percentage", "fixed"]
+                "enum": [
+                  "percentage",
+                  "fixed"
+                ]
               },
               "amount": {
                 "type": "number"
               },
               "duration": {
                 "type": "string",
-                "enum": ["forever", "once", "repeating"]
+                "enum": [
+                  "forever",
+                  "once",
+                  "repeating"
+                ]
               },
               "durationInMonths": {
                 "type": "number"
@@ -5952,7 +6634,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["checkout.completed"]
+            "enum": [
+              "checkout.completed"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -5967,13 +6651,23 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "RefundReason": {
         "type": "string",
         "description": "Reason for the refund.",
-        "enum": ["duplicate", "fraudulent", "requested_by_customer", "other"]
+        "enum": [
+          "duplicate",
+          "fraudulent",
+          "requested_by_customer",
+          "other"
+        ]
       },
       "RefundEntity": {
         "type": "object",
@@ -6085,7 +6779,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["refund.created"]
+            "enum": [
+              "refund.created"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6100,7 +6796,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "DisputeEntity": {
@@ -6184,7 +6885,15 @@
             "description": "Creation date of the dispute as timestamp"
           }
         },
-        "required": ["id", "mode", "object", "amount", "currency", "transaction", "created_at"]
+        "required": [
+          "id",
+          "mode",
+          "object",
+          "amount",
+          "currency",
+          "transaction",
+          "created_at"
+        ]
       },
       "WebhookDisputeCreatedEventEntity": {
         "type": "object",
@@ -6196,7 +6905,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["dispute.created"]
+            "enum": [
+              "dispute.created"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6211,7 +6922,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionActiveEventEntity": {
@@ -6224,7 +6940,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.active"]
+            "enum": [
+              "subscription.active"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6239,7 +6957,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionTrialingEventEntity": {
@@ -6252,7 +6975,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.trialing"]
+            "enum": [
+              "subscription.trialing"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6267,7 +6992,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionCanceledEventEntity": {
@@ -6280,7 +7010,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.canceled"]
+            "enum": [
+              "subscription.canceled"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6295,7 +7027,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionScheduledCancelEventEntity": {
@@ -6308,7 +7045,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.scheduled_cancel"]
+            "enum": [
+              "subscription.scheduled_cancel"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6323,7 +7062,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionPaidEventEntity": {
@@ -6336,7 +7080,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.paid"]
+            "enum": [
+              "subscription.paid"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6351,7 +7097,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionExpiredEventEntity": {
@@ -6364,7 +7115,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.expired"]
+            "enum": [
+              "subscription.expired"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6379,7 +7132,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionUnpaidEventEntity": {
@@ -6392,7 +7150,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.unpaid"]
+            "enum": [
+              "subscription.unpaid"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6407,7 +7167,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionUpdateEventEntity": {
@@ -6420,7 +7185,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.update"]
+            "enum": [
+              "subscription.update"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6435,7 +7202,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionPastDueEventEntity": {
@@ -6448,7 +7220,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.past_due"]
+            "enum": [
+              "subscription.past_due"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6463,7 +7237,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionPausedEventEntity": {
@@ -6476,7 +7255,9 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": ["subscription.paused"]
+            "enum": [
+              "subscription.paused"
+            ]
           },
           "created_at": {
             "type": "number",
@@ -6491,7 +7272,12 @@
             ]
           }
         },
-        "required": ["id", "eventType", "created_at", "object"],
+        "required": [
+          "id",
+          "eventType",
+          "created_at",
+          "object"
+        ],
         "x-speakeasy-include": true
       },
       "WebhookEventEntity": {

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -286,7 +286,8 @@
               "guides/sell-canva-templates",
               "guides/sell-framer-templates-instant-remix-links",
               "guides/customer-credits-recipes",
-              "guides/faq"
+              "guides/faq",
+              "guides/affiliate-program-via-api"
             ]
           }
         ]
@@ -342,7 +343,9 @@
             "pages": [
               "api-reference/endpoint/list-affiliates",
               "api-reference/endpoint/retrieve-affiliate",
-              "api-reference/endpoint/list-affiliate-commissions"
+              "api-reference/endpoint/list-affiliate-commissions",
+              "api-reference/endpoint/create-affiliate-invite",
+              "api-reference/endpoint/list-affiliate-invites"
             ]
           },
           {

--- a/packages/docs/guides/affiliate-program-via-api.mdx
+++ b/packages/docs/guides/affiliate-program-via-api.mdx
@@ -1,0 +1,115 @@
+---
+title: "Run Your Affiliate Program via API"
+description: "Invite partners, attribute sales, and track commissions programmatically — without leaving your own backend."
+---
+
+Everything the [Affiliate Hub dashboard](/features/affiliate-program) does for inviting and tracking partners is also available over the API. This guide walks through the full lifecycle: inviting an affiliate, understanding how sales are attributed, and reading commission data back.
+
+If you are new to the affiliate platform itself (programs, commission terms, payouts), start with the [Affiliate Program feature guide](/features/affiliate-program) — this page assumes a program already exists on your store.
+
+## Prerequisites
+
+- An affiliate program on your store, created from the Affiliate Hub.
+- An API key with the right scopes: reading affiliate data requires `affiliates:read`, creating invitations requires `affiliates:write`. Keys created with **Full access** cover both, including scopes added after the key was created.
+
+<Note>
+  All endpoints work in both test and live mode — use your test-mode API key while integrating.
+  Responses carry a `mode` field so you always know which environment you are looking at.
+</Note>
+
+## 1. Invite partners programmatically
+
+Create an invitation from your own backend — for example when someone fills in a "become a partner" form on your site, or when you sync partners from your CRM:
+
+```bash
+curl -X POST https://api.creem.io/v1/affiliates/invites \
+  -H "x-api-key: creem_..." \
+  -H "Content-Type: application/json" \
+  -d '{"email": "partner@example.com", "name": "Jane Partner"}'
+```
+
+The invitee receives the same invitation email as a dashboard-created invite, and appears in your Affiliate Hub's **Invites** tab immediately. Once they accept, an affiliate account is provisioned and they become an active partner.
+
+`program_id` is optional — when omitted, the invitation is created for your store's affiliate program. Pass it explicitly if your store runs more than one program.
+
+A few behaviors to design around:
+
+| Behavior                               | Response                                              |
+| -------------------------------------- | ----------------------------------------------------- |
+| Same email invited twice               | `409 Conflict` — one pending invitation per email     |
+| Invitee is a member of your store team | `400 Bad Request` — team members cannot be affiliates |
+| Pending-invite limit reached           | `400 Bad Request` — see below                         |
+| Key lacks `affiliates:write`           | `403 Forbidden`                                       |
+
+<Warning>
+  A store can have at most **100 pending invitations** at a time. Accepted invitations free their
+  slot; you can also cancel stale pending invites from the Affiliate Hub. If you legitimately need a
+  higher limit, contact [support@creem.io](mailto:support@creem.io) and we will raise it for your
+  store — no code changes needed.
+</Warning>
+
+Track the lifecycle of your invitations with [List affiliate invites](/api-reference/endpoint/list-affiliate-invites) — each invitation carries a `status` of `pending`, `accepted`, `canceled`, or `rejected`.
+
+## 2. How sales get attributed
+
+A sale is credited to an affiliate through one of three paths. Each checkout gets **exactly one** attribution — they never stack, and an explicit `affiliate_code` on the API request takes precedence.
+
+<CardGroup cols={1}>
+  <Card title="Referral link (cookie-based)" icon="link">
+    The default path. Each affiliate gets a unique referral link (`creem.io/affiliate?code=...`). A
+    click records attribution and redirects the visitor to your site; any extra query parameters on
+    the link (UTMs, deep-link params) are forwarded to your destination URL, so affiliates can
+    target specific landing pages and you can see their campaigns in your own analytics.
+  </Card>
+  <Card title="Affiliate code on the Checkout API" icon="code">
+    For server-driven and headless checkouts where cookies never enter the picture. If you already
+    know which affiliate referred the customer, pass their referral code when creating the checkout
+    — no click required.
+  </Card>
+  <Card title="Affiliate-linked discount code" icon="tag">
+    If an affiliate has a discount code assigned in the Affiliate Hub, any checkout using that code
+    credits them — including codes prefilled via the API.
+  </Card>
+</CardGroup>
+
+Passing the code at checkout creation:
+
+```bash
+curl -X POST https://api.creem.io/v1/checkouts \
+  -H "x-api-key: creem_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "product_id": "prod_...",
+    "affiliate_code": "AFFXXXXXXXX"
+  }'
+```
+
+The `affiliate_code` value is the affiliate's referral-link code — the same code you see in [List affiliates](/api-reference/endpoint/list-affiliates) responses and the affiliate sees in their portal. An invalid, inactive, or foreign-store code is rejected with `400 Bad Request` before the checkout is created, so a typo can never silently drop attribution.
+
+## 3. Commissions
+
+Commission math follows the program's configuration — you do not compute anything yourself:
+
+- **Type and value**: percentage of the sale or a fixed amount per sale.
+- **Recurrence**: `recurring` pays on every subscription payment; `one_time` pays only on the first payment of a subscription (the CPA model).
+- **Duration**: recurring commissions can be capped to a number of months.
+- **Per-product rates**: individual products can override the program rate, including a `0` rate to exclude a product entirely.
+
+Read results back with [List affiliate commissions](/api-reference/endpoint/list-affiliate-commissions), or aggregate views per partner via [List affiliates](/api-reference/endpoint/list-affiliates) (clicks, conversions, earnings per affiliate).
+
+Payouts to affiliates are handled by Creem through the affiliate portal, including identity verification — nothing to build on your side. See [the feature guide](/features/affiliate-program) for the payout flow.
+
+## Current limitations
+
+- **No affiliate webhooks yet.** Invitation acceptance and new conversions are not pushed as webhook events — poll [List affiliate invites](/api-reference/endpoint/list-affiliate-invites) and [List affiliate commissions](/api-reference/endpoint/list-affiliate-commissions) where you need to react to changes.
+- **Program management stays in the dashboard.** Creating programs and editing commission terms is done in the Affiliate Hub, not the public API.
+
+## Endpoint reference
+
+| Endpoint                                                                                   | Scope              | Purpose                                     |
+| ------------------------------------------------------------------------------------------ | ------------------ | ------------------------------------------- |
+| [`GET /v1/affiliates`](/api-reference/endpoint/list-affiliates)                            | `affiliates:read`  | List your affiliates with performance stats |
+| [`GET /v1/affiliates/:id`](/api-reference/endpoint/retrieve-affiliate)                     | `affiliates:read`  | Retrieve one affiliate                      |
+| [`GET /v1/affiliates/:id/commissions`](/api-reference/endpoint/list-affiliate-commissions) | `affiliates:read`  | List an affiliate's commissions             |
+| [`POST /v1/affiliates/invites`](/api-reference/endpoint/create-affiliate-invite)           | `affiliates:write` | Invite a partner by email                   |
+| [`GET /v1/affiliates/invites`](/api-reference/endpoint/list-affiliate-invites)             | `affiliates:read`  | List invitations and their status           |


### PR DESCRIPTION
## Why

The affiliate invitation API (`POST/GET /v1/affiliates/invites`) and the `affiliate_code` field on Create Checkout shipped to production but are absent from docs.creem.io — the Affiliate group only covers the read-only endpoints. There is also no guide explaining how the affiliate API pieces fit together.

## What

- **`api-reference/openapi.json`** refreshed from the live spec (`npm run generate:api:remote`) — brings in the two invitation endpoints and the `affiliate_code` request field on Create Checkout.
- **Two generated endpoint pages** (`create-affiliate-invite`, `list-affiliate-invites`) added to the Affiliate nav group. Descriptions come from the controllers' OpenAPI annotations; the generator reports `[desc: ✓]` for both.
- **New guide: "Run Your Affiliate Program via API"** — programmatic invites (409 duplicate / 400 team-member / 403 scope behaviors and the 100-pending-invite cap with support override), the three attribution paths (referral link with query-param forwarding, `affiliate_code` on checkout, affiliate-linked discount) and their precedence, commission terms, and current limitations (no affiliate webhooks yet — poll; program management is dashboard-only).

Every behavioral claim in the guide was verified against the backend code and by manual QA of the shipped endpoints.

Ref: ENG-693 (pugpay-monorepo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)