### PR TITLE
docs: split trading products into prohibited and restricted categories

### DIFF
--- a/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
+++ b/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
@@ -108,7 +108,7 @@ We review accounts to ensure stores are legitimate and in compliance with our te
 
 <Accordion title="Full list of prohibited products">
   - Physical goods of any kind, including, but not limited to, illegal or age-restricted products such as drugs, alcohol, tobacco, vaping products, or weapons, as well as pharmacy, pharmaceutical, and nutraceutical products
-  - Trading and investment tools, services, signals, communities, courses, and educational products
+  - Trading and investment tools and services that enable or facilitate trade execution or automation
   - IPTV services
   - Online traffic and engagement services
   - Donations or charity giving where no product exists or where the price is greater than the product value
@@ -139,6 +139,7 @@ We review accounts to ensure stores are legitimate and in compliance with our te
   - Advertising in newsletters, on websites, or in social media posts
   - API resellers
   - Generative AI products, including, but not limited to text-to-image and text-to-video generation tools
+  - Trading and investment communities, courses, and educational products that do not enable trade execution or automation
 
   All restricted products require additional verification, including previous payment processor details, chargeback/refund rate, and reason for moving to Creem. An established and proven track record is required for consideration.
 </Accordion>


### PR DESCRIPTION
## What & why

Splits the single trading-related entry in the prohibited products list into two separate categories:

- **Prohibited:** Trading and investment tools and services that enable or facilitate trade execution or automation
- **Restricted:** Trading and investment communities, courses, and educational products that do not enable trade execution or automation

This allows education-focused trading products to go through the restricted due-diligence path instead of being outright prohibited.

## Testing

Content-only change — verified MDX renders correctly in local preview.

## AI usage

- [x] I used AI tools, a human has reviewed and edited the output