### PR TITLE
docs: document license_keys[] on the checkout.completed webhook

### DIFF
--- a/packages/docs/code/webhooks.mdx
+++ b/packages/docs/code/webhooks.mdx
@@ -243,6 +243,21 @@ A checkout session was completed, returning all the information about the paymen
         },
         "mode": "local"
       },
+      "license_keys": [
+        {
+          "id": "lk_2wMk1RtYqPnZ7bVxCdEfGh",
+          "object": "license",
+          "product_id": "prod_d1AY2Sadk9YAvLI0pj97f",
+          "key": "ABCDE-FGHIJ-KLMNO-PQRST-UVWXY",
+          "status": "inactive",
+          "activation": 0,
+          "activation_limit": 1,
+          "expires_at": null,
+          "created_at": "2024-10-12T11:58:33.097Z",
+          "instance": null,
+          "mode": "local"
+        }
+      ],
       "custom_fields": [],
       "status": "completed",
       "metadata": {
@@ -256,6 +271,44 @@ A checkout session was completed, returning all the information about the paymen
     
   </Accordion>
 </AccordionGroup>
+
+#### License keys
+
+If the purchased product issues license keys, the checkout object also carries a `license_keys` array, as shown in the sample above.
+
+<Info>
+  `license_keys` is only present when the order actually issued license keys.
+  For a product without a license key feature the field is **omitted
+  entirely** — check whether it is present rather than expecting an empty
+  array.
+</Info>
+
+Each entry is a license **object**, not a key string:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | string | Unique identifier for the license, prefixed with `lk_`. |
+| `object` | string | Always `license`. |
+| `product_id` | string | The product the license was issued for. |
+| `key` | string | The license key itself: five groups of five uppercase alphanumeric characters, for example `ABCDE-FGHIJ-KLMNO-PQRST-UVWXY`. |
+| `status` | string | One of `inactive`, `active`, `expired`, or `disabled`. A key stays `inactive` until its first successful activation. |
+| `activation` | number | Number of times the key has been activated so far. |
+| `activation_limit` | number \| null | Maximum number of activations allowed. `null` means unlimited. |
+| `expires_at` | string \| null | ISO 8601 expiry date. `null` means the key does not expire. |
+| `created_at` | string | ISO 8601 date the license was created. |
+| `instance` | object \| null | The associated license instance, when one exists. |
+| `mode` | string | The environment the license belongs to. |
+
+<Tip>
+  You do not need a real purchase to see this shape. In the dashboard go to
+  **Settings → Webhooks**, open a webhook and use **Send test event** — the
+  `checkout.completed` payload it delivers includes a populated
+  `license_keys` array.
+</Tip>
+
+One key is issued per license key feature on the product, multiplied by the number of units purchased — a three-unit order of a keyed product delivers three entries. Always treat `license_keys` as a list, never as a single key.
+
+For issuing and managing keys, see [Licenses](/features/addons/licenses).
 
 ### subscription.active
 

--- a/packages/docs/skills/creem-api/skills/creem-api/WEBHOOKS.md
+++ b/packages/docs/skills/creem-api/skills/creem-api/WEBHOOKS.md
@@ -164,6 +164,21 @@ Fired when a customer successfully completes a checkout. This is your primary tr
         "internal_customer_id": "internal_123"
       }
     },
+    "license_keys": [
+      {
+        "id": "lk_2wMk1RtYqPnZ7bVxCdEfGh",
+        "object": "license",
+        "product_id": "prod_d1AY2Sadk9YAvLI0pj97f",
+        "key": "ABCDE-FGHIJ-KLMNO-PQRST-UVWXY",
+        "status": "inactive",
+        "activation": 0,
+        "activation_limit": 1,
+        "expires_at": null,
+        "instance": null,
+        "created_at": "2024-10-12T11:58:33.097Z",
+        "mode": "test"
+      }
+    ],
     "custom_fields": [],
     "metadata": {
       "custom_data": "my custom data",
@@ -172,6 +187,28 @@ Fired when a customer successfully completes a checkout. This is your primary tr
   }
 }
 ```
+
+**License keys.** When the purchased product issues license keys, the checkout
+object carries a `license_keys` array. This is the delivery mechanism for keys —
+you do not need to call the Licenses API to find out what was issued.
+
+The field is **omitted entirely** when the order issued no keys, so test for its
+presence rather than for an empty array. Each entry is a license *object*, not a
+key string:
+
+- `id` — license id, prefixed `lk_`
+- `object` — always `license`
+- `product_id` — the product the key was issued for
+- `key` — the key itself: five groups of five uppercase alphanumerics, e.g. `ABCDE-FGHIJ-KLMNO-PQRST-UVWXY`
+- `status` — `inactive` | `active` | `expired` | `disabled`; a key stays `inactive` until its first activation
+- `activation` / `activation_limit` — activations used and allowed (`activation_limit: null` means unlimited)
+- `expires_at` — ISO 8601, or `null` when the key does not expire
+- `instance` — the associated license instance, or `null`
+- `mode` — the environment the license belongs to
+
+One key is issued per license-key feature on the product, multiplied by the
+number of units purchased — a 3-unit order of a keyed product delivers three
+entries. Always treat `license_keys` as a list, never as a single key.
 
 **Handler Example:**
 

--- a/packages/docs/skills/creem-api/skills/creem-api/WORKFLOWS.md
+++ b/packages/docs/skills/creem-api/skills/creem-api/WORKFLOWS.md
@@ -446,16 +446,44 @@ For software requiring activation and device management.
 ### Architecture
 
 ```
-User purchases → License key generated → User enters in app
-                                              ↓
-        Your backend (holds the API key) ← App calls your backend
-                    ↓
-        Creem licenses API (activate / validate / deactivate)
+User purchases
+      ↓
+Creem issues the key and sends checkout.completed (license_keys[])
+      ↓
+Your backend stores / emails the key → user enters it in the app
+      ↓
+App calls your backend (which holds the API key)
+      ↓
+Creem licenses API (activate / validate / deactivate)
 ```
 
 The Creem API key is a merchant credential and must never ship inside the
 desktop binary — anyone can extract it from the app bundle. The desktop app
 calls your backend; only your backend calls Creem.
+
+### How you receive the key
+
+Creem generates the key and delivers it to you on the `checkout.completed`
+webhook, in the `license_keys` array on the checkout object. You do not have to
+poll or call the Licenses API to discover what was issued:
+
+```typescript
+if (event.eventType === "checkout.completed") {
+  for (const license of event.object.license_keys ?? []) {
+    await db.licenses.create({
+      userId: user.id,
+      key: license.key,           // "ABCDE-FGHIJ-KLMNO-PQRST-UVWXY"
+      licenseId: license.id,      // "lk_..." — needed for activate/validate
+      activationLimit: license.activation_limit,
+      expiresAt: license.expires_at,
+    });
+  }
+  await emailLicenseKeys(customer.email, event.object.license_keys ?? []);
+}
+```
+
+`license_keys` is omitted entirely when the order issued no keys, so guard on
+its presence. See WEBHOOKS.md for the full field list.
 
 ### Step 1: Product Setup
 


### PR DESCRIPTION
Closes the documentation half of [ENG-710](https://linear.app/creem/issue/ENG-710/docs-document-license-keys-in-checkoutcompleted-webhook-payload).

## The gap

`license_keys[]` has been on the `checkout.completed` payload since #1690 (merged 2026-03-13) and was documented **nowhere**:

- `packages/docs/code/webhooks.mdx` — ~35 KB, **zero** occurrences of "license"
- all four files of the `creem-api` skill — also zero

The skill is what the dashboard AI agent reads, which is why a merchant asking about the field during onboarding was told it *doesn't exist*. With the docs silent and the agent wrong, the only way to learn the shape was to take a real payment.

## Why the shape needs spelling out

It surprises people in two specific ways, so both are stated explicitly:

- entries are license **objects**, not key strings
- the field is **omitted entirely** — not an empty array — when the order issued no keys, so integrations must test for presence

## Changes

**`code/webhooks.mdx`** — adds `license_keys` to the `checkout.completed` sample body, plus a `#### License keys` subsection with an `<Info>` on conditional presence, a field table (`id`, `object`, `product_id`, `key`, `status`, `activation`, `activation_limit`, `expires_at`, `created_at`, `instance`, `mode`), and a `<Tip>` pointing at **Settings → Webhooks → Send test event**.

**skill `WEBHOOKS.md`** — the same payload and field list, so the agent's answer matches the published docs.

**skill `WORKFLOWS.md`** — §3 "License Key System for Desktop Apps" never mentioned webhooks at all. Its diagram read `License key generated → User enters in app`, with no account of how the merchant *obtains* the key. Now shows `checkout.completed` as the delivery mechanism, with a handler snippet.

## Grounding

Nothing here is inferred:

- field shapes come from `LicenseEntity` in the generated `openapi.json` (`activation_limit`/`expires_at`/`instance` nullable; `license_keys` not in `required`)
- the `lk_` id prefix and the five-groups-of-five key format come from `LicensesRepository.createLicenseKey` and `LicenseService.generateLicenseKey`
- "one key per license-key feature × units purchased" comes from the issuance loop in `orders.service.ts`
- the **Send test event** tip is only true as of armitage-labs/pugpay-monorepo#2714, which made that button emit a populated `license_keys` array. Before it, the test event sent `null` — so this tip would have been wrong last week.

`api-reference/openapi.json` is generated and was **not** touched.

## Verification

All four docs CI gates run clean locally:

| Check | Result |
|---|---|
| `mint validate` | build validation passed |
| `mint broken-links --check-redirects --check-anchors` | no broken links |
| `plugin validate ./packages/docs/skills/creem-api` | validation passed |
| `generate:api:dry-run` | exit 0 |

Also re-parsed every JSON block in `webhooks.mdx`: 13 of 14 valid, and the `checkout.completed` block parses with `license_keys` intact.

## Two notes for the reviewer

1. **No Prettier run.** All three files were *already* unformatted on `main`, so `--write` would have buried a 123-line change in a whole-file reformat. Root `lint-staged` and `format:check` cover only JS/TS, so nothing enforces it here. Happy to do it as a separate commit if you'd rather.
2. **Pre-existing, untouched:** the first JSON block in `webhooks.mdx` (in the signature-verification section) is not valid JSON on `main`. Out of scope here — flagging rather than fixing.

The `openapi.json` example for `key` is `ABC123-XYZ456-XYZ456-XYZ456` (four groups of six), which does not match the real format keys are generated in. That comes from an `@ApiProperty` example in the private backend, so it needs fixing there, not in this repo.