### PR TITLE
fix(better-auth)!: distinguish scheduled and final cancellation

### DIFF
--- a/.changeset/fresh-better-auth-cancellation.md
+++ b/.changeset/fresh-better-auth-cancellation.md
@@ -1,7 +1,13 @@
 ---
-"@creem_io/better-auth": minor
+"@creem_io/better-auth": major
 ---
 
 Handle `subscription.scheduled_cancel` with an optional `onSubscriptionScheduledCancel` callback, persist the scheduled status and `cancelAtPeriodEnd`, and retain access only until the current period ends. Synchronize the cancellation flag when cancellation is undone or finalized.
 
-Canceled subscriptions now invoke `onRevokeAccess` with `subscription_canceled` and no longer grant access through a future stored period end. Existing revoke handlers receive an additional event; update exhaustive reason checks and keep callbacks idempotent. Scheduled cancellation does not invoke grant or revoke callbacks.
+Ignore delayed scheduled-cancellation updates for subscriptions already stored as canceled or expired, including a terminal event received during the database update. Ignored `subscription.scheduled_cancel` events do not invoke `onSubscriptionScheduledCancel`.
+
+### Upgrade notes
+
+- Canceled subscriptions no longer grant access through `hasAccessGranted()`. This applies immediately to existing stored canceled records, including those with a future period end. Upgrading does not replay webhooks or invoke `onRevokeAccess` for those records. Before deploying, reconcile any separately managed entitlements with the subscription's current state in Creem.
+- New `subscription.canceled` deliveries invoke `onRevokeAccess` with the new `subscription_canceled` reason before `onSubscriptionCanceled`. Update exhaustive reason checks. If both callbacks revoke access, consolidate that logic in `onRevokeAccess` or make it idempotent. Scheduled cancellation does not invoke grant or revoke callbacks.
+- Subscription webhooks and checkout writes synchronize `cancelAtPeriodEnd` from the subscription status. Existing records are not automatically backfilled; the flag may remain unset or stale until a subsequent event updates the record. Access checks use status and period end, not this flag.

--- a/.changeset/fresh-better-auth-cancellation.md
+++ b/.changeset/fresh-better-auth-cancellation.md
@@ -1,0 +1,7 @@
+---
+"@creem_io/better-auth": minor
+---
+
+Handle `subscription.scheduled_cancel` with an optional `onSubscriptionScheduledCancel` callback, persist the scheduled status and `cancelAtPeriodEnd`, and retain access only until the current period ends. Synchronize the cancellation flag when cancellation is undone or finalized.
+
+Canceled subscriptions now invoke `onRevokeAccess` with `subscription_canceled` and no longer grant access through a future stored period end. Existing revoke handlers receive an additional event; update exhaustive reason checks and keep callbacks idempotent. Scheduled cancellation does not invoke grant or revoke callbacks.

--- a/.changeset/fresh-better-auth-cancellation.md
+++ b/.changeset/fresh-better-auth-cancellation.md
@@ -6,8 +6,6 @@ Handle `subscription.scheduled_cancel` with an optional `onSubscriptionScheduled
 
 Ignore delayed scheduled-cancellation updates for subscriptions already stored as canceled or expired, including a terminal event received during the database update. Ignored `subscription.scheduled_cancel` events do not invoke `onSubscriptionScheduledCancel`.
 
-### Upgrade notes
+**Breaking changes:** Canceled subscriptions no longer grant access through `hasAccessGranted()`, including existing records. Upgrading does not replay revoke callbacks. New `subscription.canceled` deliveries invoke `onRevokeAccess` with the additional `subscription_canceled` reason before `onSubscriptionCanceled`.
 
-- Canceled subscriptions no longer grant access through `hasAccessGranted()`. This applies immediately to existing stored canceled records, including those with a future period end. Upgrading does not replay webhooks or invoke `onRevokeAccess` for those records. Before deploying, reconcile any separately managed entitlements with the subscription's current state in Creem.
-- New `subscription.canceled` deliveries invoke `onRevokeAccess` with the new `subscription_canceled` reason before `onSubscriptionCanceled`. Update exhaustive reason checks. If both callbacks revoke access, consolidate that logic in `onRevokeAccess` or make it idempotent. Scheduled cancellation does not invoke grant or revoke callbacks.
-- Subscription webhooks and checkout writes synchronize `cancelAtPeriodEnd` from the subscription status. Existing records are not automatically backfilled; the flag may remain unset or stale until a subsequent event updates the record. Access checks use status and period end, not this flag.
+Follow the [1.x to 2.0 migration guide](https://docs.creem.io/code/sdks/better-auth/migration#upgrading-from-1-x) to update callbacks and exhaustive reason checks, reconcile existing entitlements, and verify the upgrade. No database schema migration is required; existing cancellation flags are not automatically backfilled.

--- a/packages/docs/code/sdks/better-auth.mdx
+++ b/packages/docs/code/sdks/better-auth.mdx
@@ -7,6 +7,9 @@ The `@creem_io/better-auth` plugin connects Creem billing to your Better Auth us
 session-aware endpoints for checkout, the customer portal, subscriptions, and transaction history.
 With persistence enabled, webhooks keep subscription state in your application database.
 
+Upgrading an existing integration from 1.x? Follow the
+[migration guide](/code/sdks/better-auth/migration#upgrading-from-1-x) before deploying 2.0.
+
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="/code/sdks/better-auth/quickstart">
     Install the plugin and complete a subscription checkout.

--- a/packages/docs/code/sdks/better-auth/client.mdx
+++ b/packages/docs/code/sdks/better-auth/client.mdx
@@ -67,9 +67,10 @@ the ID belongs to the signed-in user. Do not pass a value obtained from untruste
 ## Check access
 
 `hasAccessGranted()` reads the signed-in user's persisted subscriptions. It grants access for
-`active`, `trialing`, or `paid` records. A `canceled`, `past_due`, or `unpaid` subscription also
+`active`, `trialing`, or `paid` records. A `scheduled_cancel`, `past_due`, or `unpaid` subscription also
 retains access while its `periodEnd` is still in the future, so customers can use time they have
-already paid for.
+already paid for. A `canceled` subscription no longer grants access, even if its stored period end
+is in the future.
 
 ```typescript
 const { data, error } = await authClient.creem.hasAccessGranted();

--- a/packages/docs/code/sdks/better-auth/client.mdx
+++ b/packages/docs/code/sdks/better-auth/client.mdx
@@ -69,8 +69,7 @@ the ID belongs to the signed-in user. Do not pass a value obtained from untruste
 `hasAccessGranted()` reads the signed-in user's persisted subscriptions. It grants access for
 `active`, `trialing`, or `paid` records. A `scheduled_cancel`, `past_due`, or `unpaid` subscription also
 retains access while its `periodEnd` is still in the future, so customers can use time they have
-already paid for. A `canceled` subscription no longer grants access, even if its stored period end
-is in the future.
+already paid for. A `canceled` subscription no longer grants access.
 
 ```typescript
 const { data, error } = await authClient.creem.hasAccessGranted();

--- a/packages/docs/code/sdks/better-auth/configuration.mdx
+++ b/packages/docs/code/sdks/better-auth/configuration.mdx
@@ -71,17 +71,20 @@ npx @better-auth/cli generate
 
 The `creem_subscription` model contains:
 
-| Field                 | Type              | Notes                                                        |
-| --------------------- | ----------------- | ------------------------------------------------------------ |
-| `productId`           | string            | Creem product ID                                             |
-| `referenceId`         | string            | Better Auth user ID or another application reference         |
-| `creemCustomerId`     | string, optional  | Creem customer ID                                            |
-| `creemSubscriptionId` | string, optional  | Creem subscription ID                                        |
-| `creemOrderId`        | string, optional  | Creem order ID                                               |
-| `status`              | string            | Defaults to `pending`                                        |
-| `periodStart`         | date, optional    | Current billing period start                                 |
-| `periodEnd`           | date, optional    | Current billing period end                                   |
-| `cancelAtPeriodEnd`   | boolean, optional | `true` while status is `scheduled_cancel`; otherwise `false` |
+| Field                 | Type              | Notes                                                                                                                   |
+| --------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `productId`           | string            | Creem product ID                                                                                                        |
+| `referenceId`         | string            | Better Auth user ID or another application reference                                                                    |
+| `creemCustomerId`     | string, optional  | Creem customer ID                                                                                                       |
+| `creemSubscriptionId` | string, optional  | Creem subscription ID                                                                                                   |
+| `creemOrderId`        | string, optional  | Creem order ID                                                                                                          |
+| `status`              | string            | Defaults to `pending`                                                                                                   |
+| `periodStart`         | date, optional    | Current billing period start                                                                                            |
+| `periodEnd`           | date, optional    | Current billing period end                                                                                              |
+| `cancelAtPeriodEnd`   | boolean, optional | Synchronized from status by subscription webhooks and checkout writes: `true` for `scheduled_cancel`, otherwise `false` |
+
+Existing records are not automatically backfilled. `cancelAtPeriodEnd` may remain unset or stale
+until a subsequent event updates the record. Access checks use `status` and `periodEnd`.
 
 The plugin extends the Better Auth `user` model with:
 

--- a/packages/docs/code/sdks/better-auth/configuration.mdx
+++ b/packages/docs/code/sdks/better-auth/configuration.mdx
@@ -71,17 +71,17 @@ npx @better-auth/cli generate
 
 The `creem_subscription` model contains:
 
-| Field                 | Type              | Notes                                                |
-| --------------------- | ----------------- | ---------------------------------------------------- |
-| `productId`           | string            | Creem product ID                                     |
-| `referenceId`         | string            | Better Auth user ID or another application reference |
-| `creemCustomerId`     | string, optional  | Creem customer ID                                    |
-| `creemSubscriptionId` | string, optional  | Creem subscription ID                                |
-| `creemOrderId`        | string, optional  | Creem order ID                                       |
-| `status`              | string            | Defaults to `pending`                                |
-| `periodStart`         | date, optional    | Current billing period start                         |
-| `periodEnd`           | date, optional    | Current billing period end                           |
-| `cancelAtPeriodEnd`   | boolean, optional | Defaults to `false`                                  |
+| Field                 | Type              | Notes                                                        |
+| --------------------- | ----------------- | ------------------------------------------------------------ |
+| `productId`           | string            | Creem product ID                                             |
+| `referenceId`         | string            | Better Auth user ID or another application reference         |
+| `creemCustomerId`     | string, optional  | Creem customer ID                                            |
+| `creemSubscriptionId` | string, optional  | Creem subscription ID                                        |
+| `creemOrderId`        | string, optional  | Creem order ID                                               |
+| `status`              | string            | Defaults to `pending`                                        |
+| `periodStart`         | date, optional    | Current billing period start                                 |
+| `periodEnd`           | date, optional    | Current billing period end                                   |
+| `cancelAtPeriodEnd`   | boolean, optional | `true` while status is `scheduled_cancel`; otherwise `false` |
 
 The plugin extends the Better Auth `user` model with:
 

--- a/packages/docs/code/sdks/better-auth/migration.mdx
+++ b/packages/docs/code/sdks/better-auth/migration.mdx
@@ -1,0 +1,76 @@
+---
+title: "Migration"
+description: "Upgrade the Creem Better Auth plugin from 1.x to 2.0 and update cancellation access handling."
+---
+
+Use this guide when upgrading an existing `@creem_io/better-auth` integration. For a new
+integration, start with the [quickstart](/code/sdks/better-auth/quickstart).
+
+## Upgrading from 1.x
+
+Version 2.0 distinguishes scheduled cancellation from final cancellation in webhook callbacks
+and persisted access checks. Review your callbacks and existing subscription records before
+deploying the upgrade. No database schema migration is required.
+
+### What changes
+
+| Behavior                                             | 1.x                                        | 2.0                                                                                                     |
+| ---------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `subscription.scheduled_cancel` webhook              | Rejected with HTTP 400                     | Accepted; persists the scheduled status and calls the optional `onSubscriptionScheduledCancel` callback |
+| Access from a stored `scheduled_cancel` subscription | Does not grant access                      | Grants access only before its stored `periodEnd`                                                        |
+| Access from a stored `canceled` subscription         | Grants access until its stored `periodEnd` | Does not grant access                                                                                   |
+| `subscription.canceled` callbacks                    | Calls `onSubscriptionCanceled`             | Calls `onRevokeAccess` with `subscription_canceled`, then `onSubscriptionCanceled`                      |
+
+Access behavior in this table refers to `hasAccessGranted()` with persistence enabled. The
+existing `past_due` and `unpaid` period-end grace behavior is unchanged. The direct
+[server helpers](/code/sdks/better-auth/server) retain their documented active-status scope.
+
+### Update your callbacks
+
+Add `subscription_canceled` to any exhaustive switches or mappings over `RevokeAccessReason` or
+`AccessChangeReason`. If your `onRevokeAccess` handler already handles every reason the same way,
+it will now also run for final cancellation.
+
+If you currently revoke access in `onSubscriptionCanceled`, move that logic into
+`onRevokeAccess`, or ensure that calling both handlers has the same effect as calling one.
+Keep handlers idempotent because webhooks can be delivered more than once. These callback
+changes also apply when `persistSubscriptions: false`.
+
+Scheduling cancellation does not invoke `onGrantAccess` or `onRevokeAccess`. If you manage
+entitlements outside the plugin database, use `onSubscriptionScheduledCancel` to store the
+period end and enforce it in your own access checks. See
+[Webhooks and access](/code/sdks/better-auth/webhooks) for callback examples and retry behavior.
+
+### Review existing records and entitlements
+
+The new access policy applies to existing records as soon as you deploy 2.0. Upgrading does not
+replay webhooks or invoke `onRevokeAccess` for records already stored as `canceled`.
+
+Before deploying:
+
+1. Review local canceled records that currently grant access and compare them with the
+   subscription's current state in Creem. Correct stale local state from that source; do not
+   relabel a canceled subscription as scheduled solely because its stored period end is in the future.
+2. If you store entitlements separately, reconcile them with the current subscription state.
+   Do not rely on a new revoke callback arriving solely because you upgraded the package.
+3. Check any custom use of `cancelAtPeriodEnd`. Existing flags are not automatically backfilled;
+   subsequent subscription webhooks and checkout writes synchronize the flag. The plugin's
+   access checks use `status` and `periodEnd`.
+
+<Note>
+  An existing canceled record can still have a future `periodEnd`. In this edge case, upgrading
+  stops that record from granting access immediately, rather than waiting for the stored date.
+</Note>
+
+### Install and verify
+
+After updating your handlers and reviewing existing state, install the new major version:
+
+```bash
+pnpm add @creem_io/better-auth@^2
+```
+
+Run your application's typecheck to catch exhaustive reason checks that need updating. In test
+mode, verify that scheduled cancellation preserves access before the period end, that access
+ends at the period boundary, and that final cancellation invokes your revoke logic without
+duplicate side effects. If you manage entitlements separately, verify those access checks too.

--- a/packages/docs/code/sdks/better-auth/server.mdx
+++ b/packages/docs/code/sdks/better-auth/server.mdx
@@ -109,4 +109,6 @@ The server entry point also exports:
 `checkSubscriptionAccess()` and `getActiveSubscriptions()` are also exported, but their database
 mode expects a raw query-builder interface that is not compatible with every Better Auth adapter.
 Prefer the authenticated `hasAccessGranted()` endpoint or query your own database through its
-supported adapter API.
+supported adapter API. These server helpers only recognize `active`, `trialing`, and `paid`;
+they do not evaluate scheduled cancellation deadlines or payment grace periods. Use
+[`hasAccessGranted()`](/code/sdks/better-auth/client#check-access) for those access decisions.

--- a/packages/docs/code/sdks/better-auth/webhooks.mdx
+++ b/packages/docs/code/sdks/better-auth/webhooks.mdx
@@ -77,17 +77,17 @@ enabled, the plugin stores `status: "scheduled_cancel"` and `cancelAtPeriodEnd: 
 This event calls `onSubscriptionScheduledCancel` without calling `onGrantAccess` or `onRevokeAccess`.
 
 `subscription.canceled` means the subscription has ended. It calls both `onRevokeAccess` and
-`onSubscriptionCanceled`, and the access check denies that subscription even if its stored
-period end is in the future. When cancellation is undone or finalized, subsequent subscription
+`onSubscriptionCanceled`, and the access check denies that subscription.
+When cancellation is undone or finalized, subsequent subscription
 events synchronize the status and clear `cancelAtPeriodEnd` when the status is no longer
 `scheduled_cancel`.
 
-<Note>
-  Previously, canceled subscriptions retained access until their stored period end and did not
-  trigger `onRevokeAccess`. When upgrading, handle the new `subscription_canceled` reason in any
-  exhaustive reason checks and keep revoke callbacks idempotent. If you manage access outside the
-  plugin database, store the scheduled period end and enforce it in your own access checks.
-</Note>
+With persistence enabled, delayed scheduled-cancellation updates cannot change a stored `canceled`
+or `expired` subscription back to `scheduled_cancel`. Ignored `subscription.scheduled_cancel`
+events do not invoke `onSubscriptionScheduledCancel`.
+
+If you manage access outside the plugin database, store the scheduled period end and enforce it
+in your own access checks.
 
 <Warning>
   Webhooks can be retried or delivered more than once. Make every callback idempotent: applying the

--- a/packages/docs/code/sdks/better-auth/webhooks.mdx
+++ b/packages/docs/code/sdks/better-auth/webhooks.mdx
@@ -69,9 +69,25 @@ creem({
 
 - `subscription_paused`
 - `subscription_expired`
+- `subscription_canceled`
 
-Cancellation does not necessarily revoke access immediately. A subscription scheduled to cancel
-can remain usable until its paid period expires.
+`subscription.scheduled_cancel` preserves access until `current_period_end_date`. With persistence
+enabled, the plugin stores `status: "scheduled_cancel"` and `cancelAtPeriodEnd: true`;
+`hasAccessGranted()` returns false once that period ends, even if the final webhook is delayed.
+This event calls `onSubscriptionScheduledCancel` without calling `onGrantAccess` or `onRevokeAccess`.
+
+`subscription.canceled` means the subscription has ended. It calls both `onRevokeAccess` and
+`onSubscriptionCanceled`, and the access check denies that subscription even if its stored
+period end is in the future. When cancellation is undone or finalized, subsequent subscription
+events synchronize the status and clear `cancelAtPeriodEnd` when the status is no longer
+`scheduled_cancel`.
+
+<Note>
+  Previously, canceled subscriptions retained access until their stored period end and did not
+  trigger `onRevokeAccess`. When upgrading, handle the new `subscription_canceled` reason in any
+  exhaustive reason checks and keep revoke callbacks idempotent. If you manage access outside the
+  plugin database, store the scheduled period end and enforce it in your own access checks.
+</Note>
 
 <Warning>
   Webhooks can be retried or delivered more than once. Make every callback idempotent: applying the
@@ -82,20 +98,21 @@ can remain usable until its paid period expires.
 
 Use event-specific callbacks when you need more than the high-level access decision:
 
-| Callback                 | Event                   |
-| ------------------------ | ----------------------- |
-| `onCheckoutCompleted`    | `checkout.completed`    |
-| `onRefundCreated`        | `refund.created`        |
-| `onDisputeCreated`       | `dispute.created`       |
-| `onSubscriptionActive`   | `subscription.active`   |
-| `onSubscriptionTrialing` | `subscription.trialing` |
-| `onSubscriptionCanceled` | `subscription.canceled` |
-| `onSubscriptionPaid`     | `subscription.paid`     |
-| `onSubscriptionExpired`  | `subscription.expired`  |
-| `onSubscriptionUnpaid`   | `subscription.unpaid`   |
-| `onSubscriptionUpdate`   | `subscription.update`   |
-| `onSubscriptionPastDue`  | `subscription.past_due` |
-| `onSubscriptionPaused`   | `subscription.paused`   |
+| Callback                        | Event                           |
+| ------------------------------- | ------------------------------- |
+| `onCheckoutCompleted`           | `checkout.completed`            |
+| `onRefundCreated`               | `refund.created`                |
+| `onDisputeCreated`              | `dispute.created`               |
+| `onSubscriptionActive`          | `subscription.active`           |
+| `onSubscriptionTrialing`        | `subscription.trialing`         |
+| `onSubscriptionCanceled`        | `subscription.canceled`         |
+| `onSubscriptionScheduledCancel` | `subscription.scheduled_cancel` |
+| `onSubscriptionPaid`            | `subscription.paid`             |
+| `onSubscriptionExpired`         | `subscription.expired`          |
+| `onSubscriptionUnpaid`          | `subscription.unpaid`           |
+| `onSubscriptionUpdate`          | `subscription.update`           |
+| `onSubscriptionPastDue`         | `subscription.past_due`         |
+| `onSubscriptionPaused`          | `subscription.paused`           |
 
 Each callback receives normalized event data followed by the Better Auth endpoint context:
 

--- a/packages/docs/code/sdks/better-auth/webhooks.mdx
+++ b/packages/docs/code/sdks/better-auth/webhooks.mdx
@@ -85,6 +85,8 @@ events synchronize the status and clear `cancelAtPeriodEnd` when the status is n
 With persistence enabled, delayed scheduled-cancellation updates cannot change a stored `canceled`
 or `expired` subscription back to `scheduled_cancel`. Ignored `subscription.scheduled_cancel`
 events do not invoke `onSubscriptionScheduledCancel`.
+The general `onSubscriptionUpdate` callback still receives `subscription.update` events,
+including those whose scheduled status was ignored by persistence.
 
 If you manage access outside the plugin database, store the scheduled period end and enforce it
 in your own access checks.

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -203,7 +203,8 @@
                       "code/sdks/better-auth/configuration",
                       "code/sdks/better-auth/client",
                       "code/sdks/better-auth/webhooks",
-                      "code/sdks/better-auth/server"
+                      "code/sdks/better-auth/server",
+                      "code/sdks/better-auth/migration"
                     ]
                   },
                   {

--- a/packages/docs/llms.txt
+++ b/packages/docs/llms.txt
@@ -22,6 +22,7 @@ Append `.md` to any documentation URL to fetch it as raw markdown.
 - [TypeScript SDK](https://docs.creem.io/code/sdks/typescript.md): the core client for server-side JavaScript; the API key must stay on your backend
 - [Next.js adapter](https://docs.creem.io/code/sdks/nextjs.md): route handlers and server-side helpers for Next.js apps
 - [Better Auth plugin](https://docs.creem.io/code/sdks/better-auth.md): billing wired into Better Auth sessions and organizations
+- [Better Auth migration](https://docs.creem.io/code/sdks/better-auth/migration.md): upgrade from 1.x to 2.0, update cancellation callbacks, and reconcile existing entitlements
 - [Convex component](https://docs.creem.io/code/sdks/convex/integration.md): complete setup sequence with validation steps — webhook sync into the Convex database plus connected React and Svelte widgets
 - [Convex concepts](https://docs.creem.io/code/sdks/convex/concepts.md): the billing entity, the sources of billing state, and the connected API contract behind the Convex component
 - [CLI](https://docs.creem.io/code/cli.md): manage products, customers, and subscriptions from the terminal

--- a/packages/integrations/better-auth/src/__tests__/cancellation-lifecycle.test.ts
+++ b/packages/integrations/better-auth/src/__tests__/cancellation-lifecycle.test.ts
@@ -241,6 +241,71 @@ describe("cancellation lifecycle through verified webhooks", () => {
     },
   );
 
+  it("suppresses the scheduled callback when an adapter throws after a concurrent terminal write", async () => {
+    const store = createSubscriptionStore();
+    const update = store.adapter.update.getMockImplementation()!;
+    store.adapter.update.mockImplementationOnce(async () => {
+      await update({ update: { status: "canceled", cancelAtPeriodEnd: false } });
+      throw Object.assign(new Error("Record to update not found"), { code: "P2025" });
+    });
+    const onSubscriptionScheduledCancel = vi.fn();
+    const ctx = await deliver(store, "subscription.scheduled_cancel", "scheduled_cancel", {
+      ...defaultOptions,
+      onSubscriptionScheduledCancel,
+    });
+    expect(ctx.json).toHaveBeenCalledWith({ message: "Webhook received" });
+    expect(store.record.status).toBe("canceled");
+    expect(onSubscriptionScheduledCancel).not.toHaveBeenCalled();
+  });
+
+  it("retries scheduled persistence failures before running the callback", async () => {
+    const store = createSubscriptionStore();
+    store.adapter.update.mockRejectedValueOnce(new Error("Database unavailable"));
+    const onSubscriptionScheduledCancel = vi.fn();
+    const options = { ...defaultOptions, onSubscriptionScheduledCancel };
+    const failed = await deliver(
+      store,
+      "subscription.scheduled_cancel",
+      "scheduled_cancel",
+      options,
+    );
+    expect(failed.json).toHaveBeenCalledWith(
+      { error: "Failed to process webhook" },
+      { status: 500 },
+    );
+    expect(onSubscriptionScheduledCancel).not.toHaveBeenCalled();
+    const retried = await deliver(
+      store,
+      "subscription.scheduled_cancel",
+      "scheduled_cancel",
+      options,
+    );
+    expect(retried.json).toHaveBeenCalledWith({ message: "Webhook received" });
+    expect(store.record.status).toBe("scheduled_cancel");
+    expect(onSubscriptionScheduledCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("delivers a new subscription's scheduled callback without overwriting an older canceled fallback row", async () => {
+    const store = createSubscriptionStore();
+    await store.adapter.update({
+      update: { creemSubscriptionId: "sub_older", status: "canceled" },
+    });
+    store.adapter.update.mockClear();
+    store.adapter.findOne.mockResolvedValueOnce(null);
+    const onSubscriptionScheduledCancel = vi.fn();
+    const ctx = await deliver(store, "subscription.scheduled_cancel", "scheduled_cancel", {
+      ...defaultOptions,
+      onSubscriptionScheduledCancel,
+    });
+    expect(ctx.json).toHaveBeenCalledWith({ message: "Webhook received" });
+    expect(store.adapter.update).not.toHaveBeenCalled();
+    expect(store.record).toMatchObject({ creemSubscriptionId: "sub_older", status: "canceled" });
+    expect(onSubscriptionScheduledCancel).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ id: mockSubscription.id }),
+      ctx,
+    );
+  });
+
   it("keeps the scheduled flag when a subscription.update still carries scheduled_cancel", async () => {
     const store = createSubscriptionStore();
     await deliver(store, "subscription.update", "scheduled_cancel");

--- a/packages/integrations/better-auth/src/__tests__/cancellation-lifecycle.test.ts
+++ b/packages/integrations/better-auth/src/__tests__/cancellation-lifecycle.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CreemOptions, SubscriptionRecord } from "../types.js";
+import {
+  createMockAdapter,
+  createMockContext,
+  defaultOptions,
+  mockDbSubscription,
+  mockSubscription,
+} from "./fixtures.js";
+import { generateSignature } from "../utils.js";
+
+vi.mock("better-auth/api", () => ({
+  createAuthEndpoint: vi.fn((_path, _opts, handler) => handler),
+  getSessionFromCtx: vi.fn(async () => ({ user: { id: "user_123" } })),
+}));
+
+import { createWebhookEndpoint } from "../webhook.js";
+import { createHasAccessGrantedEndpoint } from "../has-active-subscription.js";
+
+const periodEnd = new Date("2030-02-01T12:00:00.000Z");
+
+function createSubscriptionStore() {
+  let record: SubscriptionRecord = { ...mockDbSubscription, periodEnd };
+  const adapter = createMockAdapter();
+  adapter.findOne.mockImplementation(async () => record);
+  adapter.findMany.mockImplementation(async () => [record]);
+  adapter.update.mockImplementation(async ({ update }) => {
+    record = { ...record, ...update };
+    return record;
+  });
+  return {
+    adapter,
+    get record() {
+      return record;
+    },
+  };
+}
+
+async function deliver(
+  store: ReturnType<typeof createSubscriptionStore>,
+  eventType: string,
+  status: typeof mockSubscription.status,
+  options: CreemOptions = defaultOptions,
+) {
+  const payload = JSON.stringify({
+    id: "evt_cancellation",
+    created_at: 1896000000,
+    eventType,
+    object: { ...mockSubscription, status, current_period_end_date: periodEnd },
+  });
+  const signature = await generateSignature(payload, options.webhookSecret!);
+  const ctx = createMockContext({
+    adapter: store.adapter,
+    requestText: payload,
+    headers: { "creem-signature": signature },
+  });
+  await createWebhookEndpoint(options)(ctx);
+  return ctx;
+}
+
+async function hasAccess(store: ReturnType<typeof createSubscriptionStore>) {
+  const ctx = createMockContext({ adapter: store.adapter });
+  await createHasAccessGrantedEndpoint(defaultOptions)(ctx);
+  return ctx.json.mock.calls[0][0].hasAccessGranted;
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe("cancellation lifecycle through verified webhooks", () => {
+  it("persists scheduled cancellation before its callback and retains access without provisioning callbacks", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(periodEnd.getTime() - 1));
+    const store = createSubscriptionStore();
+    const onGrantAccess = vi.fn();
+    const onRevokeAccess = vi.fn();
+    const onSubscriptionScheduledCancel = vi.fn(async (data, ctx) => {
+      expect(store.record).toMatchObject({
+        status: "scheduled_cancel",
+        cancelAtPeriodEnd: true,
+        periodEnd,
+      });
+      expect(data).toMatchObject({
+        webhookEventType: "subscription.scheduled_cancel",
+        webhookId: "evt_cancellation",
+        webhookCreatedAt: 1896000000,
+        id: mockSubscription.id,
+        current_period_end_date: periodEnd.toISOString(),
+      });
+      expect(ctx.context.adapter).toBe(store.adapter);
+    });
+    const ctx = await deliver(store, "subscription.scheduled_cancel", "scheduled_cancel", {
+      ...defaultOptions,
+      onGrantAccess,
+      onRevokeAccess,
+      onSubscriptionScheduledCancel,
+    });
+    expect(ctx.json).toHaveBeenCalledWith({ message: "Webhook received" });
+    expect(onSubscriptionScheduledCancel).toHaveBeenCalledTimes(1);
+    expect(onGrantAccess).not.toHaveBeenCalled();
+    expect(onRevokeAccess).not.toHaveBeenCalled();
+    expect(await hasAccess(store)).toBe(true);
+  });
+
+  it.each([0, 1])(
+    "denies scheduled cancellation at/after period end (%i ms) without waiting for another webhook",
+    async (offset) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(periodEnd.getTime() + offset));
+      const store = createSubscriptionStore();
+      const ctx = await deliver(store, "subscription.scheduled_cancel", "scheduled_cancel");
+      expect(ctx.json).toHaveBeenCalledWith({ message: "Webhook received" });
+      expect(await hasAccess(store)).toBe(false);
+    },
+  );
+
+  it.each([undefined, new Date("invalid")])(
+    "denies scheduled cancellation without a usable period end (%s)",
+    async (missingEnd) => {
+      const store = createSubscriptionStore();
+      await store.adapter.update({ update: { status: "scheduled_cancel", periodEnd: missingEnd } });
+      expect(await hasAccess(store)).toBe(false);
+    },
+  );
+
+  it("revokes canceled subscriptions with a future period end and invokes the specific callback afterward", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(periodEnd.getTime() - 86400000));
+    const store = createSubscriptionStore();
+    await deliver(store, "subscription.scheduled_cancel", "scheduled_cancel");
+    const calls: string[] = [];
+    const onRevokeAccess = vi.fn(async (data, ctx) => {
+      expect(data).toMatchObject({ reason: "subscription_canceled", id: mockSubscription.id });
+      expect(ctx.context.adapter).toBe(store.adapter);
+      expect(store.record).toMatchObject({ status: "canceled", cancelAtPeriodEnd: false });
+      calls.push("revoke");
+    });
+    const onSubscriptionCanceled = vi.fn(async () => {
+      calls.push("canceled");
+    });
+    const ctx = await deliver(store, "subscription.canceled", "canceled", {
+      ...defaultOptions,
+      onRevokeAccess,
+      onSubscriptionCanceled,
+    });
+    expect(ctx.json).toHaveBeenCalledWith({ message: "Webhook received" });
+    expect(calls).toEqual(["revoke", "canceled"]);
+    expect(await hasAccess(store)).toBe(false);
+  });
+
+  it.each([
+    ["subscription.active", "active"],
+    ["subscription.update", "active"],
+    ["subscription.canceled", "canceled"],
+    ["subscription.expired", "canceled"],
+  ] as const)("clears the scheduled flag on %s with %s status", async (eventType, status) => {
+    const store = createSubscriptionStore();
+    await deliver(store, "subscription.scheduled_cancel", "scheduled_cancel");
+    await deliver(store, eventType, status);
+    expect(store.record.cancelAtPeriodEnd).toBe(false);
+    expect(store.record.status).toBe(eventType === "subscription.expired" ? "expired" : status);
+  });
+
+  it("keeps the scheduled flag when a subscription.update still carries scheduled_cancel", async () => {
+    const store = createSubscriptionStore();
+    await deliver(store, "subscription.update", "scheduled_cancel");
+    expect(store.record).toMatchObject({ status: "scheduled_cancel", cancelAtPeriodEnd: true });
+  });
+
+  it.each(["subscription.scheduled_cancel", "subscription.canceled"] as const)(
+    "accepts %s without optional callbacks",
+    async (eventType) => {
+      const store = createSubscriptionStore();
+      const ctx = await deliver(
+        store,
+        eventType,
+        eventType === "subscription.canceled" ? "canceled" : "scheduled_cancel",
+      );
+      expect(ctx.json).toHaveBeenCalledWith({ message: "Webhook received" });
+    },
+  );
+
+  it("runs scheduled cancellation callbacks with persistence disabled", async () => {
+    const store = createSubscriptionStore();
+    const onSubscriptionScheduledCancel = vi.fn();
+    const ctx = await deliver(store, "subscription.scheduled_cancel", "scheduled_cancel", {
+      ...defaultOptions,
+      persistSubscriptions: false,
+      onSubscriptionScheduledCancel,
+    });
+    expect(ctx.json).toHaveBeenCalledWith({ message: "Webhook received" });
+    expect(onSubscriptionScheduledCancel).toHaveBeenCalledTimes(1);
+    expect(store.adapter.findOne).not.toHaveBeenCalled();
+    expect(store.adapter.update).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["subscription.scheduled_cancel", "scheduled_cancel", "onSubscriptionScheduledCancel"],
+    ["subscription.canceled", "canceled", "onRevokeAccess"],
+    ["subscription.canceled", "canceled", "onSubscriptionCanceled"],
+  ] as const)(
+    "awaits %s %s callback %s before acknowledging",
+    async (eventType, status, callbackName) => {
+      const store = createSubscriptionStore();
+      let release!: () => void;
+      let started!: () => void;
+      const entered = new Promise<void>((resolve) => {
+        started = resolve;
+      });
+      const pending = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const callback = vi.fn(async () => {
+        started();
+        await pending;
+      });
+      let finished = false;
+      const delivery = deliver(store, eventType, status, {
+        ...defaultOptions,
+        [callbackName]: callback,
+      }).then((ctx) => {
+        finished = true;
+        return ctx;
+      });
+      await entered;
+      expect(finished).toBe(false);
+      release();
+      const ctx = await delivery;
+      expect(ctx.json).toHaveBeenCalledWith({ message: "Webhook received" });
+    },
+  );
+
+  it.each([
+    ["subscription.scheduled_cancel", "scheduled_cancel", "onSubscriptionScheduledCancel"],
+    ["subscription.canceled", "canceled", "onRevokeAccess"],
+  ] as const)(
+    "returns 500 on %s callback failure and accepts a retry",
+    async (eventType, status, callbackName) => {
+      const store = createSubscriptionStore();
+      const callback = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Temporary provisioning failure"))
+        .mockResolvedValue(undefined);
+      const options = { ...defaultOptions, [callbackName]: callback };
+      const failed = await deliver(store, eventType, status, options);
+      expect(failed.json).toHaveBeenCalledWith(
+        { error: "Failed to process webhook" },
+        { status: 500 },
+      );
+      const retried = await deliver(store, eventType, status, options);
+      expect(retried.json).toHaveBeenCalledWith({ message: "Webhook received" });
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(store.record.cancelAtPeriodEnd).toBe(status === "scheduled_cancel");
+    },
+  );
+});

--- a/packages/integrations/better-auth/src/__tests__/cancellation-lifecycle.test.ts
+++ b/packages/integrations/better-auth/src/__tests__/cancellation-lifecycle.test.ts
@@ -24,7 +24,16 @@ function createSubscriptionStore() {
   const adapter = createMockAdapter();
   adapter.findOne.mockImplementation(async () => record);
   adapter.findMany.mockImplementation(async () => [record]);
-  adapter.update.mockImplementation(async ({ update }) => {
+  adapter.update.mockImplementation(async ({ update, where = [] }) => {
+    for (const condition of where) {
+      if (
+        condition.field === "status" &&
+        condition.operator === "not_in" &&
+        condition.value.includes(record.status)
+      ) {
+        return null;
+      }
+    }
     record = { ...record, ...update };
     return record;
   });
@@ -160,6 +169,78 @@ describe("cancellation lifecycle through verified webhooks", () => {
     expect(store.record.status).toBe(eventType === "subscription.expired" ? "expired" : status);
   });
 
+  it.each(["canceled", "expired"] as const)(
+    "ignores a scheduled-cancellation retry after %s without restoring access",
+    async (terminalStatus) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(periodEnd.getTime() - 1));
+      const store = createSubscriptionStore();
+      const onSubscriptionScheduledCancel = vi.fn().mockRejectedValueOnce(new Error("Retry"));
+      const options = { ...defaultOptions, onSubscriptionScheduledCancel };
+      const failed = await deliver(
+        store,
+        "subscription.scheduled_cancel",
+        "scheduled_cancel",
+        options,
+      );
+      expect(failed.json).toHaveBeenCalledWith(
+        { error: "Failed to process webhook" },
+        { status: 500 },
+      );
+
+      await deliver(store, `subscription.${terminalStatus}`, "canceled");
+      const retried = await deliver(
+        store,
+        "subscription.scheduled_cancel",
+        "scheduled_cancel",
+        options,
+      );
+      expect(retried.json).toHaveBeenCalledWith({ message: "Webhook received" });
+      expect(onSubscriptionScheduledCancel).toHaveBeenCalledTimes(1);
+      expect(store.record).toMatchObject({ status: terminalStatus, cancelAtPeriodEnd: false });
+      expect(await hasAccess(store)).toBe(false);
+
+      await deliver(store, "subscription.update", "scheduled_cancel");
+      expect(store.record.status).toBe(terminalStatus);
+      expect(await hasAccess(store)).toBe(false);
+    },
+  );
+
+  it("keeps terminal state when cancellation finishes between the scheduled-event lookup and write", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(periodEnd.getTime() - 1));
+    const store = createSubscriptionStore();
+    const update = store.adapter.update.getMockImplementation()!;
+    store.adapter.update.mockImplementationOnce(async (args) => {
+      await update({ update: { status: "canceled", cancelAtPeriodEnd: false } });
+      return update(args);
+    });
+    const onSubscriptionScheduledCancel = vi.fn();
+    const ctx = await deliver(store, "subscription.scheduled_cancel", "scheduled_cancel", {
+      ...defaultOptions,
+      onSubscriptionScheduledCancel,
+    });
+    expect(ctx.json).toHaveBeenCalledWith({ message: "Webhook received" });
+    expect(store.record).toMatchObject({ status: "canceled", cancelAtPeriodEnd: false });
+    expect(onSubscriptionScheduledCancel).not.toHaveBeenCalled();
+    expect(await hasAccess(store)).toBe(false);
+  });
+
+  it.each(["past_due", "unpaid"] as const)(
+    "preserves the existing %s grace period",
+    async (status) => {
+      vi.useFakeTimers();
+      const store = createSubscriptionStore();
+      await deliver(store, `subscription.${status}`, status);
+      vi.setSystemTime(new Date(periodEnd.getTime() - 1));
+      expect(await hasAccess(store)).toBe(true);
+      vi.setSystemTime(periodEnd);
+      expect(await hasAccess(store)).toBe(false);
+      vi.setSystemTime(new Date(periodEnd.getTime() + 1));
+      expect(await hasAccess(store)).toBe(false);
+    },
+  );
+
   it("keeps the scheduled flag when a subscription.update still carries scheduled_cancel", async () => {
     const store = createSubscriptionStore();
     await deliver(store, "subscription.update", "scheduled_cancel");
@@ -190,6 +271,27 @@ describe("cancellation lifecycle through verified webhooks", () => {
     expect(ctx.json).toHaveBeenCalledWith({ message: "Webhook received" });
     expect(onSubscriptionScheduledCancel).toHaveBeenCalledTimes(1);
     expect(store.adapter.findOne).not.toHaveBeenCalled();
+    expect(store.adapter.update).not.toHaveBeenCalled();
+  });
+
+  it("revokes canceled subscriptions with persistence disabled", async () => {
+    const store = createSubscriptionStore();
+    const onRevokeAccess = vi.fn();
+    const onSubscriptionCanceled = vi.fn();
+    const ctx = await deliver(store, "subscription.canceled", "canceled", {
+      ...defaultOptions,
+      persistSubscriptions: false,
+      onRevokeAccess,
+      onSubscriptionCanceled,
+    });
+    expect(ctx.json).toHaveBeenCalledWith({ message: "Webhook received" });
+    expect(onRevokeAccess).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ reason: "subscription_canceled", id: mockSubscription.id }),
+      ctx,
+    );
+    expect(onSubscriptionCanceled).toHaveBeenCalledTimes(1);
+    expect(store.adapter.findOne).not.toHaveBeenCalled();
+    expect(store.adapter.findMany).not.toHaveBeenCalled();
     expect(store.adapter.update).not.toHaveBeenCalled();
   });
 

--- a/packages/integrations/better-auth/src/__tests__/endpoints.test.ts
+++ b/packages/integrations/better-auth/src/__tests__/endpoints.test.ts
@@ -450,7 +450,7 @@ describe("Has access granted endpoint", () => {
     expect(ctx.json).toHaveBeenCalledWith(expect.objectContaining({ hasAccessGranted: true }));
   });
 
-  it("returns true for canceled subscription with future periodEnd", async () => {
+  it("returns false for canceled subscription with future periodEnd", async () => {
     const adapter = createMockAdapter();
     adapter.findMany.mockResolvedValue([
       {
@@ -463,7 +463,7 @@ describe("Has access granted endpoint", () => {
     const ctx = createMockContext({ adapter });
     mockGetSession.mockResolvedValue({ user: { id: "user_123" } });
     await handler(ctx);
-    expect(ctx.json).toHaveBeenCalledWith(expect.objectContaining({ hasAccessGranted: true }));
+    expect(ctx.json).toHaveBeenCalledWith(expect.objectContaining({ hasAccessGranted: false }));
   });
 
   it("returns false for canceled subscription with past periodEnd", async () => {

--- a/packages/integrations/better-auth/src/__tests__/hooks.test.ts
+++ b/packages/integrations/better-auth/src/__tests__/hooks.test.ts
@@ -48,6 +48,34 @@ describe("onCheckoutCompleted", () => {
     vi.clearAllMocks();
   });
 
+  it.each(["active", "scheduled_cancel"] as const)(
+    "persists the cancellation flag from a %s checkout subscription",
+    async (status) => {
+      const adapter = createMockAdapter();
+      const ctx = createMockContext({ adapter });
+      await onCheckoutCompleted(
+        ctx,
+        {
+          ...mockCheckoutCompletedEvent,
+          object: {
+            ...mockCheckoutCompletedEvent.object,
+            subscription: { ...mockSubscription, status },
+          },
+        },
+        defaultOptions,
+      );
+      expect(adapter.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: "creem_subscription",
+          data: expect.objectContaining({
+            status,
+            cancelAtPeriodEnd: status === "scheduled_cancel",
+          }),
+        }),
+      );
+    },
+  );
+
   it("skips when persistSubscriptions is false", async () => {
     const ctx = createMockContext();
     await onCheckoutCompleted(ctx, mockCheckoutCompletedEvent, optionsNoPersist);

--- a/packages/integrations/better-auth/src/__tests__/webhook.test.ts
+++ b/packages/integrations/better-auth/src/__tests__/webhook.test.ts
@@ -304,6 +304,11 @@ describe("webhook handler", () => {
       { ...mockSubscription, status: "canceled" },
     ],
     ["onSubscriptionPaid", "subscription.paid", mockSubscription],
+    [
+      "onSubscriptionScheduledCancel",
+      "subscription.scheduled_cancel",
+      { ...mockSubscription, status: "scheduled_cancel" },
+    ],
     ["onSubscriptionExpired", "subscription.expired", { ...mockSubscription, status: "expired" }],
     ["onSubscriptionUnpaid", "subscription.unpaid", { ...mockSubscription, status: "unpaid" }],
     ["onSubscriptionUpdate", "subscription.update", mockSubscription],
@@ -321,6 +326,22 @@ describe("webhook handler", () => {
 
     expect(callback).toHaveBeenCalledTimes(1);
     expect(callback.mock.calls[0]?.[1]).toBe(ctx);
+  });
+
+  it("skips the scheduled callback when persistence ignores a stale event", async () => {
+    vi.mocked(hooks.onSubscriptionScheduledCancel).mockResolvedValueOnce(false);
+    const onSubscriptionScheduledCancel = vi.fn();
+    const ctx = await callWebhook(
+      { ...defaultOptions, onSubscriptionScheduledCancel },
+      {
+        eventType: "subscription.scheduled_cancel",
+        id: "stale-scheduled-event",
+        created_at: 1234567890,
+        object: { ...mockSubscription, status: "scheduled_cancel" },
+      },
+    );
+    expect(ctx.json).toHaveBeenCalledWith({ message: "Webhook received" });
+    expect(onSubscriptionScheduledCancel).not.toHaveBeenCalled();
   });
 
   it("returns 500 on processing error", async () => {

--- a/packages/integrations/better-auth/src/__tests__/webhook.test.ts
+++ b/packages/integrations/better-auth/src/__tests__/webhook.test.ts
@@ -24,6 +24,7 @@ vi.mock("../hooks.js", () => ({
   onSubscriptionActive: vi.fn(),
   onSubscriptionTrialing: vi.fn(),
   onSubscriptionCanceled: vi.fn(),
+  onSubscriptionScheduledCancel: vi.fn(),
   onSubscriptionPaid: vi.fn(),
   onSubscriptionExpired: vi.fn(),
   onSubscriptionUnpaid: vi.fn(),

--- a/packages/integrations/better-auth/src/has-active-subscription.ts
+++ b/packages/integrations/better-auth/src/has-active-subscription.ts
@@ -78,8 +78,8 @@ const createHasAccessGrantedHandler = (options: CreemOptions) => {
           });
         }
 
-        // For canceled, past_due, or unpaid - check if period hasn't ended yet
-        if (status === "canceled" || status === "past_due" || status === "unpaid") {
+        // Scheduled cancellation and existing payment grace periods retain access until periodEnd.
+        if (status === "scheduled_cancel" || status === "past_due" || status === "unpaid") {
           if (subscription.periodEnd) {
             const periodEnd = new Date(subscription.periodEnd);
 

--- a/packages/integrations/better-auth/src/hooks.ts
+++ b/packages/integrations/better-auth/src/hooks.ts
@@ -242,7 +242,7 @@ export async function onSubscriptionScheduledCancel(
   event: NormalizedSubscriptionScheduledCancelEvent,
   options: CreemOptions,
 ) {
-  await updateSubscriptionFromEvent(ctx, event.object, "scheduled_cancel", options);
+  return updateSubscriptionFromEvent(ctx, event.object, "scheduled_cancel", options);
 }
 
 /**
@@ -373,6 +373,17 @@ async function updateSubscriptionFromEvent(
       return;
     }
 
+    // A delayed scheduled-cancellation event must not reopen a terminated subscription.
+    if (
+      status === "scheduled_cancel" &&
+      (subscription.status === "canceled" || subscription.status === "expired")
+    ) {
+      logger.info(
+        `[creem] Ignoring scheduled cancellation for terminated subscription ${subscription.id}`,
+      );
+      return false;
+    }
+
     // Prepare update data
     const updateData: Partial<SubscriptionRecord> = {
       status,
@@ -388,11 +399,21 @@ async function updateSubscriptionFromEvent(
     };
 
     // Update subscription
-    await ctx.context.adapter.update({
+    const updated = await ctx.context.adapter.update({
       model: "creem_subscription",
-      where: [{ field: "id", value: subscription.id }],
+      where: [
+        { field: "id", value: subscription.id },
+        // Also protect against a terminal event arriving between the lookup and this write.
+        ...(status === "scheduled_cancel"
+          ? [{ field: "status", operator: "not_in" as const, value: ["canceled", "expired"] }]
+          : []),
+      ],
       update: updateData,
     });
+
+    if (status === "scheduled_cancel" && !updated) {
+      return false;
+    }
 
     logger.info(`[creem] Updated subscription ${subscription.id} to status: ${status}`);
   } catch (error) {

--- a/packages/integrations/better-auth/src/hooks.ts
+++ b/packages/integrations/better-auth/src/hooks.ts
@@ -373,6 +373,19 @@ async function updateSubscriptionFromEvent(
       return;
     }
 
+    // A customer fallback may belong to a different subscription. Leave that row alone,
+    // but still deliver the event-specific callback as with any missing local record.
+    if (
+      status === "scheduled_cancel" &&
+      subscription.creemSubscriptionId &&
+      subscription.creemSubscriptionId !== subscriptionData.id
+    ) {
+      logger.warn(
+        `[creem] No matching local subscription for scheduled cancellation: ${subscriptionData.id}`,
+      );
+      return;
+    }
+
     // A delayed scheduled-cancellation event must not reopen a terminated subscription.
     if (
       status === "scheduled_cancel" &&
@@ -399,17 +412,29 @@ async function updateSubscriptionFromEvent(
     };
 
     // Update subscription
-    const updated = await ctx.context.adapter.update({
-      model: "creem_subscription",
-      where: [
-        { field: "id", value: subscription.id },
-        // Also protect against a terminal event arriving between the lookup and this write.
-        ...(status === "scheduled_cancel"
-          ? [{ field: "status", operator: "not_in" as const, value: ["canceled", "expired"] }]
-          : []),
-      ],
-      update: updateData,
-    });
+    const updated = await ctx.context.adapter
+      .update({
+        model: "creem_subscription",
+        where: [
+          { field: "id", value: subscription.id },
+          // Also protect against a terminal event arriving between the lookup and this write.
+          ...(status === "scheduled_cancel"
+            ? [{ field: "status", operator: "not_in" as const, value: ["canceled", "expired"] }]
+            : []),
+        ],
+        update: updateData,
+      })
+      .catch(async (error: unknown) => {
+        // Prisma throws when the guarded write matches no row; other adapters return null.
+        if (status === "scheduled_cancel") {
+          const current = await ctx.context.adapter.findOne<SubscriptionRecord>({
+            model: "creem_subscription",
+            where: [{ field: "id", value: subscription.id }],
+          });
+          if (current?.status === "canceled" || current?.status === "expired") return null;
+        }
+        throw error;
+      });
 
     if (status === "scheduled_cancel" && !updated) {
       return false;
@@ -419,5 +444,6 @@ async function updateSubscriptionFromEvent(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     logger.error(`[creem] Webhook failed (subscription update): ${message}`);
+    if (status === "scheduled_cancel") throw error;
   }
 }

--- a/packages/integrations/better-auth/src/hooks.ts
+++ b/packages/integrations/better-auth/src/hooks.ts
@@ -4,6 +4,7 @@ import type {
   NormalizedSubscriptionActiveEvent,
   NormalizedSubscriptionTrialingEvent,
   NormalizedSubscriptionCanceledEvent,
+  NormalizedSubscriptionScheduledCancelEvent,
   NormalizedSubscriptionPaidEvent,
   NormalizedSubscriptionExpiredEvent,
   NormalizedSubscriptionUnpaidEvent,
@@ -95,6 +96,7 @@ export async function onCheckoutCompleted(
           creemSubscriptionId: subscriptionData.id,
           creemOrderId: orderId,
           status: subscriptionData.status,
+          cancelAtPeriodEnd: subscriptionData.status === "scheduled_cancel",
           periodStart: subscriptionData.current_period_start_date
             ? new Date(subscriptionData.current_period_start_date)
             : undefined,
@@ -233,6 +235,17 @@ export async function onSubscriptionCanceled(
 }
 
 /**
+ * Handle subscription.scheduled_cancel without revoking access.
+ */
+export async function onSubscriptionScheduledCancel(
+  ctx: GenericEndpointContext,
+  event: NormalizedSubscriptionScheduledCancelEvent,
+  options: CreemOptions,
+) {
+  await updateSubscriptionFromEvent(ctx, event.object, "scheduled_cancel", options);
+}
+
+/**
  * Handle subscription.paid event
  * Updates subscription with latest payment information
  */
@@ -363,6 +376,7 @@ async function updateSubscriptionFromEvent(
     // Prepare update data
     const updateData: Partial<SubscriptionRecord> = {
       status,
+      cancelAtPeriodEnd: status === "scheduled_cancel",
       creemSubscriptionId: subscriptionData.id,
       creemCustomerId: customerId,
       periodStart: subscriptionData.current_period_start_date

--- a/packages/integrations/better-auth/src/hooks.ts
+++ b/packages/integrations/better-auth/src/hooks.ts
@@ -427,10 +427,13 @@ async function updateSubscriptionFromEvent(
       .catch(async (error: unknown) => {
         // Prisma throws when the guarded write matches no row; other adapters return null.
         if (status === "scheduled_cancel") {
-          const current = await ctx.context.adapter.findOne<SubscriptionRecord>({
-            model: "creem_subscription",
-            where: [{ field: "id", value: subscription.id }],
-          });
+          const current = await ctx.context.adapter
+            .findOne<SubscriptionRecord>({
+              model: "creem_subscription",
+              where: [{ field: "id", value: subscription.id }],
+            })
+            // Preserve the original write error if the diagnostic read also fails.
+            .catch(() => null);
           if (current?.status === "canceled" || current?.status === "expired") return null;
         }
         throw error;
@@ -444,6 +447,7 @@ async function updateSubscriptionFromEvent(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     logger.error(`[creem] Webhook failed (subscription update): ${message}`);
+    // Retry failed scheduled-state writes, including subscription.update, before callbacks run.
     if (status === "scheduled_cancel") throw error;
   }
 }

--- a/packages/integrations/better-auth/src/types.ts
+++ b/packages/integrations/better-auth/src/types.ts
@@ -72,7 +72,10 @@ export type GrantAccessReason =
   | "subscription_trialing"
   | "subscription_paid";
 
-export type RevokeAccessReason = "subscription_paused" | "subscription_expired";
+export type RevokeAccessReason =
+  | "subscription_paused"
+  | "subscription_expired"
+  | "subscription_canceled";
 
 export type AccessChangeReason = GrantAccessReason | RevokeAccessReason;
 
@@ -202,11 +205,22 @@ export interface CreemOptions {
   ) => void | Promise<void>;
 
   /**
-   * Called when a subscription is canceled.
+   * Called when a subscription ends, including immediate cancellation.
+   * onRevokeAccess is also called for this event.
    * All properties are flattened for easy destructuring.
    */
   onSubscriptionCanceled?: (
     data: FlatSubscriptionEvent<"subscription.canceled">,
+    betterAuthContext: GenericEndpointContext,
+  ) => void | Promise<void>;
+
+  /**
+   * Called when cancellation is scheduled for the end of the billing period.
+   * Access is retained until current_period_end_date; onRevokeAccess is not called.
+   * All properties are flattened for easy destructuring.
+   */
+  onSubscriptionScheduledCancel?: (
+    data: FlatSubscriptionEvent<"subscription.scheduled_cancel">,
     betterAuthContext: GenericEndpointContext,
   ) => void | Promise<void>;
 
@@ -288,7 +302,8 @@ export interface CreemOptions {
 
   /**
    * Called when a user's access should be revoked.
-   * This is triggered for: paused, expired, and canceled (after period ends) subscriptions.
+   * Triggered by subscription.paused, subscription.expired, and subscription.canceled.
+   * subscription.scheduled_cancel does not revoke access.
    *
    * All subscription properties are flattened for easy destructuring:
    * { reason, product, customer, status, metadata, ... }

--- a/packages/integrations/better-auth/src/webhook.ts
+++ b/packages/integrations/better-auth/src/webhook.ts
@@ -7,6 +7,7 @@ import {
   onSubscriptionActive,
   onSubscriptionTrialing,
   onSubscriptionCanceled,
+  onSubscriptionScheduledCancel,
   onSubscriptionPaid,
   onSubscriptionExpired,
   onSubscriptionUnpaid,
@@ -130,7 +131,21 @@ const createWebhookHandler = (options: CreemOptions) => {
           break;
         case "subscription.canceled":
           await onSubscriptionCanceled(ctx, event, options);
+          await options.onRevokeAccess?.({ reason: "subscription_canceled", ...event.object }, ctx);
           await options.onSubscriptionCanceled?.(
+            {
+              webhookEventType: event.eventType,
+              webhookId: event.id,
+              webhookCreatedAt: event.created_at,
+              ...event.object,
+            },
+            ctx,
+          );
+          break;
+
+        case "subscription.scheduled_cancel":
+          await onSubscriptionScheduledCancel(ctx, event, options);
+          await options.onSubscriptionScheduledCancel?.(
             {
               webhookEventType: event.eventType,
               webhookId: event.id,

--- a/packages/integrations/better-auth/src/webhook.ts
+++ b/packages/integrations/better-auth/src/webhook.ts
@@ -144,7 +144,7 @@ const createWebhookHandler = (options: CreemOptions) => {
           break;
 
         case "subscription.scheduled_cancel":
-          await onSubscriptionScheduledCancel(ctx, event, options);
+          if ((await onSubscriptionScheduledCancel(ctx, event, options)) === false) break;
           await options.onSubscriptionScheduledCancel?.(
             {
               webhookEventType: event.eventType,


### PR DESCRIPTION
## Why

`subscription.scheduled_cancel` currently returns HTTP 400, so Better Auth never persists scheduled cancellation. A finalized `canceled` subscription can still pass `hasAccessGranted()` until its stored period ends.

Fixes #163.

## What changed

- Accept scheduled cancellation, persist its status and cancellation flag, and expose `onSubscriptionScheduledCancel`. Retain access only before the period ends; scheduling does not invoke grant/revoke callbacks.
- Treat final cancellation as terminal: deny access and invoke `onRevokeAccess` with `subscription_canceled` before `onSubscriptionCanceled`.
- Synchronize the cancellation flag on checkout and subscription writes, including undoing or finalizing cancellation.
- Prevent delayed scheduled updates from restoring terminal subscriptions, including concurrent writes and adapters that throw on unmatched updates. Suppress the dedicated callback for ignored events, and retry scheduled persistence failures. Preserve callbacks when the fallback row belongs to a different subscription without overwriting that row.
- Update JSDoc and the canonical Better Auth guides. Add a dedicated [1.x to 2.0 migration guide](https://github.com/armitage-labs/creem/blob/fix/better-auth-cancellation-lifecycle/packages/docs/code/sdks/better-auth/migration.mdx) covering callback changes, existing records, separately managed entitlements, and upgrade verification. Link it from the docs navigation, overview, agent index, and **major changeset**.

## Compatibility and upgrade

This is a breaking change for the 1.x package:

- Existing stored canceled records immediately stop granting access after upgrade. No webhook is replayed and no revoke callback is synthesized for those records. Reconcile separately managed entitlements with current Creem subscription state before deploying.
- Handle the new `subscription_canceled` reason in exhaustive checks. Consolidate duplicate revoke logic or make callbacks idempotent.
- Existing cancellation flags are not backfilled; subsequent events synchronize them. Access checks use status and period end. No database schema migration is needed.

The existing `past_due` and `unpaid` grace policy is preserved. Server-only helpers retain their documented active-status scope. The declared Better Auth peer floor stays unchanged: `not_in` support was verified in the shipped first-party adapters of 1.3.34.

## Validation

- 244 Better Auth unit tests pass, including signed-webhook lifecycle tests, period-end boundaries, persistence-disabled callbacks, delayed retries, concurrent writes, Prisma-style exceptions, and fallback records.
- Typecheck, build, package export/type checks, formatting, package metadata, repository contracts, Changesets status, and Mintlify build/link validation pass.
- Current main is merged without conflicts.
- Live Creem API integration tests were not run; webhook behavior is exercised locally with signed payloads and a stateful adapter double. Adapter compatibility was checked against published source.

- [x] Tests cover new or changed behavior.
- [x] Documentation is updated where users will notice the change.
- [x] Published-package changes include a changeset.
- [x] Generated SDK source is unchanged.
- [x] No secrets or credentials are included.

Material AI assistance: Codex implemented the changes and validation. Claude Fable 5.1 performed the independent ready-to-merge review and follow-up review; its findings and observations were addressed.
