### PR TITLE
fix(sdk): run prettier on openapi.json

### DIFF
--- a/packages/creem-sdk/openapi.json
+++ b/packages/creem-sdk/openapi.json
@@ -80,9 +80,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "security": [
           {
             "ApiKey": []
@@ -139,9 +137,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "security": [
           {
             "ApiKey": []
@@ -187,9 +183,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "security": [
           {
             "ApiKey": []
@@ -244,9 +238,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "security": [
           {
             "ApiKey": []
@@ -290,9 +282,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Products"
-        ],
+        "tags": ["Products"],
         "security": [
           {
             "ApiKey": []
@@ -370,9 +360,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "security": [
           {
             "ApiKey": []
@@ -440,9 +428,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "security": [
           {
             "ApiKey": []
@@ -510,9 +496,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "security": [
           {
             "ApiKey": []
@@ -580,9 +564,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "security": [
           {
             "ApiKey": []
@@ -639,9 +621,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "security": [
           {
             "ApiKey": []
@@ -686,9 +666,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "security": [
           {
             "ApiKey": []
@@ -732,9 +710,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "security": [
           {
             "ApiKey": []
@@ -781,9 +757,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Customers"
-        ],
+        "tags": ["Customers"],
         "security": [
           {
             "ApiKey": []
@@ -830,9 +804,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Subscriptions"
-        ],
+        "tags": ["Subscriptions"],
         "security": [
           {
             "ApiKey": []
@@ -910,9 +882,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Subscriptions"
-        ],
+        "tags": ["Subscriptions"],
         "security": [
           {
             "ApiKey": []
@@ -969,9 +939,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Subscriptions"
-        ],
+        "tags": ["Subscriptions"],
         "security": [
           {
             "ApiKey": []
@@ -1028,9 +996,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Subscriptions"
-        ],
+        "tags": ["Subscriptions"],
         "security": [
           {
             "ApiKey": []
@@ -1087,9 +1053,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Subscriptions"
-        ],
+        "tags": ["Subscriptions"],
         "security": [
           {
             "ApiKey": []
@@ -1135,9 +1099,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Subscriptions"
-        ],
+        "tags": ["Subscriptions"],
         "security": [
           {
             "ApiKey": []
@@ -1183,9 +1145,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Subscriptions"
-        ],
+        "tags": ["Subscriptions"],
         "security": [
           {
             "ApiKey": []
@@ -1232,9 +1192,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Checkouts"
-        ],
+        "tags": ["Checkouts"],
         "security": [
           {
             "ApiKey": []
@@ -1279,9 +1237,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Checkouts"
-        ],
+        "tags": ["Checkouts"],
         "security": [
           {
             "ApiKey": []
@@ -1328,9 +1284,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Licenses"
-        ],
+        "tags": ["Licenses"],
         "security": [
           {
             "ApiKey": []
@@ -1377,9 +1331,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Licenses"
-        ],
+        "tags": ["Licenses"],
         "security": [
           {
             "ApiKey": []
@@ -1426,9 +1378,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Licenses"
-        ],
+        "tags": ["Licenses"],
         "security": [
           {
             "ApiKey": []
@@ -1515,9 +1465,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Licenses"
-        ],
+        "tags": ["Licenses"],
         "security": [
           {
             "ApiKey": []
@@ -1589,10 +1537,7 @@
             "in": "query",
             "description": "Filter by discount status.",
             "schema": {
-              "enum": [
-                "active",
-                "deleted"
-              ],
+              "enum": ["active", "deleted"],
               "type": "string"
             }
           },
@@ -1602,10 +1547,7 @@
             "in": "query",
             "description": "Filter by discount type.",
             "schema": {
-              "enum": [
-                "percentage",
-                "fixed"
-              ],
+              "enum": ["percentage", "fixed"],
               "type": "string"
             }
           },
@@ -1651,9 +1593,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Discounts"
-        ],
+        "tags": ["Discounts"],
         "security": [
           {
             "ApiKey": []
@@ -1710,9 +1650,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Discounts"
-        ],
+        "tags": ["Discounts"],
         "security": [
           {
             "ApiKey": []
@@ -1757,9 +1695,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Discounts"
-        ],
+        "tags": ["Discounts"],
         "security": [
           {
             "ApiKey": []
@@ -1805,9 +1741,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Discounts"
-        ],
+        "tags": ["Discounts"],
         "security": [
           {
             "ApiKey": []
@@ -1854,9 +1788,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Transactions"
-        ],
+        "tags": ["Transactions"],
         "security": [
           {
             "ApiKey": []
@@ -1964,9 +1896,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Transactions"
-        ],
+        "tags": ["Transactions"],
         "security": [
           {
             "ApiKey": []
@@ -2005,11 +1935,7 @@
             "in": "query",
             "description": "Groups time-series data into buckets of this size. Requires startDate and endDate. Returns a periods array with one entry per bucket containing grossRevenue and netRevenue.",
             "schema": {
-              "enum": [
-                "day",
-                "week",
-                "month"
-              ],
+              "enum": ["day", "week", "month"],
               "type": "string"
             }
           },
@@ -2018,10 +1944,7 @@
             "required": true,
             "in": "query",
             "schema": {
-              "enum": [
-                "EUR",
-                "USD"
-              ],
+              "enum": ["EUR", "USD"],
               "type": "string"
             }
           }
@@ -2047,9 +1970,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Stats"
-        ],
+        "tags": ["Stats"],
         "security": [
           {
             "ApiKey": []
@@ -2096,9 +2017,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Moderation"
-        ],
+        "tags": ["Moderation"],
         "security": [
           {
             "ApiKey": []
@@ -2146,9 +2065,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Refunds"
-        ],
+        "tags": ["Refunds"],
         "security": [
           {
             "ApiKey": []
@@ -2195,9 +2112,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Customer Credits - Accounts (Experimental)"
-        ],
+        "tags": ["Customer Credits - Accounts (Experimental)"],
         "security": [
           {
             "ApiKey": []
@@ -2292,9 +2207,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Customer Credits - Accounts (Experimental)"
-        ],
+        "tags": ["Customer Credits - Accounts (Experimental)"],
         "security": [
           {
             "ApiKey": []
@@ -2340,9 +2253,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Customer Credits - Accounts (Experimental)"
-        ],
+        "tags": ["Customer Credits - Accounts (Experimental)"],
         "security": [
           {
             "ApiKey": []
@@ -2398,9 +2309,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Customer Credits - Accounts (Experimental)"
-        ],
+        "tags": ["Customer Credits - Accounts (Experimental)"],
         "security": [
           {
             "ApiKey": []
@@ -2495,9 +2404,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Customer Credits - Accounts (Experimental)"
-        ],
+        "tags": ["Customer Credits - Accounts (Experimental)"],
         "security": [
           {
             "ApiKey": []
@@ -2553,9 +2460,7 @@
             }
           }
         },
-        "tags": [
-          "Customer Credits - Accounts (Experimental)"
-        ],
+        "tags": ["Customer Credits - Accounts (Experimental)"],
         "security": [
           {
             "ApiKey": []
@@ -2611,9 +2516,7 @@
             }
           }
         },
-        "tags": [
-          "Customer Credits - Accounts (Experimental)"
-        ],
+        "tags": ["Customer Credits - Accounts (Experimental)"],
         "security": [
           {
             "ApiKey": []
@@ -2679,9 +2582,7 @@
             }
           }
         },
-        "tags": [
-          "Customer Credits - Accounts (Experimental)"
-        ],
+        "tags": ["Customer Credits - Accounts (Experimental)"],
         "security": [
           {
             "ApiKey": []
@@ -2747,9 +2648,7 @@
             }
           }
         },
-        "tags": [
-          "Customer Credits - Accounts (Experimental)"
-        ],
+        "tags": ["Customer Credits - Accounts (Experimental)"],
         "security": [
           {
             "ApiKey": []
@@ -2805,9 +2704,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Customer Credits - Accounts (Experimental)"
-        ],
+        "tags": ["Customer Credits - Accounts (Experimental)"],
         "security": [
           {
             "ApiKey": []
@@ -2863,9 +2760,7 @@
             }
           }
         },
-        "tags": [
-          "Customer Credits - Accounts (Experimental)"
-        ],
+        "tags": ["Customer Credits - Accounts (Experimental)"],
         "security": [
           {
             "ApiKey": []
@@ -2915,9 +2810,7 @@
             "description": "Conflict - an invitation has already been sent to this email address"
           }
         },
-        "tags": [
-          "Affiliates"
-        ],
+        "tags": ["Affiliates"],
         "security": [
           {
             "ApiKey": []
@@ -2993,9 +2886,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Affiliates"
-        ],
+        "tags": ["Affiliates"],
         "security": [
           {
             "ApiKey": []
@@ -3073,9 +2964,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Affiliates"
-        ],
+        "tags": ["Affiliates"],
         "security": [
           {
             "ApiKey": []
@@ -3121,9 +3010,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Affiliates"
-        ],
+        "tags": ["Affiliates"],
         "security": [
           {
             "ApiKey": []
@@ -3219,9 +3106,7 @@
             "description": "Not Found - Resource does not exist"
           }
         },
-        "tags": [
-          "Affiliates"
-        ],
+        "tags": ["Affiliates"],
         "security": [
           {
             "ApiKey": []
@@ -3271,29 +3156,17 @@
       "ProductStatus": {
         "type": "string",
         "description": "Lifecycle status of the product: `active` or `archived`.",
-        "enum": [
-          "active",
-          "archived"
-        ]
+        "enum": ["active", "archived"]
       },
       "EnvironmentMode": {
         "type": "string",
         "description": "String representing the environment.",
-        "enum": [
-          "test",
-          "prod",
-          "sandbox"
-        ]
+        "enum": ["test", "prod", "sandbox"]
       },
       "ProductFeatureType": {
         "type": "string",
         "description": "The type of the feature: `custom` (private note), `file` (downloadable files), `licenseKey` (license key), or `customerCredits` (customer credit grant).",
-        "enum": [
-          "custom",
-          "file",
-          "licenseKey",
-          "customerCredits"
-        ]
+        "enum": ["custom", "file", "licenseKey", "customerCredits"]
       },
       "FeatureEntity": {
         "type": "object",
@@ -3313,19 +3186,12 @@
             "example": "Access to premium course materials."
           }
         },
-        "required": [
-          "id",
-          "type",
-          "description"
-        ]
+        "required": ["id", "type", "description"]
       },
       "ProductBillingType": {
         "type": "string",
         "description": "Indicates the billing method for the customer. It can either be a `recurring` billing cycle or a `onetime` payment.",
-        "enum": [
-          "recurring",
-          "onetime"
-        ]
+        "enum": ["recurring", "onetime"]
       },
       "ProductBillingPeriod": {
         "type": "string",
@@ -3342,27 +3208,17 @@
       "TaxMode": {
         "type": "string",
         "description": "Specifies the tax calculation mode for the transaction. If set to \"inclusive,\" the tax is included in the price. If set to \"exclusive,\" the tax is added on top of the price.",
-        "enum": [
-          "inclusive",
-          "exclusive"
-        ]
+        "enum": ["inclusive", "exclusive"]
       },
       "TaxCategory": {
         "type": "string",
         "description": "Categorizes the type of product or service for tax purposes. This helps determine the applicable tax rules based on the nature of the item or service.",
-        "enum": [
-          "saas",
-          "digital-goods-service",
-          "ebooks"
-        ]
+        "enum": ["saas", "digital-goods-service", "ebooks"]
       },
       "CustomFieldType": {
         "type": "string",
         "description": "The type of the field.",
-        "enum": [
-          "text",
-          "checkbox"
-        ]
+        "enum": ["text", "checkbox"]
       },
       "Text": {
         "type": "object",
@@ -3439,11 +3295,7 @@
             ]
           }
         },
-        "required": [
-          "type",
-          "key",
-          "label"
-        ]
+        "required": ["type", "key", "label"]
       },
       "ProductEntity": {
         "type": "object",
@@ -3475,9 +3327,7 @@
           },
           "image_urls": {
             "description": "Ordered list of product image URLs. The first entry is the cover image (mirrored in image_url).",
-            "example": [
-              "https://example.com/image.jpg"
-            ],
+            "example": ["https://example.com/image.jpg"],
             "type": "array",
             "items": {
               "type": "string"
@@ -3600,13 +3450,7 @@
             "nullable": true
           }
         },
-        "required": [
-          "total_records",
-          "total_pages",
-          "current_page",
-          "next_page",
-          "prev_page"
-        ]
+        "required": ["total_records", "total_pages", "current_page", "next_page", "prev_page"]
       },
       "ProductListEntity": {
         "type": "object",
@@ -3627,26 +3471,17 @@
             ]
           }
         },
-        "required": [
-          "items",
-          "pagination"
-        ]
+        "required": ["items", "pagination"]
       },
       "ProductCurrency": {
         "type": "string",
         "description": "Three-letter uppercase ISO 4217 currency code. Must be one of Creem's supported currencies.",
-        "enum": [
-          "EUR",
-          "USD"
-        ]
+        "enum": ["EUR", "USD"]
       },
       "ProductRequestBillingType": {
         "type": "string",
         "description": "Billing method for the product: `recurring` subscription or `onetime` payment.",
-        "enum": [
-          "recurring",
-          "onetime"
-        ]
+        "enum": ["recurring", "onetime"]
       },
       "ProductRequestBillingPeriod": {
         "type": "string",
@@ -3663,10 +3498,7 @@
       "CustomFieldRequestType": {
         "type": "string",
         "description": "The type of the field.",
-        "enum": [
-          "text",
-          "checkbox"
-        ]
+        "enum": ["text", "checkbox"]
       },
       "TextFieldConfig": {
         "type": "object",
@@ -3733,11 +3565,7 @@
             ]
           }
         },
-        "required": [
-          "type",
-          "key",
-          "label"
-        ]
+        "required": ["type", "key", "label"]
       },
       "CreateProductRequestEntity": {
         "type": "object",
@@ -3757,10 +3585,7 @@
           },
           "image_urls": {
             "description": "Ordered list of product image URLs (max 8). The first entry is the cover image; when provided it takes precedence over image_url.",
-            "example": [
-              "https://picsum.photos/200/300",
-              "https://picsum.photos/200/301"
-            ],
+            "example": ["https://picsum.photos/200/300", "https://picsum.photos/200/301"],
             "type": "array",
             "items": {
               "type": "string"
@@ -3827,13 +3652,7 @@
             "default": false
           }
         },
-        "required": [
-          "name",
-          "description",
-          "price",
-          "currency",
-          "billing_type"
-        ]
+        "required": ["name", "description", "price", "currency", "billing_type"]
       },
       "UpdateProductRequestEntity": {
         "type": "object",
@@ -3945,15 +3764,7 @@
             "example": "2023-01-01T00:00:00Z"
           }
         },
-        "required": [
-          "id",
-          "mode",
-          "object",
-          "email",
-          "country",
-          "created_at",
-          "updated_at"
-        ]
+        "required": ["id", "mode", "object", "email", "country", "created_at", "updated_at"]
       },
       "CustomerListEntity": {
         "type": "object",
@@ -3974,26 +3785,17 @@
             ]
           }
         },
-        "required": [
-          "items",
-          "pagination"
-        ]
+        "required": ["items", "pagination"]
       },
       "OrderStatus": {
         "type": "string",
         "description": "Current status of the order.",
-        "enum": [
-          "pending",
-          "paid"
-        ]
+        "enum": ["pending", "paid"]
       },
       "OrderType": {
         "type": "string",
         "description": "The type of order. This can specify whether it's a regular purchase, subscription, etc.",
-        "enum": [
-          "recurring",
-          "onetime"
-        ]
+        "enum": ["recurring", "onetime"]
       },
       "OrderEntity": {
         "type": "object",
@@ -4141,10 +3943,7 @@
             ]
           }
         },
-        "required": [
-          "items",
-          "pagination"
-        ]
+        "required": ["items", "pagination"]
       },
       "SubscriptionItemEntity": {
         "type": "object",
@@ -4174,18 +3973,12 @@
             "nullable": true
           }
         },
-        "required": [
-          "id",
-          "mode",
-          "object"
-        ]
+        "required": ["id", "mode", "object"]
       },
       "SubscriptionCollectionMethod": {
         "type": "string",
         "description": "The method used for collecting payments for the subscription.",
-        "enum": [
-          "charge_automatically"
-        ]
+        "enum": ["charge_automatically"]
       },
       "SubscriptionStatus": {
         "type": "string",
@@ -4203,10 +3996,7 @@
       "TransactionType": {
         "type": "string",
         "description": "The type of transaction. payment(one time payments) and invoice(subscription)",
-        "enum": [
-          "payment",
-          "invoice"
-        ]
+        "enum": ["payment", "invoice"]
       },
       "TransactionStatus": {
         "type": "string",
@@ -4317,16 +4107,7 @@
             "description": "Creation date of the order as timestamp"
           }
         },
-        "required": [
-          "id",
-          "mode",
-          "object",
-          "amount",
-          "currency",
-          "type",
-          "status",
-          "created_at"
-        ]
+        "required": ["id", "mode", "object", "amount", "currency", "type", "status", "created_at"]
       },
       "SubscriptionEntity": {
         "type": "object",
@@ -4455,21 +4236,14 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "percentage",
-                  "fixed"
-                ]
+                "enum": ["percentage", "fixed"]
               },
               "amount": {
                 "type": "number"
               },
               "duration": {
                 "type": "string",
-                "enum": [
-                  "forever",
-                  "once",
-                  "repeating"
-                ]
+                "enum": ["forever", "once", "repeating"]
               },
               "durationInMonths": {
                 "type": "number"
@@ -4517,20 +4291,12 @@
             ]
           }
         },
-        "required": [
-          "items",
-          "pagination"
-        ]
+        "required": ["items", "pagination"]
       },
       "LicenseStatus": {
         "type": "string",
         "description": "The current status of the license key.",
-        "enum": [
-          "inactive",
-          "active",
-          "expired",
-          "disabled"
-        ]
+        "enum": ["inactive", "active", "expired", "disabled"]
       },
       "LicenseInstanceEntity": {
         "type": "object",
@@ -4555,10 +4321,7 @@
           "status": {
             "type": "string",
             "description": "The status of the license instance.",
-            "enum": [
-              "active",
-              "deactivated"
-            ],
+            "enum": ["active", "deactivated"],
             "example": "active"
           },
           "created_at": {
@@ -4568,14 +4331,7 @@
             "example": "2023-09-13T00:00:00Z"
           }
         },
-        "required": [
-          "id",
-          "mode",
-          "object",
-          "name",
-          "status",
-          "created_at"
-        ]
+        "required": ["id", "mode", "object", "name", "status", "created_at"]
       },
       "LicenseEntity": {
         "type": "object",
@@ -4669,10 +4425,7 @@
             ]
           }
         },
-        "required": [
-          "items",
-          "pagination"
-        ]
+        "required": ["items", "pagination"]
       },
       "CreateCustomerRequestEntity": {
         "type": "object",
@@ -4696,10 +4449,7 @@
             "additionalProperties": true
           }
         },
-        "required": [
-          "email",
-          "name"
-        ]
+        "required": ["email", "name"]
       },
       "UpdateCustomerRequestEntity": {
         "type": "object",
@@ -4723,9 +4473,7 @@
             "additionalProperties": true
           }
         },
-        "required": [
-          "customer_id"
-        ]
+        "required": ["customer_id"]
       },
       "CreateCustomerPortalLinkRequestEntity": {
         "type": "object",
@@ -4735,9 +4483,7 @@
             "description": "Unique identifier of the customer."
           }
         },
-        "required": [
-          "customer_id"
-        ]
+        "required": ["customer_id"]
       },
       "CustomerLinksEntity": {
         "type": "object",
@@ -4747,9 +4493,7 @@
             "description": "Customer portal link."
           }
         },
-        "required": [
-          "customer_portal_link"
-        ]
+        "required": ["customer_portal_link"]
       },
       "CancelSubscriptionRequestEntity": {
         "type": "object",
@@ -4757,19 +4501,13 @@
           "mode": {
             "type": "string",
             "description": "The mode of cancellation (immediate or scheduled), default can be configured in the store billing settings.",
-            "enum": [
-              "immediate",
-              "scheduled"
-            ],
+            "enum": ["immediate", "scheduled"],
             "example": "immediate"
           },
           "onExecute": {
             "type": "string",
             "description": "The action to execute when canceling (cancel or pause) when mode is scheduled, ignored when mode is immediate or not provided",
-            "enum": [
-              "cancel",
-              "pause"
-            ],
+            "enum": ["cancel", "pause"],
             "example": "cancel"
           }
         }
@@ -4808,11 +4546,7 @@
           "update_behavior": {
             "type": "string",
             "description": "The update behavior for the subscription (defaults to proration)",
-            "enum": [
-              "proration-charge-immediately",
-              "proration-charge",
-              "proration-none"
-            ],
+            "enum": ["proration-charge-immediately", "proration-charge", "proration-none"],
             "default": "proration-charge"
           }
         }
@@ -4828,17 +4562,11 @@
           "update_behavior": {
             "type": "string",
             "description": "The update behavior for the subscription (defaults to proration-charge-immediately)",
-            "enum": [
-              "proration-charge-immediately",
-              "proration-charge",
-              "proration-none"
-            ],
+            "enum": ["proration-charge-immediately", "proration-charge", "proration-none"],
             "default": "proration-charge-immediately"
           }
         },
-        "required": [
-          "product_id"
-        ]
+        "required": ["product_id"]
       },
       "FeatureFileEntity": {
         "type": "object",
@@ -4869,13 +4597,7 @@
             "example": 1024000
           }
         },
-        "required": [
-          "id",
-          "file_name",
-          "url",
-          "type",
-          "size"
-        ]
+        "required": ["id", "file_name", "url", "type", "size"]
       },
       "FileFeatureEntity": {
         "type": "object",
@@ -4888,9 +4610,7 @@
             }
           }
         },
-        "required": [
-          "files"
-        ]
+        "required": ["files"]
       },
       "CustomerCreditsFeatureEntity": {
         "type": "object",
@@ -4907,9 +4627,7 @@
             "nullable": true
           }
         },
-        "required": [
-          "amount"
-        ]
+        "required": ["amount"]
       },
       "ProductFeatureEntity": {
         "type": "object",
@@ -4993,12 +4711,7 @@
           "status": {
             "type": "string",
             "description": "Status of the checkout.",
-            "enum": [
-              "pending",
-              "processing",
-              "completed",
-              "expired"
-            ],
+            "enum": ["pending", "processing", "completed", "expired"],
             "example": "completed"
           },
           "request_id": {
@@ -5117,21 +4830,14 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "percentage",
-                  "fixed"
-                ]
+                "enum": ["percentage", "fixed"]
               },
               "amount": {
                 "type": "number"
               },
               "duration": {
                 "type": "string",
-                "enum": [
-                  "forever",
-                  "once",
-                  "repeating"
-                ]
+                "enum": ["forever", "once", "repeating"]
               },
               "durationInMonths": {
                 "type": "number"
@@ -5139,13 +4845,7 @@
             }
           }
         },
-        "required": [
-          "id",
-          "mode",
-          "object",
-          "status",
-          "product"
-        ]
+        "required": ["id", "mode", "object", "status", "product"]
       },
       "CustomerRequestEntity": {
         "type": "object",
@@ -5237,9 +4937,7 @@
             "additionalProperties": true
           }
         },
-        "required": [
-          "product_id"
-        ]
+        "required": ["product_id"]
       },
       "ActivateLicenseRequestEntity": {
         "type": "object",
@@ -5253,10 +4951,7 @@
             "description": "A label for the new instance to identify it in Creem."
           }
         },
-        "required": [
-          "key",
-          "instance_name"
-        ]
+        "required": ["key", "instance_name"]
       },
       "DeactivateLicenseRequestEntity": {
         "type": "object",
@@ -5270,10 +4965,7 @@
             "description": "Id of the instance to deactivate."
           }
         },
-        "required": [
-          "key",
-          "instance_id"
-        ]
+        "required": ["key", "instance_id"]
       },
       "ValidateLicenseRequestEntity": {
         "type": "object",
@@ -5287,10 +4979,7 @@
             "description": "Id of the instance to validate."
           }
         },
-        "required": [
-          "key",
-          "instance_id"
-        ]
+        "required": ["key", "instance_id"]
       },
       "LicenseInstanceListEntity": {
         "type": "object",
@@ -5311,10 +5000,7 @@
             ]
           }
         },
-        "required": [
-          "items",
-          "pagination"
-        ]
+        "required": ["items", "pagination"]
       },
       "DiscountEntity": {
         "type": "object",
@@ -5334,13 +5020,7 @@
           "status": {
             "type": "string",
             "description": "The status of the discount (e.g., active, inactive).",
-            "enum": [
-              "deleted",
-              "active",
-              "draft",
-              "expired",
-              "scheduled"
-            ],
+            "enum": ["deleted", "active", "draft", "expired", "scheduled"],
             "example": "active"
           },
           "name": {
@@ -5356,10 +5036,7 @@
           "type": {
             "type": "string",
             "description": "The type of the discount, either \"percentage\" or \"fixed\".",
-            "enum": [
-              "percentage",
-              "fixed"
-            ],
+            "enum": ["percentage", "fixed"],
             "example": "percentage"
           },
           "amount": {
@@ -5391,11 +5068,7 @@
           "duration": {
             "type": "string",
             "description": "The duration type for the discount.",
-            "enum": [
-              "forever",
-              "once",
-              "repeating"
-            ],
+            "enum": ["forever", "once", "repeating"],
             "example": "repeating"
           },
           "duration_in_months": {
@@ -5405,10 +5078,7 @@
           },
           "applies_to_products": {
             "description": "The list of product IDs to which this discount applies.",
-            "example": [
-              "prod_123",
-              "prod_456"
-            ],
+            "example": ["prod_123", "prod_456"],
             "type": "array",
             "items": {
               "type": "string"
@@ -5420,15 +5090,7 @@
             "example": 15
           }
         },
-        "required": [
-          "id",
-          "mode",
-          "object",
-          "status",
-          "name",
-          "code",
-          "type"
-        ]
+        "required": ["id", "mode", "object", "status", "name", "code", "type"]
       },
       "DiscountListEntity": {
         "type": "object",
@@ -5449,27 +5111,17 @@
             ]
           }
         },
-        "required": [
-          "items",
-          "pagination"
-        ]
+        "required": ["items", "pagination"]
       },
       "DiscountType": {
         "type": "string",
         "description": "The type of the discount, either \"percentage\" or \"fixed\".",
-        "enum": [
-          "percentage",
-          "fixed"
-        ]
+        "enum": ["percentage", "fixed"]
       },
       "CouponDurationType": {
         "type": "string",
         "description": "The duration type for the discount.",
-        "enum": [
-          "forever",
-          "once",
-          "repeating"
-        ]
+        "enum": ["forever", "once", "repeating"]
       },
       "CreateDiscountRequestEntity": {
         "type": "object",
@@ -5524,22 +5176,14 @@
           },
           "applies_to_products": {
             "description": "The list of product IDs to which this discount applies.",
-            "example": [
-              "prod_123",
-              "prod_456"
-            ],
+            "example": ["prod_123", "prod_456"],
             "type": "array",
             "items": {
               "type": "string"
             }
           }
         },
-        "required": [
-          "name",
-          "type",
-          "duration",
-          "applies_to_products"
-        ]
+        "required": ["name", "type", "duration", "applies_to_products"]
       },
       "TransactionListEntity": {
         "type": "object",
@@ -5560,10 +5204,7 @@
             ]
           }
         },
-        "required": [
-          "items",
-          "pagination"
-        ]
+        "required": ["items", "pagination"]
       },
       "StatsMetricTotalsEntity": {
         "type": "object",
@@ -5645,11 +5286,7 @@
             "example": 122173
           }
         },
-        "required": [
-          "timestamp",
-          "grossRevenue",
-          "netRevenue"
-        ]
+        "required": ["timestamp", "grossRevenue", "netRevenue"]
       },
       "StatsSummaryEntity": {
         "type": "object",
@@ -5712,9 +5349,7 @@
             }
           }
         },
-        "required": [
-          "totals"
-        ]
+        "required": ["totals"]
       },
       "ScreenPromptRequest": {
         "type": "object",
@@ -5728,9 +5363,7 @@
             "description": "An optional identifier to associate this request with."
           }
         },
-        "required": [
-          "prompt"
-        ]
+        "required": ["prompt"]
       },
       "UsageEntity": {
         "type": "object",
@@ -5740,9 +5373,7 @@
             "description": "Number of units consumed by this call."
           }
         },
-        "required": [
-          "units"
-        ]
+        "required": ["units"]
       },
       "ScreenPromptResponse": {
         "type": "object",
@@ -5767,11 +5398,7 @@
           "decision": {
             "type": "string",
             "description": "The moderation decision.",
-            "enum": [
-              "allow",
-              "deny",
-              "flag"
-            ]
+            "enum": ["allow", "deny", "flag"]
           },
           "usage": {
             "description": "Usage information for this call.",
@@ -5782,13 +5409,7 @@
             ]
           }
         },
-        "required": [
-          "id",
-          "object",
-          "prompt",
-          "decision",
-          "usage"
-        ]
+        "required": ["id", "object", "prompt", "decision", "usage"]
       },
       "CreateRefundRequestEntity": {
         "type": "object",
@@ -5799,20 +5420,12 @@
             "example": "tran_1234567890"
           }
         },
-        "required": [
-          "transaction_id"
-        ]
+        "required": ["transaction_id"]
       },
       "RefundStatus": {
         "type": "string",
         "description": "Status of the refund. `pending` and `requiresAction` represent non-terminal provider processing states.",
-        "enum": [
-          "pending",
-          "requiresAction",
-          "succeeded",
-          "failed",
-          "canceled"
-        ]
+        "enum": ["pending", "requiresAction", "succeeded", "failed", "canceled"]
       },
       "RefundResponseEntity": {
         "type": "object",
@@ -5822,9 +5435,7 @@
             "$ref": "#/components/schemas/RefundStatus"
           }
         },
-        "required": [
-          "status"
-        ]
+        "required": ["status"]
       },
       "CreateAccountDto": {
         "type": "object",
@@ -5852,9 +5463,7 @@
             "example": "300"
           }
         },
-        "required": [
-          "customer_id"
-        ]
+        "required": ["customer_id"]
       },
       "AccountResponseDto": {
         "type": "object",
@@ -5886,11 +5495,7 @@
           "status": {
             "type": "string",
             "description": "Account status",
-            "enum": [
-              "active",
-              "frozen",
-              "closed"
-            ]
+            "enum": ["active", "frozen", "closed"]
           },
           "created_at": {
             "type": "string",
@@ -5932,11 +5537,7 @@
             "description": "Whether more items exist beyond this page"
           }
         },
-        "required": [
-          "object",
-          "data",
-          "has_more"
-        ]
+        "required": ["object", "data", "has_more"]
       },
       "BalanceResponseDto": {
         "type": "object",
@@ -5955,9 +5556,7 @@
             "description": "Point-in-time the balance was computed at (present for at-time queries)"
           }
         },
-        "required": [
-          "balance"
-        ]
+        "required": ["balance"]
       },
       "EntryResponseDto": {
         "type": "object",
@@ -5980,10 +5579,7 @@
           "side": {
             "type": "string",
             "description": "Debit or credit side",
-            "enum": [
-              "debit",
-              "credit"
-            ]
+            "enum": ["debit", "credit"]
           },
           "amount": {
             "type": "string",
@@ -5995,14 +5591,7 @@
             "description": "Creation timestamp"
           }
         },
-        "required": [
-          "id",
-          "transaction_id",
-          "account_id",
-          "side",
-          "amount",
-          "created_at"
-        ]
+        "required": ["id", "transaction_id", "account_id", "side", "amount", "created_at"]
       },
       "EntryListResponseDto": {
         "type": "object",
@@ -6024,11 +5613,7 @@
             "description": "Whether more items exist beyond this page"
           }
         },
-        "required": [
-          "object",
-          "data",
-          "has_more"
-        ]
+        "required": ["object", "data", "has_more"]
       },
       "CustomerCreditsErrorDetailDto": {
         "type": "object",
@@ -6067,12 +5652,7 @@
             "example": "req_abc123def456"
           }
         },
-        "required": [
-          "type",
-          "code",
-          "message",
-          "request_id"
-        ]
+        "required": ["type", "code", "message", "request_id"]
       },
       "CustomerCreditsErrorResponseDto": {
         "type": "object",
@@ -6086,9 +5666,7 @@
             ]
           }
         },
-        "required": [
-          "error"
-        ]
+        "required": ["error"]
       },
       "CreditDebitRequestDto": {
         "type": "object",
@@ -6109,11 +5687,7 @@
             "example": "idem_abc123"
           }
         },
-        "required": [
-          "amount",
-          "reference",
-          "idempotency_key"
-        ]
+        "required": ["amount", "reference", "idempotency_key"]
       },
       "TransactionResponseDto": {
         "type": "object",
@@ -6154,14 +5728,7 @@
             "description": "Creation timestamp"
           }
         },
-        "required": [
-          "id",
-          "store_id",
-          "reference",
-          "idempotency_key",
-          "entries",
-          "created_at"
-        ]
+        "required": ["id", "store_id", "reference", "idempotency_key", "entries", "created_at"]
       },
       "ReverseTransactionRequestDto": {
         "type": "object",
@@ -6172,9 +5739,7 @@
             "example": "cct_abc123"
           }
         },
-        "required": [
-          "transaction_id"
-        ]
+        "required": ["transaction_id"]
       },
       "CreateAffiliateInviteRequestEntity": {
         "type": "object",
@@ -6196,10 +5761,7 @@
             "nullable": true
           }
         },
-        "required": [
-          "email",
-          "name"
-        ]
+        "required": ["email", "name"]
       },
       "AffiliateInviteEntity": {
         "type": "object",
@@ -6237,14 +5799,7 @@
             "description": "Creation date of the invitation as a timestamp."
           }
         },
-        "required": [
-          "id",
-          "mode",
-          "object",
-          "email",
-          "status",
-          "created_at"
-        ]
+        "required": ["id", "mode", "object", "email", "status", "created_at"]
       },
       "AffiliateInviteListEntity": {
         "type": "object",
@@ -6265,10 +5820,7 @@
             ]
           }
         },
-        "required": [
-          "items",
-          "pagination"
-        ]
+        "required": ["items", "pagination"]
       },
       "AffiliateEntity": {
         "type": "object",
@@ -6365,19 +5917,12 @@
             ]
           }
         },
-        "required": [
-          "items",
-          "pagination"
-        ]
+        "required": ["items", "pagination"]
       },
       "CommissionStatus": {
         "type": "string",
         "description": "The settlement status of the commission. `pending` while on hold, `approved` once cleared and available, `paid` once settled by a payout.",
-        "enum": [
-          "pending",
-          "approved",
-          "paid"
-        ]
+        "enum": ["pending", "approved", "paid"]
       },
       "CommissionEntity": {
         "type": "object",
@@ -6454,10 +5999,7 @@
             ]
           }
         },
-        "required": [
-          "items",
-          "pagination"
-        ]
+        "required": ["items", "pagination"]
       },
       "WebhookSubscriptionEntity": {
         "type": "object",
@@ -6580,21 +6122,14 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "percentage",
-                  "fixed"
-                ]
+                "enum": ["percentage", "fixed"]
               },
               "amount": {
                 "type": "number"
               },
               "duration": {
                 "type": "string",
-                "enum": [
-                  "forever",
-                  "once",
-                  "repeating"
-                ]
+                "enum": ["forever", "once", "repeating"]
               },
               "durationInMonths": {
                 "type": "number"
@@ -6634,9 +6169,7 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": [
-              "checkout.completed"
-            ]
+            "enum": ["checkout.completed"]
           },
           "created_at": {
             "type": "number",
@@ -6651,23 +6184,13 @@
             ]
           }
         },
-        "required": [
-          "id",
-          "eventType",
-          "created_at",
-          "object"
-        ],
+        "required": ["id", "eventType", "created_at", "object"],
         "x-speakeasy-include": true
       },
       "RefundReason": {
         "type": "string",
         "description": "Reason for the refund.",
-        "enum": [
-          "duplicate",
-          "fraudulent",
-          "requested_by_customer",
-          "other"
-        ]
+        "enum": ["duplicate", "fraudulent", "requested_by_customer", "other"]
       },
       "RefundEntity": {
         "type": "object",
@@ -6779,9 +6302,7 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": [
-              "refund.created"
-            ]
+            "enum": ["refund.created"]
           },
           "created_at": {
             "type": "number",
@@ -6796,12 +6317,7 @@
             ]
           }
         },
-        "required": [
-          "id",
-          "eventType",
-          "created_at",
-          "object"
-        ],
+        "required": ["id", "eventType", "created_at", "object"],
         "x-speakeasy-include": true
       },
       "DisputeEntity": {
@@ -6885,15 +6401,7 @@
             "description": "Creation date of the dispute as timestamp"
           }
         },
-        "required": [
-          "id",
-          "mode",
-          "object",
-          "amount",
-          "currency",
-          "transaction",
-          "created_at"
-        ]
+        "required": ["id", "mode", "object", "amount", "currency", "transaction", "created_at"]
       },
       "WebhookDisputeCreatedEventEntity": {
         "type": "object",
@@ -6905,9 +6413,7 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": [
-              "dispute.created"
-            ]
+            "enum": ["dispute.created"]
           },
           "created_at": {
             "type": "number",
@@ -6922,12 +6428,7 @@
             ]
           }
         },
-        "required": [
-          "id",
-          "eventType",
-          "created_at",
-          "object"
-        ],
+        "required": ["id", "eventType", "created_at", "object"],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionActiveEventEntity": {
@@ -6940,9 +6441,7 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": [
-              "subscription.active"
-            ]
+            "enum": ["subscription.active"]
           },
           "created_at": {
             "type": "number",
@@ -6957,12 +6456,7 @@
             ]
           }
         },
-        "required": [
-          "id",
-          "eventType",
-          "created_at",
-          "object"
-        ],
+        "required": ["id", "eventType", "created_at", "object"],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionTrialingEventEntity": {
@@ -6975,9 +6469,7 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": [
-              "subscription.trialing"
-            ]
+            "enum": ["subscription.trialing"]
           },
           "created_at": {
             "type": "number",
@@ -6992,12 +6484,7 @@
             ]
           }
         },
-        "required": [
-          "id",
-          "eventType",
-          "created_at",
-          "object"
-        ],
+        "required": ["id", "eventType", "created_at", "object"],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionCanceledEventEntity": {
@@ -7010,9 +6497,7 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": [
-              "subscription.canceled"
-            ]
+            "enum": ["subscription.canceled"]
           },
           "created_at": {
             "type": "number",
@@ -7027,12 +6512,7 @@
             ]
           }
         },
-        "required": [
-          "id",
-          "eventType",
-          "created_at",
-          "object"
-        ],
+        "required": ["id", "eventType", "created_at", "object"],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionScheduledCancelEventEntity": {
@@ -7045,9 +6525,7 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": [
-              "subscription.scheduled_cancel"
-            ]
+            "enum": ["subscription.scheduled_cancel"]
           },
           "created_at": {
             "type": "number",
@@ -7062,12 +6540,7 @@
             ]
           }
         },
-        "required": [
-          "id",
-          "eventType",
-          "created_at",
-          "object"
-        ],
+        "required": ["id", "eventType", "created_at", "object"],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionPaidEventEntity": {
@@ -7080,9 +6553,7 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": [
-              "subscription.paid"
-            ]
+            "enum": ["subscription.paid"]
           },
           "created_at": {
             "type": "number",
@@ -7097,12 +6568,7 @@
             ]
           }
         },
-        "required": [
-          "id",
-          "eventType",
-          "created_at",
-          "object"
-        ],
+        "required": ["id", "eventType", "created_at", "object"],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionExpiredEventEntity": {
@@ -7115,9 +6581,7 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": [
-              "subscription.expired"
-            ]
+            "enum": ["subscription.expired"]
           },
           "created_at": {
             "type": "number",
@@ -7132,12 +6596,7 @@
             ]
           }
         },
-        "required": [
-          "id",
-          "eventType",
-          "created_at",
-          "object"
-        ],
+        "required": ["id", "eventType", "created_at", "object"],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionUnpaidEventEntity": {
@@ -7150,9 +6609,7 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": [
-              "subscription.unpaid"
-            ]
+            "enum": ["subscription.unpaid"]
           },
           "created_at": {
             "type": "number",
@@ -7167,12 +6624,7 @@
             ]
           }
         },
-        "required": [
-          "id",
-          "eventType",
-          "created_at",
-          "object"
-        ],
+        "required": ["id", "eventType", "created_at", "object"],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionUpdateEventEntity": {
@@ -7185,9 +6637,7 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": [
-              "subscription.update"
-            ]
+            "enum": ["subscription.update"]
           },
           "created_at": {
             "type": "number",
@@ -7202,12 +6652,7 @@
             ]
           }
         },
-        "required": [
-          "id",
-          "eventType",
-          "created_at",
-          "object"
-        ],
+        "required": ["id", "eventType", "created_at", "object"],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionPastDueEventEntity": {
@@ -7220,9 +6665,7 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": [
-              "subscription.past_due"
-            ]
+            "enum": ["subscription.past_due"]
           },
           "created_at": {
             "type": "number",
@@ -7237,12 +6680,7 @@
             ]
           }
         },
-        "required": [
-          "id",
-          "eventType",
-          "created_at",
-          "object"
-        ],
+        "required": ["id", "eventType", "created_at", "object"],
         "x-speakeasy-include": true
       },
       "WebhookSubscriptionPausedEventEntity": {
@@ -7255,9 +6693,7 @@
           "eventType": {
             "type": "string",
             "description": "The event name.",
-            "enum": [
-              "subscription.paused"
-            ]
+            "enum": ["subscription.paused"]
           },
           "created_at": {
             "type": "number",
@@ -7272,12 +6708,7 @@
             ]
           }
         },
-        "required": [
-          "id",
-          "eventType",
-          "created_at",
-          "object"
-        ],
+        "required": ["id", "eventType", "created_at", "object"],
         "x-speakeasy-include": true
       },
       "WebhookEventEntity": {


### PR DESCRIPTION
Main's `format:check` fails on `packages/creem-sdk/openapi.json` — the affiliate spec sync in #174 copied the API generator's output without running Prettier over it. Formatting-only change, no content diff; `prettier --check` passes locally after this.

Unblocks the failed pipeline: https://github.com/armitage-labs/creem/actions/runs/32133450077

🤖 Generated with [Claude Code](https://claude.com/claude-code)