### PR TITLE
feat(better-auth): pass GenericEndpointContext to all webhook callbacks

### DIFF
--- a/.changeset/warm-webhooks-share-context.md
+++ b/.changeset/warm-webhooks-share-context.md
@@ -1,0 +1,5 @@
+---
+"@creem_io/better-auth": minor
+---
+
+Pass the Better Auth endpoint context to webhook callbacks as their second argument.

--- a/packages/better-auth/BETTERAUTH.md
+++ b/packages/better-auth/BETTERAUTH.md
@@ -635,22 +635,65 @@ interface CreemOptions {
   persistSubscriptions?: boolean;
 
   // Event-Specific Webhook Handlers
-  onCheckoutCompleted?: (data: FlatCheckoutCompleted) => void | Promise<void>;
-  onRefundCreated?: (data: FlatRefundCreated) => void | Promise<void>;
-  onDisputeCreated?: (data: FlatDisputeCreated) => void | Promise<void>;
-  onSubscriptionActive?: (data: FlatSubscriptionEvent) => void | Promise<void>;
-  onSubscriptionTrialing?: (data: FlatSubscriptionEvent) => void | Promise<void>;
-  onSubscriptionCanceled?: (data: FlatSubscriptionEvent) => void | Promise<void>;
-  onSubscriptionPaid?: (data: FlatSubscriptionEvent) => void | Promise<void>;
-  onSubscriptionExpired?: (data: FlatSubscriptionEvent) => void | Promise<void>;
-  onSubscriptionUnpaid?: (data: FlatSubscriptionEvent) => void | Promise<void>;
-  onSubscriptionUpdate?: (data: FlatSubscriptionEvent) => void | Promise<void>;
-  onSubscriptionPastDue?: (data: FlatSubscriptionEvent) => void | Promise<void>;
-  onSubscriptionPaused?: (data: FlatSubscriptionEvent) => void | Promise<void>;
+  // Each callback receives the better-auth GenericEndpointContext as its second argument
+  onCheckoutCompleted?: (
+    data: FlatCheckoutCompleted,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
+  onRefundCreated?: (
+    data: FlatRefundCreated,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
+  onDisputeCreated?: (
+    data: FlatDisputeCreated,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
+  onSubscriptionActive?: (
+    data: FlatSubscriptionEvent,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
+  onSubscriptionTrialing?: (
+    data: FlatSubscriptionEvent,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
+  onSubscriptionCanceled?: (
+    data: FlatSubscriptionEvent,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
+  onSubscriptionPaid?: (
+    data: FlatSubscriptionEvent,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
+  onSubscriptionExpired?: (
+    data: FlatSubscriptionEvent,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
+  onSubscriptionUnpaid?: (
+    data: FlatSubscriptionEvent,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
+  onSubscriptionUpdate?: (
+    data: FlatSubscriptionEvent,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
+  onSubscriptionPastDue?: (
+    data: FlatSubscriptionEvent,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
+  onSubscriptionPaused?: (
+    data: FlatSubscriptionEvent,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
 
   // Access Control Handlers (High-level)
-  onGrantAccess?: (context: GrantAccessContext) => void | Promise<void>;
-  onRevokeAccess?: (context: RevokeAccessContext) => void | Promise<void>;
+  onGrantAccess?: (
+    context: GrantAccessContext,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
+  onRevokeAccess?: (
+    context: RevokeAccessContext,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
 }
 ```
 

--- a/packages/better-auth/README.md
+++ b/packages/better-auth/README.md
@@ -795,40 +795,65 @@ interface CreemOptions {
   persistSubscriptions?: boolean;
 
   // Webhook Handlers
-  onCheckoutCompleted?: (data: FlatCheckoutCompleted) => void; // Great for One Time Payments
-  onRefundCreated?: (data: FlatRefundCreated) => void;
-  onDisputeCreated?: (data: FlatDisputeCreated) => void;
+  // Each callback receives the better-auth GenericEndpointContext as its second argument
+  onCheckoutCompleted?: (
+    data: FlatCheckoutCompleted,
+    betterAuthContext: GenericEndpointContext,
+  ) => void; // Great for One Time Payments
+  onRefundCreated?: (
+    data: FlatRefundCreated,
+    betterAuthContext: GenericEndpointContext,
+  ) => void;
+  onDisputeCreated?: (
+    data: FlatDisputeCreated,
+    betterAuthContext: GenericEndpointContext,
+  ) => void;
   onSubscriptionActive?: (
     data: FlatSubscriptionEvent<"subscription.active">,
+    betterAuthContext: GenericEndpointContext,
   ) => void;
   onSubscriptionTrialing?: (
     data: FlatSubscriptionEvent<"subscription.trialing">,
+    betterAuthContext: GenericEndpointContext,
   ) => void;
   onSubscriptionCanceled?: (
     data: FlatSubscriptionEvent<"subscription.canceled">,
+    betterAuthContext: GenericEndpointContext,
   ) => void;
   onSubscriptionPaid?: (
     data: FlatSubscriptionEvent<"subscription.paid">,
+    betterAuthContext: GenericEndpointContext,
   ) => void;
   onSubscriptionExpired?: (
     data: FlatSubscriptionEvent<"subscription.expired">,
+    betterAuthContext: GenericEndpointContext,
   ) => void;
   onSubscriptionUnpaid?: (
     data: FlatSubscriptionEvent<"subscription.unpaid">,
+    betterAuthContext: GenericEndpointContext,
   ) => void;
   onSubscriptionUpdate?: (
     data: FlatSubscriptionEvent<"subscription.update">,
+    betterAuthContext: GenericEndpointContext,
   ) => void;
   onSubscriptionPastDue?: (
     data: FlatSubscriptionEvent<"subscription.past_due">,
+    betterAuthContext: GenericEndpointContext,
   ) => void;
   onSubscriptionPaused?: (
     data: FlatSubscriptionEvent<"subscription.paused">,
+    betterAuthContext: GenericEndpointContext,
   ) => void;
 
   // Access Control (High-level)
-  onGrantAccess?: (context: GrantAccessContext) => void | Promise<void>;
-  onRevokeAccess?: (context: RevokeAccessContext) => void | Promise<void>;
+  onGrantAccess?: (
+    context: GrantAccessContext,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
+  onRevokeAccess?: (
+    context: RevokeAccessContext,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
 }
 ```
 

--- a/packages/better-auth/src/__tests__/webhook.test.ts
+++ b/packages/better-auth/src/__tests__/webhook.test.ts
@@ -141,6 +141,7 @@ describe("webhook handler", () => {
     expect(hooks.onSubscriptionActive).toHaveBeenCalled();
     expect(onGrantAccess).toHaveBeenCalledWith(
       expect.objectContaining({ reason: "subscription_active" }),
+      expect.anything(),
     );
     expect(onSubscriptionActive).toHaveBeenCalled();
   });
@@ -158,6 +159,7 @@ describe("webhook handler", () => {
     expect(hooks.onSubscriptionTrialing).toHaveBeenCalled();
     expect(onGrantAccess).toHaveBeenCalledWith(
       expect.objectContaining({ reason: "subscription_trialing" }),
+      expect.anything(),
     );
   });
 
@@ -174,6 +176,7 @@ describe("webhook handler", () => {
     expect(hooks.onSubscriptionPaid).toHaveBeenCalled();
     expect(onGrantAccess).toHaveBeenCalledWith(
       expect.objectContaining({ reason: "subscription_paid" }),
+      expect.anything(),
     );
   });
 
@@ -190,6 +193,7 @@ describe("webhook handler", () => {
     expect(hooks.onSubscriptionExpired).toHaveBeenCalled();
     expect(onRevokeAccess).toHaveBeenCalledWith(
       expect.objectContaining({ reason: "subscription_expired" }),
+      expect.anything(),
     );
   });
 
@@ -206,6 +210,7 @@ describe("webhook handler", () => {
     expect(hooks.onSubscriptionPaused).toHaveBeenCalled();
     expect(onRevokeAccess).toHaveBeenCalledWith(
       expect.objectContaining({ reason: "subscription_paused" }),
+      expect.anything(),
     );
   });
 

--- a/packages/better-auth/src/__tests__/webhook.test.ts
+++ b/packages/better-auth/src/__tests__/webhook.test.ts
@@ -137,11 +137,11 @@ describe("webhook handler", () => {
       created_at: 1234567890,
       object: mockSubscription,
     };
-    await callWebhook(options, event);
+    const ctx = await callWebhook(options, event);
     expect(hooks.onSubscriptionActive).toHaveBeenCalled();
     expect(onGrantAccess).toHaveBeenCalledWith(
       expect.objectContaining({ reason: "subscription_active" }),
-      expect.anything(),
+      ctx,
     );
     expect(onSubscriptionActive).toHaveBeenCalled();
   });
@@ -155,11 +155,11 @@ describe("webhook handler", () => {
       created_at: 1234567890,
       object: { ...mockSubscription, status: "trialing" },
     };
-    await callWebhook(options, event);
+    const ctx = await callWebhook(options, event);
     expect(hooks.onSubscriptionTrialing).toHaveBeenCalled();
     expect(onGrantAccess).toHaveBeenCalledWith(
       expect.objectContaining({ reason: "subscription_trialing" }),
-      expect.anything(),
+      ctx,
     );
   });
 
@@ -172,11 +172,11 @@ describe("webhook handler", () => {
       created_at: 1234567890,
       object: mockSubscription,
     };
-    await callWebhook(options, event);
+    const ctx = await callWebhook(options, event);
     expect(hooks.onSubscriptionPaid).toHaveBeenCalled();
     expect(onGrantAccess).toHaveBeenCalledWith(
       expect.objectContaining({ reason: "subscription_paid" }),
-      expect.anything(),
+      ctx,
     );
   });
 
@@ -189,11 +189,11 @@ describe("webhook handler", () => {
       created_at: 1234567890,
       object: mockSubscription,
     };
-    await callWebhook(options, event);
+    const ctx = await callWebhook(options, event);
     expect(hooks.onSubscriptionExpired).toHaveBeenCalled();
     expect(onRevokeAccess).toHaveBeenCalledWith(
       expect.objectContaining({ reason: "subscription_expired" }),
-      expect.anything(),
+      ctx,
     );
   });
 
@@ -206,11 +206,11 @@ describe("webhook handler", () => {
       created_at: 1234567890,
       object: { ...mockSubscription, status: "paused" },
     };
-    await callWebhook(options, event);
+    const ctx = await callWebhook(options, event);
     expect(hooks.onSubscriptionPaused).toHaveBeenCalled();
     expect(onRevokeAccess).toHaveBeenCalledWith(
       expect.objectContaining({ reason: "subscription_paused" }),
-      expect.anything(),
+      ctx,
     );
   });
 
@@ -285,6 +285,41 @@ describe("webhook handler", () => {
     };
     await callWebhook(options, event);
     expect(onDisputeCreated).toHaveBeenCalled();
+  });
+
+  it.each([
+    ["onCheckoutCompleted", "checkout.completed", mockCheckout],
+    ["onRefundCreated", "refund.created", mockRefund],
+    ["onDisputeCreated", "dispute.created", mockDispute],
+    ["onSubscriptionActive", "subscription.active", mockSubscription],
+    [
+      "onSubscriptionTrialing",
+      "subscription.trialing",
+      { ...mockSubscription, status: "trialing" },
+    ],
+    [
+      "onSubscriptionCanceled",
+      "subscription.canceled",
+      { ...mockSubscription, status: "canceled" },
+    ],
+    ["onSubscriptionPaid", "subscription.paid", mockSubscription],
+    ["onSubscriptionExpired", "subscription.expired", { ...mockSubscription, status: "expired" }],
+    ["onSubscriptionUnpaid", "subscription.unpaid", { ...mockSubscription, status: "unpaid" }],
+    ["onSubscriptionUpdate", "subscription.update", mockSubscription],
+    ["onSubscriptionPastDue", "subscription.past_due", { ...mockSubscription, status: "past_due" }],
+    ["onSubscriptionPaused", "subscription.paused", { ...mockSubscription, status: "paused" }],
+  ] as const)("passes the exact context to %s for %s", async (callbackName, eventType, object) => {
+    const callback = vi.fn();
+    const options = { ...defaultOptions, [callbackName]: callback } as CreemOptions;
+    const ctx = await callWebhook(options, {
+      eventType,
+      id: `context-${eventType}`,
+      created_at: 1234567890,
+      object,
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.calls[0]?.[1]).toBe(ctx);
   });
 
   it("returns 500 on processing error", async () => {

--- a/packages/better-auth/src/types.ts
+++ b/packages/better-auth/src/types.ts
@@ -1,4 +1,5 @@
 import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
+import type { GenericEndpointContext } from "better-auth";
 import type {
   NormalizedCheckoutEntity,
   NormalizedRefundEntity,
@@ -153,19 +154,28 @@ export interface CreemOptions {
    *   console.log(`Checkout completed: ${customer?.email} purchased ${product.name}`);
    * }
    */
-  onCheckoutCompleted?: (data: FlatCheckoutCompleted) => void | Promise<void>;
+  onCheckoutCompleted?: (
+    data: FlatCheckoutCompleted,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
 
   /**
    * Called when a refund is created.
    * All properties are flattened for easy destructuring.
    */
-  onRefundCreated?: (data: FlatRefundCreated) => void | Promise<void>;
+  onRefundCreated?: (
+    data: FlatRefundCreated,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
 
   /**
    * Called when a dispute is created.
    * All properties are flattened for easy destructuring.
    */
-  onDisputeCreated?: (data: FlatDisputeCreated) => void | Promise<void>;
+  onDisputeCreated?: (
+    data: FlatDisputeCreated,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
 
   /**
    * Called when a subscription becomes active.
@@ -179,6 +189,7 @@ export interface CreemOptions {
    */
   onSubscriptionActive?: (
     data: FlatSubscriptionEvent<"subscription.active">,
+    betterAuthContext: GenericEndpointContext,
   ) => void | Promise<void>;
 
   /**
@@ -187,6 +198,7 @@ export interface CreemOptions {
    */
   onSubscriptionTrialing?: (
     data: FlatSubscriptionEvent<"subscription.trialing">,
+    betterAuthContext: GenericEndpointContext,
   ) => void | Promise<void>;
 
   /**
@@ -195,13 +207,17 @@ export interface CreemOptions {
    */
   onSubscriptionCanceled?: (
     data: FlatSubscriptionEvent<"subscription.canceled">,
+    betterAuthContext: GenericEndpointContext,
   ) => void | Promise<void>;
 
   /**
    * Called when a subscription is paid.
    * All properties are flattened for easy destructuring.
    */
-  onSubscriptionPaid?: (data: FlatSubscriptionEvent<"subscription.paid">) => void | Promise<void>;
+  onSubscriptionPaid?: (
+    data: FlatSubscriptionEvent<"subscription.paid">,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
 
   /**
    * Called when a subscription has expired.
@@ -209,6 +225,7 @@ export interface CreemOptions {
    */
   onSubscriptionExpired?: (
     data: FlatSubscriptionEvent<"subscription.expired">,
+    betterAuthContext: GenericEndpointContext,
   ) => void | Promise<void>;
 
   /**
@@ -217,6 +234,7 @@ export interface CreemOptions {
    */
   onSubscriptionUnpaid?: (
     data: FlatSubscriptionEvent<"subscription.unpaid">,
+    betterAuthContext: GenericEndpointContext,
   ) => void | Promise<void>;
 
   /**
@@ -225,6 +243,7 @@ export interface CreemOptions {
    */
   onSubscriptionUpdate?: (
     data: FlatSubscriptionEvent<"subscription.update">,
+    betterAuthContext: GenericEndpointContext,
   ) => void | Promise<void>;
 
   /**
@@ -233,6 +252,7 @@ export interface CreemOptions {
    */
   onSubscriptionPastDue?: (
     data: FlatSubscriptionEvent<"subscription.past_due">,
+    betterAuthContext: GenericEndpointContext,
   ) => void | Promise<void>;
 
   /**
@@ -241,6 +261,7 @@ export interface CreemOptions {
    */
   onSubscriptionPaused?: (
     data: FlatSubscriptionEvent<"subscription.paused">,
+    betterAuthContext: GenericEndpointContext,
   ) => void | Promise<void>;
 
   /**
@@ -260,7 +281,10 @@ export interface CreemOptions {
    *   // Your database logic here
    * }
    */
-  onGrantAccess?: (context: GrantAccessContext) => void | Promise<void>;
+  onGrantAccess?: (
+    context: GrantAccessContext,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
 
   /**
    * Called when a user's access should be revoked.
@@ -279,5 +303,8 @@ export interface CreemOptions {
    *   // Your database logic here
    * }
    */
-  onRevokeAccess?: (context: RevokeAccessContext) => void | Promise<void>;
+  onRevokeAccess?: (
+    context: RevokeAccessContext,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
 }

--- a/packages/better-auth/src/webhook.ts
+++ b/packages/better-auth/src/webhook.ts
@@ -53,140 +53,191 @@ const createWebhookHandler = (options: CreemOptions) => {
       switch (event.eventType) {
         case "checkout.completed":
           await onCheckoutCompleted(ctx, event, options);
-          await options.onCheckoutCompleted?.({
-            webhookEventType: event.eventType,
-            webhookId: event.id,
-            webhookCreatedAt: event.created_at,
-            ...event.object,
-          });
+          await options.onCheckoutCompleted?.(
+            {
+              webhookEventType: event.eventType,
+              webhookId: event.id,
+              webhookCreatedAt: event.created_at,
+              ...event.object,
+            },
+            ctx,
+          );
           break;
 
         case "refund.created":
-          await options.onRefundCreated?.({
-            webhookEventType: event.eventType,
-            webhookId: event.id,
-            webhookCreatedAt: event.created_at,
-            ...event.object,
-          });
+          await options.onRefundCreated?.(
+            {
+              webhookEventType: event.eventType,
+              webhookId: event.id,
+              webhookCreatedAt: event.created_at,
+              ...event.object,
+            },
+            ctx,
+          );
           break;
 
         case "dispute.created":
-          await options.onDisputeCreated?.({
-            webhookEventType: event.eventType,
-            webhookId: event.id,
-            webhookCreatedAt: event.created_at,
-            ...event.object,
-          });
+          await options.onDisputeCreated?.(
+            {
+              webhookEventType: event.eventType,
+              webhookId: event.id,
+              webhookCreatedAt: event.created_at,
+              ...event.object,
+            },
+            ctx,
+          );
           break;
 
         case "subscription.active":
           await onSubscriptionActive(ctx, event, options);
-          await options.onGrantAccess?.({
-            reason: "subscription_active",
-            ...event.object,
-          });
-          await options.onSubscriptionActive?.({
-            webhookEventType: event.eventType,
-            webhookId: event.id,
-            webhookCreatedAt: event.created_at,
-            ...event.object,
-          });
+          await options.onGrantAccess?.(
+            {
+              reason: "subscription_active",
+              ...event.object,
+            },
+            ctx,
+          );
+          await options.onSubscriptionActive?.(
+            {
+              webhookEventType: event.eventType,
+              webhookId: event.id,
+              webhookCreatedAt: event.created_at,
+              ...event.object,
+            },
+            ctx,
+          );
           break;
 
         case "subscription.trialing":
           await onSubscriptionTrialing(ctx, event, options);
-          await options.onGrantAccess?.({
-            reason: "subscription_trialing",
-            ...event.object,
-          });
-          await options.onSubscriptionTrialing?.({
-            webhookEventType: event.eventType,
-            webhookId: event.id,
-            webhookCreatedAt: event.created_at,
-            ...event.object,
-          });
+          await options.onGrantAccess?.(
+            {
+              reason: "subscription_trialing",
+              ...event.object,
+            },
+            ctx,
+          );
+          await options.onSubscriptionTrialing?.(
+            {
+              webhookEventType: event.eventType,
+              webhookId: event.id,
+              webhookCreatedAt: event.created_at,
+              ...event.object,
+            },
+            ctx,
+          );
 
           break;
         case "subscription.canceled":
           await onSubscriptionCanceled(ctx, event, options);
-          await options.onSubscriptionCanceled?.({
-            webhookEventType: event.eventType,
-            webhookId: event.id,
-            webhookCreatedAt: event.created_at,
-            ...event.object,
-          });
+          await options.onSubscriptionCanceled?.(
+            {
+              webhookEventType: event.eventType,
+              webhookId: event.id,
+              webhookCreatedAt: event.created_at,
+              ...event.object,
+            },
+            ctx,
+          );
           break;
 
         case "subscription.paid":
           await onSubscriptionPaid(ctx, event, options);
-          await options.onGrantAccess?.({
-            reason: "subscription_paid",
-            ...event.object,
-          });
-          await options.onSubscriptionPaid?.({
-            webhookEventType: event.eventType,
-            webhookId: event.id,
-            webhookCreatedAt: event.created_at,
-            ...event.object,
-          });
+          await options.onGrantAccess?.(
+            {
+              reason: "subscription_paid",
+              ...event.object,
+            },
+            ctx,
+          );
+          await options.onSubscriptionPaid?.(
+            {
+              webhookEventType: event.eventType,
+              webhookId: event.id,
+              webhookCreatedAt: event.created_at,
+              ...event.object,
+            },
+            ctx,
+          );
           break;
 
         case "subscription.expired":
           await onSubscriptionExpired(ctx, event, options);
-          await options.onRevokeAccess?.({
-            reason: "subscription_expired",
-            ...event.object,
-          });
-          await options.onSubscriptionExpired?.({
-            webhookEventType: event.eventType,
-            webhookId: event.id,
-            webhookCreatedAt: event.created_at,
-            ...event.object,
-          });
+          await options.onRevokeAccess?.(
+            {
+              reason: "subscription_expired",
+              ...event.object,
+            },
+            ctx,
+          );
+          await options.onSubscriptionExpired?.(
+            {
+              webhookEventType: event.eventType,
+              webhookId: event.id,
+              webhookCreatedAt: event.created_at,
+              ...event.object,
+            },
+            ctx,
+          );
           break;
 
         case "subscription.unpaid":
           await onSubscriptionUnpaid(ctx, event, options);
-          await options.onSubscriptionUnpaid?.({
-            webhookEventType: event.eventType,
-            webhookId: event.id,
-            webhookCreatedAt: event.created_at,
-            ...event.object,
-          });
+          await options.onSubscriptionUnpaid?.(
+            {
+              webhookEventType: event.eventType,
+              webhookId: event.id,
+              webhookCreatedAt: event.created_at,
+              ...event.object,
+            },
+            ctx,
+          );
           break;
 
         case "subscription.update":
           await onSubscriptionUpdate(ctx, event, options);
-          await options.onSubscriptionUpdate?.({
-            webhookEventType: event.eventType,
-            webhookId: event.id,
-            webhookCreatedAt: event.created_at,
-            ...event.object,
-          });
+          await options.onSubscriptionUpdate?.(
+            {
+              webhookEventType: event.eventType,
+              webhookId: event.id,
+              webhookCreatedAt: event.created_at,
+              ...event.object,
+            },
+            ctx,
+          );
           break;
 
         case "subscription.past_due":
           await onSubscriptionPastDue(ctx, event, options);
-          await options.onSubscriptionPastDue?.({
-            webhookEventType: event.eventType,
-            webhookId: event.id,
-            webhookCreatedAt: event.created_at,
-            ...event.object,
-          });
+          await options.onSubscriptionPastDue?.(
+            {
+              webhookEventType: event.eventType,
+              webhookId: event.id,
+              webhookCreatedAt: event.created_at,
+              ...event.object,
+            },
+            ctx,
+          );
           break;
 
         case "subscription.paused":
           await onSubscriptionPaused(ctx, event, options);
-          await options.onRevokeAccess?.({
-            reason: "subscription_paused",
-            ...event.object,
-          });
-          await options.onSubscriptionPaused?.({
-            webhookEventType: event.eventType,
-            webhookId: event.id,
-            webhookCreatedAt: event.created_at,
-            ...event.object,
-          });
+          await options.onRevokeAccess?.(
+            {
+              reason: "subscription_paused",
+              ...event.object,
+            },
+            ctx,
+          );
+          await options.onSubscriptionPaused?.(
+            {
+              webhookEventType: event.eventType,
+              webhookId: event.id,
+              webhookCreatedAt: event.created_at,
+              ...event.object,
+            },
+            ctx,
+          );
           break;
 
         default:


### PR DESCRIPTION
## What & why

All plugin callbacks (`onCheckoutCompleted`, `onSubscription*`, `onGrantAccess`, `onRevokeAccess`, etc.) now receive the better-auth `GenericEndpointContext` as their second argument, so handlers can access the request, headers, and auth context during webhook processing.

The context is appended after the existing data parameter, keeping this backwards compatible.

Also updates `webhook.ts` to pass the context through, refreshes the callback signatures in README/BETTERAUTH docs, and adjusts webhook test assertions.

These were changes that I had open a PR for already in the old repo and never got merged in, so I used AI to make the changes being very specific as to what to do and then reviewed everything manually.

## Testing

- `pnpm typecheck` — passes
- `pnpm test` in `packages/better-auth` — 200/200 passing
- `pnpm format:check` — passes

## AI usage

- [ ] I did not use AI tools for this PR.
- [x] I used AI tools, a human has reviewed and can explain every change, and this description was written or edited by a human.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
