### PR TITLE
docs: clarify product verification test purchases

### DIFF
--- a/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
+++ b/packages/docs/merchant-of-record/account-reviews/account-reviews.mdx
@@ -59,6 +59,14 @@ Go to **Balance → Payout Account** and click **Set up Payout Account** to subm
 - A description of the products you intend to sell through Creem
 - Your country of tax residence
 
+<Note>
+  As part of onboarding and ongoing compliance monitoring, CREEM may perform a limited test purchase
+  to verify the customer experience and product functionality. To make this process frictionless, we
+  may create and apply a one-time 100% discount code. You may see a zero-value test order and
+  limited product usage associated with the review. Testing is limited to verification purposes and
+  kept to the minimum reasonably necessary.
+</Note>
+
 ### Common reasons for requests for changes
 
 1. **Support email mismatch** - The email in your Business Details doesn't match what's on your website.


### PR DESCRIPTION
Adds a low-prominence note under Account Reviews → What information is needed.

It explains that CREEM may use a one-time 100% discount code for a limited test purchase during onboarding or ongoing compliance monitoring, including the possibility of minimal product usage.

Mintlify validation and internal link checks pass; the repository-wide formatter still reports pre-existing formatting drift, including on this page before the change.